### PR TITLE
fix(picker): bind browse to `<c-x>` in issue picker (#20)

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -142,7 +142,7 @@ Top-level keys: ~
           refresh = '<c-r>',
         },
         issue = {
-          browse = '<cr>',
+          browse = '<c-x>',
           close = '<c-s>',
           filter = '<c-o>',
           refresh = '<c-r>',
@@ -319,7 +319,7 @@ PR PICKER ~ Lists PRs/MRs with number, title, author, and relative time.
 ISSUE PICKER ~ Lists issues with number, title, author, and relative time.
 
   Action      Default Key    Description ~
-  `browse`      `<cr>`           Open issue in browser
+  `browse`      `<cr>` / `<c-x>`     Open issue in browser
   `close`       `<c-s>`          Close or reopen the issue
   `create`      `<c-a>`          Create new issue
   `filter`      `<c-o>`          Cycle state: all -> open -> closed

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -117,7 +117,7 @@ local DEFAULTS = {
       refresh = '<c-r>',
     },
     issue = {
-      browse = '<cr>',
+      browse = '<c-x>',
       close = '<c-s>',
       filter = '<c-o>',
       refresh = '<c-r>',

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -624,6 +624,14 @@ function M.issue(state, f)
       entries = entries,
       actions = {
         {
+          name = 'default',
+          fn = function(entry)
+            if entry then
+              f:view_web(cli_kind, entry.value)
+            end
+          end,
+        },
+        {
           name = 'browse',
           fn = function(entry)
             if entry then


### PR DESCRIPTION
## Summary

- Add a `default` action to the issue picker so `<cr>` continues to open the issue in the browser
- Map `browse` to `<c-x>` in the issue picker defaults, matching the PR and CI picker convention
- Update docs to reflect both `<cr>` and `<c-x>` as browse keys

Closes #20