### PR TITLE
feat(issue): add issue creation with compose buffer

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -28,6 +28,7 @@ CONTENTS                                                 *forge.nvim-contents*
     `:Forge issue browse` {num}..........................|:Forge-issue-browse|
     `:Forge issue close` {num}............................|:Forge-issue-close|
     `:Forge issue reopen` {num}..........................|:Forge-issue-reopen|
+    `:Forge issue create` [{flags}]........................|:Forge-issue-create|
     `:Forge ci` [{flags}]..........................................|:Forge-ci|
     `:Forge release`..........................................|:Forge-release|
     `:Forge release browse` {tag}......................|:Forge-release-browse|
@@ -254,6 +255,11 @@ COMMANDS                                                              *:Forge*
 `:Forge issue reopen` {num}                              *:Forge-issue-reopen*
     Reopen issue `{num}`.
 
+`:Forge issue create` [{flags}]                          *:Forge-issue-create*
+    Create a new issue.
+    (no flags)         Open the compose buffer.
+    `--web`            Open the forge's web create-issue page.
+
 `:Forge ci` [{flags}]                                              *:Forge-ci*
     Open the CI runs picker. Defaults to current branch.
     `--all`            Show runs for all branches.
@@ -315,6 +321,7 @@ ISSUE PICKER ~ Lists issues with number, title, author, and relative time.
   Action      Default Key    Description ~
   `browse`      `<cr>`           Open issue in browser
   `close`       `<c-s>`          Close or reopen the issue
+  `create`      `<c-a>`          Create new issue
   `filter`      `<c-o>`          Cycle state: all -> open -> closed
   `refresh`     `<c-r>`          Clear cache and re-fetch
 
@@ -404,6 +411,23 @@ Metadata fields: ~
   `Draft: true`      Create as draft. `false` = not draft.
   `Reviewers:`       Comma or space separated usernames.
 
+Creating an issue (without `--web`) opens a compose buffer at
+`forge://issue/new` with filetype `markdown` and buftype `acwrite`.
+
+Layout: ~
+  Line 1      Issue title
+  Line 2      Empty separator
+  Lines 3+    Issue body (from discovered issue template, or empty)
+  `<!--`        Metadata comment block (forge, labels, assignees).
+  `-->`         End of metadata
+
+Write (`:w`) to create the issue. An empty title or body aborts creation.
+The issue URL is copied to the `+` register on success.
+
+Metadata fields: ~
+  `Labels:`          Comma or space separated label names.
+  `Assignees:`       Comma or space separated usernames.
+
 Template discovery: ~
   forge.nvim searches forge-specific template paths. If a template
   directory contains multiple `.md` files, you are prompted to choose.
@@ -412,6 +436,15 @@ Template discovery: ~
   GitLab: `.gitlab/merge_request_templates/`
   Codeberg: `.gitea/pull_request_template.md`,
             `.github/pull_request_template.md`
+
+  Issue templates: ~
+  GitHub: `.github/ISSUE_TEMPLATE.md`,
+          `.github/ISSUE_TEMPLATE/`
+  GitLab: `.gitlab/issue_templates/`
+  Codeberg: `.gitea/issue_template.md`,
+            `.gitea/ISSUE_TEMPLATE/`,
+            `.github/ISSUE_TEMPLATE.md`,
+            `.github/ISSUE_TEMPLATE/`
 
 See |forge-highlights| for compose buffer highlight groups.
 
@@ -474,6 +507,7 @@ support for features that vary:
   Per-PR CI checks             yes       yes       yes*
   Per-check log viewing        yes       yes        -
   CI runs (repo-wide)          yes       yes       yes
+  Issue create                   yes       yes       yes
   Issues                       yes       yes       yes
   Releases                     yes       yes       yes
   Release draft/prerelease     yes        -        yes
@@ -580,6 +614,10 @@ All methods receive `self` as the first argument (use `:` syntax).
   `reopen_issue_cmd(num)`              `string[]` cmd to reopen issue.
   `create_pr_cmd(title, body,`          `string[]` cmd to create a PR.
     `base, draft, reviewers?)`
