### PR TITLE
fix(ci): use per-job IDs in GitLab/Codeberg log and watch commands

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -161,15 +161,16 @@ end
 
 ---@param run_id string
 ---@param failed_only boolean
----@param _job_id string?
+---@param job_id string?
 ---@return string[]
-function M:check_log_cmd(run_id, failed_only, _job_id)
+function M:check_log_cmd(run_id, failed_only, job_id)
   local _ = failed_only
   local lines = forge.config().ci.lines
+  local job_flag = job_id and (' --job %s'):format(job_id) or ''
   return {
     'sh',
     '-c',
-    ('tea actions runs logs %s | tail -n %d'):format(run_id, lines),
+    ('tea actions runs logs %s%s | tail -n %d'):format(run_id, job_flag, lines),
   }
 end
 

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -176,15 +176,16 @@ end
 
 ---@param run_id string
 ---@param failed_only boolean
----@param _job_id string?
+---@param job_id string?
 ---@return string[]
-function M:check_log_cmd(run_id, failed_only, _job_id)
+function M:check_log_cmd(run_id, failed_only, job_id)
   local _ = failed_only
   local lines = forge.config().ci.lines
+  local id = job_id or run_id
   return {
     'sh',
     '-c',
-    ('glab ci trace %s | tail -n %d'):format(run_id, lines),
+    ('glab ci trace %s | tail -n %d'):format(id, lines),
   }
 end
 
@@ -200,9 +201,15 @@ function M:live_tail_cmd(run_id)
   return { 'glab', 'ci', 'trace', run_id }
 end
 
+---@param id string?
 ---@return string[]
-function M:watch_cmd()
-  return { 'glab', 'ci', 'view' }
+function M:watch_cmd(id)
+  local cmd = { 'glab', 'ci', 'view' }
+  if id then
+    table.insert(cmd, '-p')
+    table.insert(cmd, id)
+  end
+  return cmd
 end
 
 function M:list_runs_json_cmd(branch)


### PR DESCRIPTION
## Problem

GitLab `watch_cmd` ignored the pipeline ID, always showing the most recent pipeline via `glab ci view`. Both GitLab and Codeberg `check_log_cmd` ignored the `job_id` parameter, dumping entire pipeline/run logs instead of the specific job's output.

## Solution

Pass `-p <id>` to `glab ci view` so it targets the selected pipeline. Prefer `job_id` over `run_id` in GitLab's `glab ci trace` call. Append `--job <id>` to Codeberg's `tea actions runs logs` when a job ID is available.