### PR TITLE
feat(log): handle UNKNOWN STEP and rich error/warning styling

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -195,8 +195,10 @@ local hl_defaults = {
   ForgeDim = 'Comment',
   ForgeLogJob = 'Title',
   ForgeLogStep = 'Function',
-  ForgeLogError = 'DiagnosticError',
-  ForgeLogWarning = 'DiagnosticWarn',
+  ForgeLogError = 'DiagnosticVirtualTextError',
+  ForgeLogErrorLabel = 'ErrorMsg',
+  ForgeLogWarning = 'DiagnosticVirtualTextWarn',
+  ForgeLogWarningLabel = 'WarningMsg',
   ForgeLogSection = 'Special',
   ForgeLogDim = 'Comment',
 }

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -76,6 +76,8 @@ local function parse_github(raw_lines)
   local headers = {}
   local errors = {}
   local cur_job, cur_step
+  local unknown_step = false
+  local in_group = false
   for _, raw in ipairs(raw_lines) do
     if raw:byte(1) == 0xEF and raw:byte(2) == 0xBB and raw:byte(3) == 0xBF then
       raw = raw:sub(4)
@@ -90,13 +92,18 @@ local function parse_github(raw_lines)
     if job ~= cur_job then
       cur_job = job
       cur_step = nil
