### PR TITLE
fix(picker): add refresh logging for checks and CI pickers

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -318,6 +318,7 @@ function M.checks(f, num, filter, cached_checks)
         {
           name = 'refresh',
           fn = function()
+            log.info(('refreshing checks for %s #%s...'):format(f.labels.pr_one, num))
             M.checks(f, num, filter)
           end,
         },
@@ -449,6 +450,7 @@ function M.ci(f, branch)
         {
           name = 'refresh',
           fn = function()
+            log.info('refreshing CI runs...')
             M.ci(f, branch)
           end,
         },


### PR DESCRIPTION
## Summary

- Add `log.info` on `<c-r>` refresh in the checks and CI run pickers, matching the pattern already used by the PR, issue, and release pickers
- Per-job log filtering (`<c-t>` from a PR, then selecting a specific check) already works correctly — the `job_id` is extracted from the check link and passed as `--job` to `gh run view`

Closes #13