### PR TITLE
refactor: remove yank functionality

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -219,11 +219,6 @@ COMMANDS                                                              *:Forge*
                        branch. In visual mode, the selected line range is
                        included.
 
-`:Forge yank` [{flags}]                                          *:Forge-yank*
-    Yank a permalink URL to the `+` register.
-    `--commit`         Yank a commit-pinned URL.
-    (no flags)         Yank a branch-pinned URL.
-
 `:Forge review end`                                        *:Forge-review-end*
     End the current review session.
 
@@ -241,9 +236,8 @@ PICKERS                                                        *forge-pickers*
                                                                 *forge-picker*
 FORGE PICKER ~ The main entry point. Adapts based on the detected forge and
 current buffer. Lists: PRs/MRs, Issues, CI/CD, Releases, Browse Remote, Open
-File, Yank Commit URL, Yank Branch URL. Items that require a forge are hidden
-when no forge is detected. "Open File" and yank entries require a named buffer
-on a branch.
+File. Items that require a forge are hidden when no forge is detected. "Open
+File" requires a named buffer on a branch.
 
                                                              *forge-picker-pr*
 PR PICKER ~ Lists PRs/MRs with number, title, author, and relative time.
@@ -407,19 +401,19 @@ COMPATIBILITY ~
 Not all features are available on every forge. The table below shows per-forge
 support for features that vary:
 
-  Feature                     GitHub    GitLab    Codeberg ~
-  PR list/filter                yes       yes        yes
-  PR create                     yes       yes        yes
-  PR create (draft)             yes       yes         -
-  PR create (reviewers)         yes       yes         -
-  PR draft toggle               yes       yes         -
-  Per-PR CI checks              yes       yes        yes*
-  Per-check log viewing         yes       yes         -
-  CI runs (repo-wide)           yes       yes        yes
-  Issues                        yes       yes        yes
-  Releases                      yes       yes        yes
-  Release draft/prerelease      yes        -         yes
-  Browse/Yank                   yes       yes        yes
+  Feature                    GitHub    GitLab    Codeberg ~
+  PR list/filter               yes       yes       yes
+  PR create                    yes       yes       yes
+  PR create (draft)            yes       yes        -
+  PR create (reviewers)        yes       yes        -
+  PR draft toggle              yes       yes        -
+  Per-PR CI checks             yes       yes       yes*
+  Per-check log viewing        yes       yes        -
+  CI runs (repo-wide)          yes       yes       yes
+  Issues                       yes       yes       yes
+  Releases                     yes       yes       yes
+  Release draft/prerelease     yes        -        yes
+  Browse                       yes       yes       yes
 
   * Codeberg per-PR checks show commit statuses reported by external CI.
     The browse action opens the CI provider's page. Log viewing requires
@@ -490,8 +484,6 @@ All methods receive `self` as the first argument (use `:` syntax).
   `browse_branch(branch)`              Opens branch in browser.
   `browse_commit(sha)`                 Opens commit in browser.
   `checkout_cmd(num)`                   `string[]` cmd to checkout a PR.
-  `yank_branch(loc)`                    Yanks branch-pinned URL.
-  `yank_commit(loc)`                    Yanks commit-pinned URL.
   `fetch_pr(num)`                       `string[]` git fetch refspec for PR.
   `pr_base_cmd(num)`                    `string[]` cmd returning base branch.
   `pr_for_branch_cmd(branch)`          `string[]` cmd returning PR number
@@ -637,11 +629,6 @@ PUBLIC API: `require('forge')` ~
 `remote_web_url()`
     Returns `string`. The HTTPS URL of the `origin` remote, normalized
     from SSH or git URLs.
-
-                                                            *forge.yank_url()*
-`yank_url(args)`
-    Runs `args` (string[]) asynchronously and copies stdout to the `+`
-    register.
 
                                                           *forge.clear_list()*
 `clear_list(key?)`

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -106,26 +106,6 @@ function M:checkout_cmd(num)
   return { 'tea', 'pr', 'checkout', num }
 end
 
----@param loc string
-function M:yank_branch(loc)
-  local branch = vim.trim(vim.fn.system('git branch --show-current'))
-  local base = forge.remote_web_url()
-  local file, lines = loc:match('^(.+):(.+)$')
-  local url = ('%s/src/branch/%s/%s#L%s'):format(base, branch, file, lines)
-  vim.fn.setreg('+', url)
-  require('forge.logger').info('URL copied')
-end
-
----@param loc string
-function M:yank_commit(loc)
-  local commit = vim.trim(vim.fn.system('git rev-parse HEAD'))
-  local base = forge.remote_web_url()
-  local file, lines = loc:match('^(.+):(.+)$')
-  local url = ('%s/src/commit/%s/%s#L%s'):format(base, commit, file, lines)
-  vim.fn.setreg('+', url)
-  require('forge.logger').info('URL copied')
-end
-
 ---@param num string
 ---@return string[]
 function M:fetch_pr(num)

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -106,16 +106,6 @@ function M:checkout_cmd(num)
   return { 'gh', 'pr', 'checkout', num }
 end
 