+      in_group = false
       lines[#lines + 1] = { text = job, hls = {}, fold = '>1', kind = 'job' }
       headers[#headers + 1] = #lines
     end
     if step ~= cur_step then
       cur_step = step
-      lines[#lines + 1] = { text = '  ' .. step, hls = {}, fold = '>2', kind = 'step' }
-      headers[#headers + 1] = #lines
+      in_group = false
+      unknown_step = step == 'UNKNOWN STEP'
+      if not unknown_step then
+        lines[#lines + 1] = { text = '  ' .. step, hls = {}, fold = '>2', kind = 'step' }
+        headers[#headers + 1] = #lines
+      end
     end
     do
       local _, content = rest:match('^(%d%d%d%d%-%d%d%-%d%dT[%d:.]+Z)%s(.*)$')
@@ -107,13 +114,13 @@ local function parse_github(raw_lines)
       m = content:match('^##%[error[^%]]*%](.*)$')
       if m then
         kind = 'error'
-        content = m
+        content = 'Error: ' .. m
         goto emit
       end
       m = content:match('^##%[warning[^%]]*%](.*)$')
       if m then
         kind = 'warning'
-        content = m
+        content = 'Warning: ' .. m
         goto emit
       end
       m = content:match('^##%[group[^%]]*%](.*)$')
@@ -123,6 +130,7 @@ local function parse_github(raw_lines)
         goto emit
       end
       if content:match('^##%[endgroup') then
+        in_group = false
         goto continue
       end
       m = content:match('^##%[debug[^%]]*%](.*)$')
@@ -138,16 +146,26 @@ local function parse_github(raw_lines)
       end
       ::emit::
       local text, h = strip_ansi(content)
+      local indent_n = (unknown_step and not in_group) and 2 or 4
+      local fold_val
+      if kind == 'group' then
+        fold_val = unknown_step and '>2' or '>3'
+      elseif unknown_step and not in_group then
+        fold_val = '1'
+      else
+        fold_val = '2'
+      end
       lines[#lines + 1] = {
-        text = '    ' .. text,
-        hls = offset_hls(h, 4),
-        fold = kind == 'group' and '>3' or '2',
+        text = (' '):rep(indent_n) .. text,
+        hls = offset_hls(h, indent_n),
+        fold = fold_val,
         kind = kind,
       }
       if kind == 'error' then
         errors[#errors + 1] = #lines
       elseif kind == 'group' then
         headers[#headers + 1] = #lines
+        in_group = true
       end
     end
     ::continue::
@@ -279,7 +297,23 @@ local function render(buf, parsed)
       vim.api.nvim_buf_set_extmark(buf, ns, lnum, 0, { line_hl_group = 'ForgeLogSection' })
     elseif line.kind == 'error' then
       vim.api.nvim_buf_set_extmark(buf, ns, lnum, 0, { line_hl_group = 'ForgeLogError' })
-    elseif line.kind == 'warning' or line.kind == 'notice' then
+      local start = line.text:find('Error: ', 1, true)
+      if start then
+        vim.api.nvim_buf_set_extmark(buf, ns, lnum, start - 1, {
+          end_col = start + 6,
+          hl_group = 'ForgeLogErrorLabel',
+        })
+      end
+    elseif line.kind == 'warning' then
+      vim.api.nvim_buf_set_extmark(buf, ns, lnum, 0, { line_hl_group = 'ForgeLogWarning' })
+      local start = line.text:find('Warning: ', 1, true)
+      if start then
+        vim.api.nvim_buf_set_extmark(buf, ns, lnum, start - 1, {
+          end_col = start + 8,
+          hl_group = 'ForgeLogWarningLabel',
+        })
+      end
+    elseif line.kind == 'notice' then
       vim.api.nvim_buf_set_extmark(buf, ns, lnum, 0, { line_hl_group = 'ForgeLogWarning' })
     elseif line.kind == 'debug' then
       vim.api.nvim_buf_set_extmark(buf, ns, lnum, 0, { line_hl_group = 'ForgeLogDim' })

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -97,7 +97,7 @@ describe('parse_github', function()
     })
     assert.equals(3, #result.lines)
     assert.equals('error', result.lines[3].kind)
-    assert.equals('    something broke', result.lines[3].text)
+    assert.equals('    Error: something broke', result.lines[3].text)
     assert.equals(1, #result.errors)
     assert.equals(3, result.errors[1])
   end)
@@ -114,7 +114,7 @@ describe('parse_github', function()
       'job\tstep\t2024-01-01T00:00:00Z ##[error file=main.go,line=5]compile error',
     })
     assert.equals('error', result.lines[3].kind)
-    assert.equals('    compile error', result.lines[3].text)
+    assert.equals('    Error: compile error', result.lines[3].text)
   end)
 
   it('skips endgroup lines', function()
@@ -163,6 +163,69 @@ describe('parse_github', function()
     assert.equals('test', result.lines[4].text)
     assert.equals('job', result.lines[4].kind)
     assert.equals('>1', result.lines[4].fold)
+  end)
+
+  it('prepends Warning: to warning content', function()
+    local result = parse_github({
+      'job\tstep\t2024-01-01T00:00:00Z ##[warning]careful now',
+    })
+    assert.equals('warning', result.lines[3].kind)
+    assert.equals('    Warning: careful now', result.lines[3].text)
+  end)
+
+  it('skips UNKNOWN STEP header and promotes groups', function()
+    local result = parse_github({
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:00Z ##[group]Run cachix/install-nix',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:01Z installing...',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:02Z ##[endgroup]',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:03Z ##[group]Run nix develop',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:04Z building...',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:05Z ##[endgroup]',
+    })
+    assert.equals('job', result.lines[1].text)
+    assert.equals('job', result.lines[1].kind)
+    assert.equals('  Run cachix/install-nix', result.lines[2].text)
+    assert.equals('group', result.lines[2].kind)
+    assert.equals('>2', result.lines[2].fold)
+    assert.equals('    installing...', result.lines[3].text)
+    assert.equals('2', result.lines[3].fold)
+    assert.equals('  Run nix develop', result.lines[4].text)
+    assert.equals('>2', result.lines[4].fold)
+    assert.equals('    building...', result.lines[5].text)
+    assert.equals('2', result.lines[5].fold)
+  end)
+
+  it('uses indent 2 for content outside groups in UNKNOWN STEP', function()
+    local result = parse_github({
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:00Z top level content',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:01Z ##[group]My Group',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:02Z inside group',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:03Z ##[endgroup]',
+      'job\tUNKNOWN STEP\t2024-01-01T00:00:04Z after group',
+    })
+    assert.equals('  top level content', result.lines[2].text)
+    assert.equals('1', result.lines[2].fold)
+    assert.equals('  My Group', result.lines[3].text)
+    assert.equals('>2', result.lines[3].fold)
+    assert.equals('    inside group', result.lines[4].text)
+    assert.equals('2', result.lines[4].fold)
+    assert.equals('  after group', result.lines[5].text)
+    assert.equals('1', result.lines[5].fold)
+  end)
+
+  it('does not skip real step names', function()
+    local result = parse_github({
+      'job\tSetup\t2024-01-01T00:00:00Z ##[group]My Group',
+      'job\tSetup\t2024-01-01T00:00:01Z inside',
+      'job\tSetup\t2024-01-01T00:00:02Z ##[endgroup]',
+    })
+    assert.equals('  Setup', result.lines[2].text)
+    assert.equals('step', result.lines[2].kind)
+    assert.equals('>2', result.lines[2].fold)
+    assert.equals('    My Group', result.lines[3].text)
+    assert.equals('>3', result.lines[3].fold)
+    assert.equals('    inside', result.lines[4].text)
+    assert.equals('2', result.lines[4].fold)
   end)
 end)
 


### PR DESCRIPTION
## Problem

`gh run view --log --job <id>` returns `UNKNOWN STEP` for all step names, producing one useless fold instead of per-step structure. Error and warning markers (`##[error]`, `##[warning]`) lack visual distinction from surrounding log content.

## Solution

Skip `UNKNOWN STEP` headers and promote `##[group]` folds from level 3 → 2, using `in_group` state tracking for correct indentation. Prepend `Error: `/`Warning: ` labels with inline extmarks linked to `ForgeLogErrorLabel`/`ForgeLogWarningLabel`. Switch error/warning line highlights to `DiagnosticVirtualTextError`/`DiagnosticVirtualTextWarn` for background color.