### PR TITLE
feat(issue): add --blank and --template= flags to issue create

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -1644,6 +1644,8 @@ end
 
 ---@class forge.CreateIssueOpts
 ---@field web boolean?
+---@field blank boolean?
+---@field template string?
 
 ---@param opts forge.CreateIssueOpts?
 function M.create_issue(opts)
@@ -1669,8 +1671,26 @@ function M.create_issue(opts)
     return
   end
 
+  if opts.blank then
+    open_issue_compose_buffer(f, nil)
+    return
+  end
+
   local root = git_root() or ''
   local result, templates = discover_templates(f:issue_template_paths(), root)
+
+  if opts.template and templates then
+    local slug = opts.template:lower()
+    for _, t in ipairs(templates) do
+      if t.name:gsub('%.ya?ml$', ''):gsub('%.md$', ''):lower() == slug then
+        open_issue_compose_buffer(f, load_template(t))
+        return
+      end
+    end
+    log.warn('template not found: ' .. opts.template)
+    return
+  end
+
   if result or not templates then
     open_issue_compose_buffer(f, result)
     return
@@ -1700,6 +1720,24 @@ function M.create_issue(opts)
     },
     picker_name = '_menu',
   })
+end
+
+function M.template_slugs()
+  local f = M.detect()
+  if not f then
+    return {}
+  end
+  local root = git_root() or ''
+  local _, templates = discover_templates(f:issue_template_paths(), root)
+  if not templates then
+    return {}
+  end
+  local slugs = {}
+  for _, t in ipairs(templates) do
+    local slug = t.name:gsub('%.ya?ml$', ''):gsub('%.md$', '')
+    slugs[#slugs + 1] = slug
+  end
+  return slugs
 end
 
 M._discover_templates = discover_templates

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -147,11 +147,17 @@ local function dispatch(args)
     local action = pos[1]
     if action == 'create' then
       local cf = parse_flags(args, 3)
+      local opts = {}
       if cf.web then
-        forge_mod.create_issue({ web = true })
-      else
-        forge_mod.create_issue()
+        opts.web = true
       end
+      if cf.blank then
+        opts.blank = true
+      end
+      if cf.template then
+        opts.template = cf.template ~= true and cf.template or nil
+      end
+      forge_mod.create_issue(opts)
       return
     end
     local num = pos[2]
@@ -319,6 +325,7 @@ local function complete(arglead, cmdline, _)
     ['--state'] = { 'open', 'closed', 'all' },
   }
   local create_flags = { '--draft', '--fill', '--web' }
+  local issue_create_flags = { '--web', '--blank', '--template=' }
 
   local function filter(candidates)
     return vim.tbl_filter(function(s)
@@ -327,15 +334,21 @@ local function complete(arglead, cmdline, _)
   end
 
   local flag, value_prefix = arglead:match('^(%-%-[^=]+)=(.*)$')
-  if flag and flag_values[flag] then
-    return vim.tbl_map(
-      function(v)
-        return flag .. '=' .. v
-      end,
-      vim.tbl_filter(function(v)
-        return v:find(value_prefix, 1, true) == 1
-      end, flag_values[flag])
-    )
+  if flag then
+    local values = flag_values[flag]
+    if not values and flag == '--template' then
+      values = require('forge').template_slugs()
+    end
+    if values then
+      return vim.tbl_map(
+        function(v)
+          return flag .. '=' .. v
+        end,
+        vim.tbl_filter(function(v)
+          return v:find(value_prefix, 1, true) == 1
+        end, values)
+      )
+    end
   end
 
   if arg_idx == 1 then
@@ -353,7 +366,7 @@ local function complete(arglead, cmdline, _)
   end
 
   if sub == 'issue' and words[3] == 'create' then
-    return filter({ '--web' })
+    return filter(issue_create_flags)
   end
 
   return {}


### PR DESCRIPTION
## Problem

`:Forge issue create` always opens a picker when multiple templates exist, with no way to bypass from the command line.

## Solution

Add `--blank` to skip template discovery entirely, and `--template=<slug>` to select by filename stem. Tab completion for `--template=` discovers templates via `fs_scandir` and offers slugs like `bug_report`, `feature_request`.