+  `create_issue_cmd(title, body,`       `string[]` cmd to create an issue.
+    `labels?, assignees?)`
+  `issue_template_paths()`              `string[]` repo-relative paths to
+                                        issue templates.
   `default_branch_cmd()`                `string[]` cmd returning default
                                         branch name.
   `template_paths()`                    `string[]` repo-relative paths to
@@ -606,6 +644,9 @@ Optional methods: ~
                                         used as a raw fzf-lua command.
   `create_pr_web_cmd()`                `string[]?` cmd to open web PR
                                         creation. Return `nil` to no-op.
+  `create_issue_web_cmd()`             `string[]?` cmd to open web issue
+                                        creation. If absent, falls back
+                                        to opening `{remote}/issues/new`.
 
 Skeleton: >lua
     local M = {
@@ -679,6 +720,11 @@ PUBLIC API: `require('forge')` ~
       `draft`     `boolean?`  Create as draft.
       `instant`   `boolean?`  Skip compose buffer, fill from commits.
       `web`       `boolean?`  Push and open web create page.
+
+                                                       *forge.create_issue()*
+`create_issue(opts?)`
+    Creates an issue. `opts` is `forge.CreateIssueOpts?`:
+      `web`       `boolean?`  Open web creation page.
 
                                                          *forge.clear_cache()*
 `clear_cache()`

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -295,6 +295,25 @@ function M:create_pr_web_cmd()
   return nil
 end
 
+---@param title string
+---@param body string
+---@param _labels string[]?
+---@param _assignees string[]?
+---@return string[]
+function M:create_issue_cmd(title, body, _labels, _assignees)
+  return { 'tea', 'issues', 'create', '--title', title, '--description', body }
+end
+
+---@return string[]
+function M:issue_template_paths()
+  return {
+    '.gitea/issue_template.md',
+    '.gitea/ISSUE_TEMPLATE/',
+    '.github/ISSUE_TEMPLATE.md',
+    '.github/ISSUE_TEMPLATE/',
+  }
+end
+
 ---@return string[]
 function M:default_branch_cmd()
   return {

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -310,6 +310,37 @@ function M:create_pr_web_cmd()
   return { 'gh', 'pr', 'create', '--web' }
 end
 
+---@param title string
+---@param body string
+---@param labels string[]?
+---@param assignees string[]?
+---@return string[]
+function M:create_issue_cmd(title, body, labels, assignees)
+  local cmd = { 'gh', 'issue', 'create', '--title', title, '--body', body }
+  for _, l in ipairs(labels or {}) do
+    table.insert(cmd, '--label')
+    table.insert(cmd, l)
+  end
+  for _, a in ipairs(assignees or {}) do
+    table.insert(cmd, '--assignee')
+    table.insert(cmd, a)
+  end
+  return cmd
+end
+
+---@return string[]
+function M:create_issue_web_cmd()
+  return { 'gh', 'issue', 'create', '--web' }
+end
+
+---@return string[]
+function M:issue_template_paths()
+  return {
+    '.github/ISSUE_TEMPLATE.md',
+    '.github/ISSUE_TEMPLATE/',
+  }
+end
+
 ---@return string[]
 function M:default_branch_cmd()
   return { 'gh', 'repo', 'view', '--json', 'defaultBranchRef', '--jq', '.defaultBranchRef.name' }

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -347,6 +347,34 @@ function M:create_pr_web_cmd()
   return { 'glab', 'mr', 'create', '--web' }
 end
 
+---@param title string
+---@param body string
+---@param labels string[]?
+---@param assignees string[]?
+---@return string[]
+function M:create_issue_cmd(title, body, labels, assignees)
+  local cmd = { 'glab', 'issue', 'create', '--title', title, '--description', body, '--yes' }
+  if labels and #labels > 0 then
+    table.insert(cmd, '--label')
+    table.insert(cmd, table.concat(labels, ','))
+  end
+  for _, a in ipairs(assignees or {}) do
+    table.insert(cmd, '--assignee')
+    table.insert(cmd, a)
+  end
+  return cmd
+end
+
+---@return string[]
+function M:create_issue_web_cmd()
+  return { 'glab', 'issue', 'create', '--web' }
+end
+
+---@return string[]
+function M:issue_template_paths()
+  return { '.gitlab/issue_templates/' }
+end
+
 ---@return string[]
 function M:default_branch_cmd()
   return {

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -40,6 +40,7 @@ local M = {}
 ---@class forge.IssuePickerKeys
 ---@field browse string|false
 ---@field close string|false
+---@field create string|false
 ---@field filter string|false
 ---@field refresh string|false
 
@@ -115,7 +116,13 @@ local DEFAULTS = {
       filter = '<c-o>',
       refresh = '<c-r>',
     },
-    issue = { browse = '<cr>', close = '<c-s>', filter = '<c-o>', refresh = '<c-r>' },
+    issue = {
+      browse = '<cr>',
+      close = '<c-s>',
+      filter = '<c-o>',
+      refresh = '<c-r>',
+      create = '<c-a>',
+    },
     ci = {
       log = '<cr>',
       watch = '<c-w>',
@@ -300,6 +307,9 @@ local compose_ns = vim.api.nvim_create_namespace('forge_compose')
 ---@field release_json_fields fun(self: forge.Forge): { tag: string, title: string, is_draft: string?, is_prerelease: string?, is_latest: string?, published_at: string }
 ---@field browse_release fun(self: forge.Forge, tag: string)
 ---@field delete_release_cmd fun(self: forge.Forge, tag: string): string[]
+---@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, assignees: string[]?): string[]
+---@field issue_template_paths fun(self: forge.Forge): string[]
+---@field create_issue_web_cmd (fun(self: forge.Forge): string[]?)?
 
 ---@type table<string, forge.Forge>
 local forge_cache = {}
@@ -875,7 +885,7 @@ function M.config()
     end
     if keys.issue ~= nil then
       vim.validate('forge.keys.issue', keys.issue, 'table')
-      for _, k in ipairs({ 'browse', 'close', 'filter', 'refresh' }) do
+      for _, k in ipairs({ 'browse', 'close', 'create', 'filter', 'refresh' }) do
         vim.validate('forge.keys.issue.' .. k, keys.issue[k], key_or_false, 'string or false')
       end
     end
@@ -955,11 +965,11 @@ local function fill_from_commits(branch, base)
   return clean, table.concat(lines, '\n')
 end
 
----@param f forge.Forge
+---@param paths string[]
 ---@param repo_root string
+---@param label string
 ---@return string?
-local function discover_template(f, repo_root)
-  local paths = f:template_paths()
+local function discover_template(paths, repo_root, label)
   for _, p in ipairs(paths) do
     local full = repo_root .. '/' .. p
     local stat = vim.uv.fs_stat(full)
@@ -1002,7 +1012,7 @@ local function discover_template(f, repo_root)
           table.sort(templates)
           local chosen
           vim.ui.select(templates, {
-            prompt = 'PR template: ',
+            prompt = label .. ' template: ',
           }, function(choice)
             chosen = choice
           end)
@@ -1081,6 +1091,164 @@ local function push_and_create(f, branch, title, body, pr_base, pr_draft, pr_rev
   end)
 end
 
+local function submit_issue(f, title, body, labels, assignees, buf)
+  local log = require('forge.logger')
+  log.info('creating issue...')
+  vim.system(f:create_issue_cmd(title, body, labels, assignees), { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        local url = vim.trim(result.stdout or '')
+        if url ~= '' then
+          vim.fn.setreg('+', url)
+        end
+        log.info(('created issue → %s'):format(url))
+        M.clear_list()
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          vim.bo[buf].modified = false
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      else
+        local msg = vim.trim(result.stderr or '')
+        if msg == '' then
+          msg = vim.trim(result.stdout or '')
+        end
+        if msg == '' then
+          msg = 'creation failed'
+        end
+        log.error(msg)
+      end
+    end)
+  end)
+end
+
+local function open_issue_compose_buffer(f)
+  local root = git_root() or ''
+  local template = discover_template(f:issue_template_paths(), root, 'Issue')
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_name(buf, 'forge://issue/new')
+  vim.bo[buf].buftype = 'acwrite'
+  vim.bo[buf].filetype = 'markdown'
+  vim.bo[buf].swapfile = false
+
+  local lines = { '', '' }
+  if template and template ~= '' then
+    for _, line in ipairs(vim.split(template, '\n', { plain = true })) do
+      table.insert(lines, line)
+    end
+  else
+    table.insert(lines, '')
+  end
+
+  table.insert(lines, '')
+  local comment_start = #lines + 1
+
+  local marks = {}
+
+  local function add_line(fmt, ...)
+    local text = fmt:format(...)
+    table.insert(lines, text)
+    return #lines
+  end
+
+  local function mark(ln, start, len, hl_group)
+    table.insert(marks, { line = ln, col = start, end_col = start + len, hl = hl_group })
+  end
+
+  add_line('<!--')
+
+  local creating_prefix = '  Creating issue via '
+  local ln = add_line('%s%s.', creating_prefix, f.name)
+  mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
+
+  add_line('')
+  local labels_prefix = '  Labels: '
+  add_line('%s', labels_prefix)
+
+  local assignees_prefix = '  Assignees: '
+  add_line('%s', assignees_prefix)
+
+  add_line('')
+  add_line('  An empty title or body aborts creation.')
+  add_line('-->')
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modified = false
+
+  vim.api.nvim_set_current_buf(buf)
+
+  for _, m in ipairs(marks) do
+    vim.api.nvim_buf_set_extmark(buf, compose_ns, m.line - 1, m.col, {
+      end_col = m.end_col,
+      hl_group = m.hl,
+      priority = 200,
+    })
+  end
+  for i = comment_start, #lines do
+    vim.api.nvim_buf_set_extmark(buf, compose_ns, i - 1, 0, {
+      line_hl_group = 'ForgeComposeComment',
+      priority = 200,
+    })
+  end
+
+  vim.api.nvim_create_autocmd('BufWriteCmd', {
+    buffer = buf,
+    callback = function()
+      local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      local content_lines = {}
+      for _, l in ipairs(buf_lines) do
+        if l:match('^<!--') then
+          break
+        end
+        table.insert(content_lines, l)
+      end
+      local issue_title = vim.trim(content_lines[1] or '')
+      if issue_title == '' then
+        require('forge.logger').warn('aborting: empty title')
+        vim.bo[buf].modified = false
+        vim.api.nvim_buf_delete(buf, { force = true })
+        return
+      end
+      local issue_body = vim.trim(table.concat(content_lines, '\n', 3))
+      if issue_body == '' then
+        require('forge.logger').warn('aborting: empty body')
+        vim.bo[buf].modified = false
+        vim.api.nvim_buf_delete(buf, { force = true })
+        return
+      end
+
+      local in_comment = false
+      local issue_labels = {}
+      local issue_assignees = {}
+      for _, l in ipairs(buf_lines) do
+        if l:match('^<!--') then
+          in_comment = true
+        elseif l:match('^%-%->') then
+          break
+        elseif in_comment then
+          local lv = l:match('^%s*Labels:%s*(.*)$')
+          if lv then
+            for label in vim.trim(lv):gmatch('[^,%s]+') do
+              table.insert(issue_labels, label)
+            end
+          end
+          local av = l:match('^%s*Assignees:%s*(.*)$')
+          if av then
+            for assignee in vim.trim(av):gmatch('[^,%s]+') do
+              table.insert(issue_assignees, assignee)
+            end
+          end
+        end
+      end
+
+      submit_issue(f, issue_title, issue_body, issue_labels, issue_assignees, buf)
+    end,
+  })
+
+  vim.api.nvim_win_set_cursor(0, { 1, 0 })
+  vim.cmd.startinsert()
+end
+
 ---@param f forge.Forge
 ---@param branch string
 ---@param base string
@@ -1088,7 +1256,7 @@ end
 local function open_compose_buffer(f, branch, base, draft)
   local root = git_root() or ''
   local title, commit_body = fill_from_commits(branch, base)
-  local template = discover_template(f, root)
+  local template = discover_template(f:template_paths(), root, f.labels.pr_one)
   local body = template or commit_body
 
   local buf = vim.api.nvim_create_buf(false, true)
@@ -1347,6 +1515,36 @@ function M.create_pr(opts)
       end)
     end)
   end)
