### PR TITLE
refactor(backends): replace field methods with static tables

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -18,6 +18,28 @@ local M = {
     per_pr_checks = true,
     ci_json = true,
   },
+  pr_fields = {
+    number = 'index',
+    title = 'title',
+    branch = 'head',
+    state = 'state',
+    author = 'poster',
+    created_at = 'created_at',
+  },
+  issue_fields = {
+    number = 'index',
+    title = 'title',
+    state = 'state',
+    author = 'poster',
+    created_at = 'created_at',
+  },
+  release_fields = {
+    tag = 'tag_name',
+    title = 'name',
+    is_draft = 'draft',
+    is_prerelease = 'prerelease',
+    published_at = 'published_at',
+  },
 }
 
 ---@param state string
@@ -49,27 +71,6 @@ function M:list_issue_json_cmd(state)
     'json',
     '--fields',
     'index,title,state,poster,created_at',
-  }
-end
-
-function M:pr_json_fields()
-  return {
-    number = 'index',
-    title = 'title',
-    branch = 'head',
-    state = 'state',
-    author = 'poster',
-    created_at = 'created_at',
-  }
-end
-
-function M:issue_json_fields()
-  return {
-    number = 'index',
-    title = 'title',
-    state = 'state',
-    author = 'poster',
-    created_at = 'created_at',
   }
 end
 
@@ -427,16 +428,6 @@ function M:list_releases_json_cmd()
     'sh',
     '-c',
     'tea api "/repos/:owner/:repo/releases?limit=' .. limit .. '"',
-  }
-end
-
-function M:release_json_fields()
-  return {
-    tag = 'tag_name',
-    title = 'name',
-    is_draft = 'draft',
-    is_prerelease = 'prerelease',
-    published_at = 'published_at',
   }
 end
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -136,8 +136,8 @@ local M = {}
 ---@field capabilities forge.Capabilities
 ---@field list_pr_json_cmd fun(self: forge.Forge, state: string): string[]
 ---@field list_issue_json_cmd fun(self: forge.Forge, state: string): string[]
----@field pr_json_fields fun(self: forge.Forge): { number: string, title: string, branch: string, state: string, author: string, created_at: string }
----@field issue_json_fields fun(self: forge.Forge): { number: string, title: string, state: string, author: string, created_at: string }
+---@field pr_fields { number: string, title: string, branch: string, state: string, author: string, created_at: string }
+---@field issue_fields { number: string, title: string, state: string, author: string, created_at: string }
 ---@field view_web fun(self: forge.Forge, kind: string, num: string)
 ---@field browse fun(self: forge.Forge, loc: string, branch: string)
 ---@field browse_branch fun(self: forge.Forge, branch: string)
@@ -172,7 +172,7 @@ local M = {}
 ---@field checks_json_cmd (fun(self: forge.Forge, num: string): string[])?
 ---@field template_paths fun(self: forge.Forge): string[]
 ---@field list_releases_json_cmd fun(self: forge.Forge): string[]
----@field release_json_fields fun(self: forge.Forge): { tag: string, title: string, is_draft: string?, is_prerelease: string?, is_latest: string?, published_at: string }
+---@field release_fields { tag: string, title: string, is_draft: string?, is_prerelease: string?, is_latest: string?, published_at: string }
 ---@field browse_release fun(self: forge.Forge, tag: string)
 ---@field delete_release_cmd fun(self: forge.Forge, tag: string): string[]
 ---@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, assignees: string[]?, milestone: string?): string[]

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -18,6 +18,29 @@ local M = {
     per_pr_checks = true,
     ci_json = true,
   },
+  pr_fields = {
+    number = 'number',
+    title = 'title',
+    branch = 'headRefName',
+    state = 'state',
+    author = 'author',
+    created_at = 'createdAt',
+  },
+  issue_fields = {
+    number = 'number',
+    title = 'title',
+    state = 'state',
+    author = 'author',
+    created_at = 'createdAt',
+  },
+  release_fields = {
+    tag = 'tagName',
+    title = 'name',
+    is_draft = 'isDraft',
+    is_prerelease = 'isPrerelease',
+    is_latest = 'isLatest',
+    published_at = 'publishedAt',
+  },
 }
 
 local function nwo()
@@ -54,27 +77,6 @@ function M:list_issue_json_cmd(state)
     state,
     '--json',
     'number,title,state,author,createdAt',
-  }
-end
-
-function M:pr_json_fields()
-  return {
-    number = 'number',
-    title = 'title',
-    branch = 'headRefName',
-    state = 'state',
-    author = 'author',
-    created_at = 'createdAt',
-  }
-end
-
-function M:issue_json_fields()
-  return {
-    number = 'number',
-    title = 'title',
-    state = 'state',
-    author = 'author',
-    created_at = 'createdAt',
   }
 end
 