----@param loc string
-function M:yank_branch(loc)
-  forge.yank_url({ 'gh', 'browse', loc, '-n' })
-end
-
----@param loc string
-function M:yank_commit(loc)
-  forge.yank_url({ 'gh', 'browse', loc, '--commit=last', '-n' })
-end
-
 ---@param num string
 ---@return string[]
 function M:fetch_pr(num)

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -113,26 +113,6 @@ function M:checkout_cmd(num)
   return { 'glab', 'mr', 'checkout', num }
 end
 
----@param loc string
-function M:yank_branch(loc)
-  local branch = vim.trim(vim.fn.system('git branch --show-current'))
-  local base = forge.remote_web_url()
-  local file, lines = loc:match('^(.+):(.+)$')
-  local url = ('%s/-/blob/%s/%s#L%s'):format(base, branch, file, lines)
-  vim.fn.setreg('+', url)
-  require('forge.logger').info('URL copied')
-end
-
----@param loc string
-function M:yank_commit(loc)
-  local commit = vim.trim(vim.fn.system('git rev-parse HEAD'))
-  local base = forge.remote_web_url()
-  local file, lines = loc:match('^(.+):(.+)$')
-  local url = ('%s/-/blob/%s/%s#L%s'):format(base, commit, file, lines)
-  vim.fn.setreg('+', url)
-  require('forge.logger').info('URL copied')
-end
-
 ---@param num string
 ---@return string[]
 function M:fetch_pr(num)

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -229,8 +229,6 @@ local compose_ns = vim.api.nvim_create_namespace('forge_compose')
 ---@field browse_branch fun(self: forge.Forge, branch: string)
 ---@field browse_commit fun(self: forge.Forge, sha: string)
 ---@field checkout_cmd fun(self: forge.Forge, num: string): string[]
----@field yank_branch fun(self: forge.Forge, loc: string)
----@field yank_commit fun(self: forge.Forge, loc: string)
 ---@field fetch_pr fun(self: forge.Forge, num: string): string[]
 ---@field pr_base_cmd fun(self: forge.Forge, num: string): string[]
 ---@field pr_for_branch_cmd fun(self: forge.Forge, branch: string): string[]
@@ -854,20 +852,6 @@ function M.config()
   end
 
   return cfg
-end
-
----@param args string[]
-function M.yank_url(args)
-  vim.system(args, { text = true }, function(result)
-    if result.code == 0 then
-      local url = vim.trim(result.stdout or '')
-      if url ~= '' then
-        vim.schedule(function()
-          vim.fn.setreg('+', url)
-        end)
-      end
-    end
-  end)
 end
 
 ---@param branch string

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -836,14 +836,6 @@ function M.git()
         end
         f:browse(loc, branch)
       end)
-
-      add('Yank Commit URL', function()
-        f:yank_commit(loc)
-      end)
-
-      add('Yank Branch URL', function()
-        f:yank_branch(loc)
-      end)
     end
   end
 

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -266,25 +266,6 @@ local function dispatch(args)
     return
   end
 
-  if sub == 'yank' then
-    if not require_git_or_warn() then
-      return
-    end
-    local f = require_forge_or_warn()
-    if not f then
-      return
-    end
-    local forge_mod = require('forge')
-    local loc = forge_mod.file_loc()
-    local flags = parse_flags(args, 2)
-    if flags.commit then
-      f:yank_commit(loc)
-    else
-      f:yank_branch(loc)
-    end
-    return
-  end
-
   if sub == 'review' then
     local review = require('forge.review')
     if #args < 2 then
@@ -318,7 +299,7 @@ local function complete(arglead, cmdline, _)
   end
   local arg_idx = arglead == '' and #words or #words - 1
 
-  local subcmds = { 'pr', 'issue', 'ci', 'release', 'browse', 'yank', 'review', 'clear' }
+  local subcmds = { 'pr', 'issue', 'ci', 'release', 'browse', 'review', 'clear' }
   local sub_actions = {
     pr = { 'checkout', 'diff', 'worktree', 'ci', 'browse', 'manage', 'create', '--state=' },
     issue = { 'browse', 'close', 'reopen', '--state=' },
@@ -326,7 +307,6 @@ local function complete(arglead, cmdline, _)
     release = { 'browse', 'delete' },
     review = { 'end', 'toggle' },
     browse = { '--root', '--commit' },
-    yank = { '--commit' },
   }
   local flag_values = {
     ['--state'] = { 'open', 'closed', 'all' },


### PR DESCRIPTION
## Problem

`yank_branch`, `yank_commit`, and `:Forge yank` are git-browse utilities, not forge workflow concepts. They don't belong in a plugin scoped to PRs, issues, CI, and releases.

## Solution

Remove `yank_branch()` and `yank_commit()` from all three forge backends, `yank_url()` from init, `:Forge yank` command and completion, and main picker entries. Update vimdoc accordingly. The release picker `yank` action (copying a release URL) is retained as releases are a forge-owned concept.