+end
+
+---@class forge.CreateIssueOpts
+---@field web boolean?
+
+---@param opts forge.CreateIssueOpts?
+function M.create_issue(opts)
+  opts = opts or {}
+  local log = require('forge.logger')
+
+  local f = M.detect()
+  if not f then
+    log.warn('no forge detected')
+    return
+  end
+
+  if opts.web then
+    if f.create_issue_web_cmd then
+      local cmd = f:create_issue_web_cmd()
+      if cmd then
+        vim.system(cmd)
+      end
+    else
+      local url = M.remote_web_url() .. '/issues/new'
+      vim.ui.open(url)
+    end
+    return
+  end
+
+  open_issue_compose_buffer(f)
 end
 
 return M

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -640,6 +640,12 @@ function M.issue(state, f)
           end,
         },
         {
+          name = 'create',
+          fn = function()
+            forge_mod.create_issue()
+          end,
+        },
+        {
           name = 'filter',
           fn = function()
             M.issue(next_state, f)

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -130,7 +130,7 @@ local function dispatch(args)
     if not require_git_or_warn() then
       return
     end
-    local f = require_forge_or_warn()
+    local f, forge_mod = require_forge_or_warn()
     if not f then
       return
     end
@@ -145,6 +145,15 @@ local function dispatch(args)
       return
     end
     local action = pos[1]
+    if action == 'create' then
+      local cf = parse_flags(args, 3)
+      if cf.web then
+        forge_mod.create_issue({ web = true })
+      else
+        forge_mod.create_issue()
+      end
+      return
+    end
     local num = pos[2]
     if action == 'browse' then
       if not num then
@@ -300,7 +309,7 @@ local function complete(arglead, cmdline, _)
   local subcmds = { 'pr', 'issue', 'ci', 'release', 'browse', 'review', 'clear' }
   local sub_actions = {
     pr = { 'checkout', 'diff', 'worktree', 'ci', 'browse', 'manage', 'create', '--state=' },
-    issue = { 'browse', 'close', 'reopen', '--state=' },
+    issue = { 'browse', 'close', 'reopen', 'create', '--state=' },
     ci = { '--all' },
     release = { 'browse', 'delete' },
     review = { 'end', 'toggle' },
@@ -341,6 +350,10 @@ local function complete(arglead, cmdline, _)
 
   if sub == 'pr' and words[3] == 'create' then
     return filter(create_flags)
+  end
+
+  if sub == 'issue' and words[3] == 'create' then
+    return filter({ '--web' })
   end
 
   return {}


### PR DESCRIPTION
## Problem

Issue creation was not supported — users had to leave Neovim to create issues.

## Solution

Add `create_issue` flow mirroring the PR compose buffer pattern. Supports title, body, labels, and assignees via metadata in the compose comment block. Template discovery scans forge-specific issue template paths (GitHub: `.github/ISSUE_TEMPLATE/`, GitLab: `.gitlab/issue_templates/`, Codeberg: `.gitea/issue_template.md` + `.github/ISSUE_TEMPLATE/`). Refactors `discover_template` to accept paths + label, making it reusable for both PR and issue templates.

Available as `:Forge issue create [--web]`, `<c-a>` in the issue picker, and `require('forge').create_issue()`.

Closes #28.