@@ -454,17 +456,6 @@ function M:list_releases_json_cmd()
     'tagName,name,isDraft,isPrerelease,isLatest,publishedAt',
     '--limit',
     tostring(forge.config().display.limits.releases),
-  }
-end
-
-function M:release_json_fields()
-  return {
-    tag = 'tagName',
-    title = 'name',
-    is_draft = 'isDraft',
-    is_prerelease = 'isPrerelease',
-    is_latest = 'isLatest',
-    published_at = 'publishedAt',
   }
 end
 

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -18,6 +18,26 @@ local M = {
     per_pr_checks = true,
     ci_json = true,
   },
+  pr_fields = {
+    number = 'iid',
+    title = 'title',
+    branch = 'source_branch',
+    state = 'state',
+    author = 'author',
+    created_at = 'created_at',
+  },
+  issue_fields = {
+    number = 'iid',
+    title = 'title',
+    state = 'state',
+    author = 'author',
+    created_at = 'created_at',
+  },
+  release_fields = {
+    tag = 'tag_name',
+    title = 'name',
+    published_at = 'released_at',
+  },
 }
 
 ---@param state string
@@ -58,27 +78,6 @@ function M:list_issue_json_cmd(state)
     table.insert(cmd, '--all')
   end
   return cmd
-end
-
-function M:pr_json_fields()
-  return {
-    number = 'iid',
-    title = 'title',
-    branch = 'source_branch',
-    state = 'state',
-    author = 'author',
-    created_at = 'created_at',
-  }
-end
-
-function M:issue_json_fields()
-  return {
-    number = 'iid',
-    title = 'title',
-    state = 'state',
-    author = 'author',
-    created_at = 'created_at',
-  }
 end
 
 ---@param kind string
@@ -477,14 +476,6 @@ end
 
 function M:list_releases_json_cmd()
   return { 'glab', 'release', 'list', '--output', 'json' }
-end
-
-function M:release_json_fields()
-  return {
-    tag = 'tag_name',
-    title = 'name',
-    published_at = 'released_at',
-  }
 end
 
 ---@param tag string

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -483,7 +483,7 @@ function M.pr(state, f)
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
   local forge_mod = require('forge')
   local cache_key = forge_mod.list_key('pr', state)
-  local pr_fields = f:pr_json_fields()
+  local pr_fields = f.pr_fields
   local show_state = state ~= 'open'
 
   local function open_pr_list(prs)
@@ -599,7 +599,7 @@ function M.issue(state, f)
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
   local forge_mod = require('forge')
   local cache_key = forge_mod.list_key('issue', state)
-  local issue_fields = f:issue_json_fields()
+  local issue_fields = f.issue_fields
   local num_field = issue_fields.number
   local issue_show_state = state == 'all'
 
@@ -722,7 +722,7 @@ end
 function M.release(state, f)
   local forge_mod = require('forge')
   local cache_key = forge_mod.list_key('release', state)
-  local rel_fields = f:release_json_fields()
+  local rel_fields = f.release_fields
   local next_state = ({ all = 'draft', draft = 'prerelease', prerelease = 'all' })[state]
 
   local function open_release_list(releases)

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -63,7 +63,7 @@ describe('github', function()
   end)
 
   it('returns correct pr_json_fields', function()
-    local f = gh:pr_json_fields()
+    local f = gh.pr_fields
     assert.equals('number', f.number)
     assert.equals('headRefName', f.branch)
     assert.equals('createdAt', f.created_at)
@@ -124,7 +124,7 @@ describe('gitlab', function()
   end)
 
   it('returns correct pr_json_fields', function()
-    local f = gl:pr_json_fields()
+    local f = gl.pr_fields
     assert.equals('iid', f.number)
     assert.equals('source_branch', f.branch)
     assert.equals('created_at', f.created_at)
@@ -176,7 +176,7 @@ describe('codeberg', function()
   end)
 
   it('returns correct pr_json_fields', function()
-    local f = cb:pr_json_fields()
+    local f = cb.pr_fields
     assert.equals('index', f.number)
     assert.equals('head', f.branch)
     assert.equals('poster', f.author)


### PR DESCRIPTION
## Problem

`pr_json_fields()`, `issue_json_fields()`, and `release_json_fields()` returned
the same static table on every call across all three backends, adding unnecessary
method overhead for pure data.

## Solution

Move the field mappings into table fields on `M` (`pr_fields`, `issue_fields`,
`release_fields`) and update all consumers in `pickers.lua`, `config.lua` type
annotations, and tests to use direct table access.