### PR TITLE
fix(compose): align highlights with gitcommit and fugitive conventions

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -426,11 +426,13 @@ Compose buffer: ~
   Group                    Default Link      Description ~
   `ForgeComposeComment`      `Comment`          Comment block lines
   `ForgeComposeBranch`       `Special`          Branch names
-  `ForgeComposeForge`        `Type`             Forge name
+  `ForgeComposeForge`        `Label`            Forge name
   `ForgeComposeDraft`        `DiagnosticWarn`   Draft status value
-  `ForgeComposeFile`         `Directory`        File paths in diff stat
+  `ForgeComposeFile`         `Constant`         File paths in diff stat
   `ForgeComposeAdded`        `Added`            Addition indicators (+)
   `ForgeComposeRemoved`      `Removed`          Deletion indicators (-)
+  `ForgeComposeHeader`       `PreProc`          Section headers
+  `ForgeComposeLabel`        `Label`            Metadata labels (Draft:, etc.)
 
 Picker lines: ~
 

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -184,13 +184,17 @@ function M.registered_sources()
 end
 
 local hl_defaults = {
+  -- TODO: https://github.com/barrettruth/forge.nvim/issues/33
+  -- ForgeComposeComment = 'Comment',
   ForgeComposeComment = { italic = true },
   ForgeComposeBranch = 'Special',
-  ForgeComposeForge = 'Type',
+  ForgeComposeForge = 'Label',
   ForgeComposeDraft = 'DiagnosticWarn',
-  ForgeComposeFile = 'Directory',
+  ForgeComposeFile = 'Constant',
   ForgeComposeAdded = 'Added',
   ForgeComposeRemoved = 'Removed',
+  ForgeComposeHeader = 'PreProc',
+  ForgeComposeLabel = 'Label',
   ForgeNumber = 'Number',
   ForgeOpen = 'DiagnosticInfo',
   ForgeMerged = 'Constant',
@@ -1139,6 +1143,7 @@ local function open_compose_buffer(f, branch, base, draft)
 
   local creating_prefix = '  Creating ' .. pr_kind .. ' via '
   ln = add_line('%s%s.', creating_prefix, f.name)
+  mark(ln, 2, #creating_prefix - 2, 'ForgeComposeHeader')
   mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
   add_line('')
@@ -1146,12 +1151,14 @@ local function open_compose_buffer(f, branch, base, draft)
     local draft_val = draft and 'true' or 'false'
     local draft_prefix = '  Draft: '
     ln = add_line('%s%s', draft_prefix, draft_val)
+    mark(ln, 2, 6, 'ForgeComposeLabel')
     mark(ln, #draft_prefix, #draft_val, draft and 'ForgeComposeDraft' or 'ForgeDim')
   end
 
   if f.capabilities.reviewers then
     local reviewers_prefix = '  Reviewers: '
-    add_line('%s', reviewers_prefix)
+    ln = add_line('%s', reviewers_prefix)
+    mark(ln, 2, 10, 'ForgeComposeLabel')
   end
 
   local stat_start, stat_end
@@ -1159,6 +1166,7 @@ local function open_compose_buffer(f, branch, base, draft)
     add_line('')
     local changes_prefix = '  Changes not in origin/'
     ln = add_line('%s%s:', changes_prefix, base)
+    mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
     mark(ln, #changes_prefix, #base, 'ForgeComposeBranch')
     add_line('')
     stat_start = #lines + 1


### PR DESCRIPTION
## Problem

Compose buffer highlights used generic groups (`Type`, `Directory`, italic-only) that didn't match established Neovim git conventions, producing inconsistent colors across colorschemes.

## Solution

Relink `ForgeComposeFile` to `Constant` (matching `gitcommitSelectedFile`), `ForgeComposeForge` to `Label` (matching `fugitiveHeader`). Add `ForgeComposeHeader` (`PreProc`) for section headers and `ForgeComposeLabel` (`Label`) for metadata keys like `Draft:` and `Reviewers:`, inspired by `gitcommitHeader` and `gitcommitTrailerToken`.

`ForgeComposeComment` → `Comment` is deferred to #33 due to treesitter overlay conflicts.

Closes #29.