### PR TITLE
Fix fzf-lua ansi_from_hl compatibility in fzf picker

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -23,7 +23,7 @@ local function render(segments)
   local parts = {}
   for _, seg in ipairs(segments) do
     if seg[2] then
-      table.insert(parts, utils.ansi_from_hl(seg[2], seg[1]))
+      table.insert(parts, (utils.ansi_from_hl(seg[2], seg[1])))
     else
       table.insert(parts, seg[1])
     end

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -1,0 +1,51 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+package.preload['fzf-lua.utils'] = function()
+  return {
+    ansi_from_hl = function(_, text)
+      return text, '\27[38;2;1;2;3m'
+    end,
+  }
+end
+
+local captured
+
+package.preload['fzf-lua'] = function()
+  return {
+    fzf_exec = function(lines, opts)
+      captured = { lines = lines, opts = opts }
+    end,
+  }
+end
+
+describe('fzf picker', function()
+  before_each(function()
+    captured = nil
+    package.loaded['forge'] = nil
+    package.loaded['forge.picker.fzf'] = nil
+    vim.g.forge = nil
+  end)
+
+  it('renders highlighted segments when ansi_from_hl returns extra values', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = {
+            { '#42', 'ForgeNumber' },
+            { ' fix api drift ' },
+            { 'alice  1h', 'ForgeDim' },
+          },
+          value = '42',
+        },
+      },
+      actions = {},
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.same({ '1\t#42 fix api drift alice  1h' }, captured.lines)
+    assert.equals('PRs> ', captured.opts.prompt)
+  end)
+end)


### PR DESCRIPTION
Fixes #5.

## Summary
- wrap the `ansi_from_hl()` call in the fzf picker renderer so only the rendered text is passed into `table.insert()`
- add a regression spec that stubs the newer two-value `fzf-lua.utils.ansi_from_hl()` return shape

## Verification
- `nix develop .#ci -c busted spec/init_spec.lua spec/sources_spec.lua spec/fzf_picker_spec.lua`
