### PR TITLE
feat: edit existing PR via compose buffer

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -270,6 +270,54 @@ function M:reopen_issue_cmd(num)
   return { 'tea', 'issues', 'reopen', num }
 end
 
+---@param num string
+---@return string[]
+function M:fetch_pr_details_cmd(num)
+  return {
+    'sh',
+    '-c',
+    ('tea api "/repos/:owner/:repo/pulls/%s"'):format(num),
+  }
+end
+
+---@param num string
+---@param title string
+---@param body string
+---@param _reviewers string[]?
+---@param _labels string[]?
+---@param _assignees string[]?
+---@param _milestone string?
+---@return string[]
+function M:update_pr_cmd(num, title, body, _reviewers, _labels, _assignees, _milestone)
+  return { 'tea', 'pr', 'edit', num, '--title', title, '--description', body }
+end
+
+---@param json table
+---@return { title: string, body: string, draft: boolean, reviewers: string[], labels: string[], assignees: string[], milestone: string }
+function M:parse_pr_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, l.name or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.login or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
+  return {
+    title = json.title or '',
+    body = json.body or '',
+    draft = false,
+    labels = labels,
+    assignees = assignees,
+    reviewers = {},
+    milestone = milestone,
+  }
+end
+
 ---@param title string
 ---@param body string
 ---@param base string

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -492,4 +492,234 @@ end
 
 M.push_and_create = push_and_create
 
+---@param f forge.Forge
+---@param num string
+---@param title string
+---@param body string
+---@param pr_draft boolean
+---@param original_draft boolean
+---@param pr_reviewers string[]?
+---@param pr_labels string[]?
+---@param pr_assignees string[]?
+---@param pr_milestone string?
+---@param buf integer?
+local function update_pr(
+  f,
+  num,
+  title,
+  body,
+  pr_draft,
+  original_draft,
+  pr_reviewers,
+  pr_labels,
+  pr_assignees,
+  pr_milestone,
+  buf
+)
+  local log = require('forge.logger')
+  log.info('updating ' .. f.labels.pr_one .. ' #' .. num .. '...')
+  vim.system(
+    f:update_pr_cmd(num, title, body, pr_reviewers, pr_labels, pr_assignees, pr_milestone),
+    { text = true },
+    function(result)
+      vim.schedule(function()
+        if result.code ~= 0 then
+          local msg = vim.trim(result.stderr or '')
+          if msg == '' then
+            msg = vim.trim(result.stdout or '')
+          end
+          if msg == '' then
+            msg = 'update failed'
+          end
+          log.error(msg)
+          return
+        end
+        if pr_draft ~= original_draft then
+          local draft_cmd = f:draft_toggle_cmd(num, original_draft)
+          if draft_cmd then
+            vim.system(draft_cmd, { text = true }, function(dr)
+              vim.schedule(function()
+                if dr.code ~= 0 then
+                  log.warn('updated ' .. f.labels.pr_one .. ' but draft toggle failed')
+                else
+                  log.info(('updated %s #%s'):format(f.labels.pr_one, num))
+                end
+              end)
+            end)
+          else
+            log.info(('updated %s #%s'):format(f.labels.pr_one, num))
+          end
+        else
+          log.info(('updated %s #%s'):format(f.labels.pr_one, num))
+        end
+        require('forge').clear_list()
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          vim.bo[buf].modified = false
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end)
+    end
+  )
+end
+
+---@param f forge.Forge
+---@param num string
+---@param details { title: string, body: string, draft: boolean, reviewers: string[], labels: string[], assignees: string[], milestone: string }
+---@param branch string
+---@param base string
+function M.open_pr_edit(f, num, details, branch, base)
+  local buf = create_compose_buf(('forge://pr/%s/edit'):format(num))
+
+  local b = ComposeBuilder.new()
+  b.lines = { '# ' .. details.title, '' }
+  if details.body ~= '' then
+    for _, line in ipairs(vim.split(details.body, '\n', { plain = true })) do
+      table.insert(b.lines, line)
+    end
+  else
+    table.insert(b.lines, '')
+  end
+
+  table.insert(b.lines, '')
+  local comment_start = #b.lines + 1
+
+  local pr_kind = f.labels.pr_full:gsub('s$', '')
+  local diff_stat = vim.fn.system('git diff --stat origin/' .. base .. '..HEAD'):gsub('%s+$', '')
+
+  b:add_line('<!--')
+
+  local branch_prefix = '  On branch '
+  local against = ' against '
+  local ln = b:add_line('%s%s%s%s.', branch_prefix, branch, against, base)
+  b:mark(ln, #branch_prefix, #branch, 'ForgeComposeBranch')
+  b:mark(ln, #branch_prefix + #branch + #against, #base, 'ForgeComposeBranch')
+
+  local editing_prefix = '  Editing ' .. pr_kind .. ' #' .. num .. ' via '
+  ln = b:add_line('%s%s.', editing_prefix, f.name)
+  b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
+  b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
+
+  b:add_line('')
+  local original_draft = details.draft
+  if f.capabilities.draft then
+    local draft_val = details.draft and 'true' or 'false'
+    local draft_prefix = '  Draft: '
+    ln = b:add_line('%s%s', draft_prefix, draft_val)
+    b:mark(ln, 2, 6, 'ForgeComposeLabel')
+    b:mark(ln, #draft_prefix, #draft_val, details.draft and 'ForgeComposeDraft' or 'ForgeDim')
+  end
+
+  if f.capabilities.reviewers then
+    local reviewers_prefix = '  Reviewers: '
+    local reviewers_val = table.concat(details.reviewers, ', ')
+    ln = b:add_line('%s%s', reviewers_prefix, reviewers_val)
+    b:mark(ln, 2, 10, 'ForgeComposeLabel')
+  end
+
+  local labels_prefix = '  Labels: '
+  local labels_val = table.concat(details.labels, ', ')
+  ln = b:add_line('%s%s', labels_prefix, labels_val)
+  b:mark(ln, 2, 7, 'ForgeComposeLabel')
+
+  local assignees_prefix = '  Assignees: '
+  local assignees_val = table.concat(details.assignees, ', ')
+  ln = b:add_line('%s%s', assignees_prefix, assignees_val)
+  b:mark(ln, 2, 10, 'ForgeComposeLabel')
+
+  local milestone_prefix = '  Milestone: '
+  ln = b:add_line('%s%s', milestone_prefix, details.milestone)
+  b:mark(ln, 2, 10, 'ForgeComposeLabel')
+
+  local stat_start, stat_end
+  if diff_stat ~= '' then
+    b:add_line('')
+    local changes_prefix = '  Changes not in origin/'
+    ln = b:add_line('%s%s:', changes_prefix, base)
+    b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
+    b:mark(ln, #changes_prefix, #base, 'ForgeComposeBranch')
+    b:add_line('')
+    stat_start = #b.lines + 1
+    for _, sl in ipairs(vim.split(diff_stat, '\n', { plain = true })) do
+      table.insert(b.lines, '  ' .. sl)
+    end
+    stat_end = #b.lines
+  end
+  b:add_line('')
+  b:add_line('  An empty title or body aborts editing.')
+  b:add_line('-->')
+
+  b:apply(buf, comment_start)
+
+  if stat_start and stat_end then
+    for i = stat_start, stat_end do
+      local line = b.lines[i]
+      local pipe = line:find('|')
+      if pipe then
+        local fname_start = line:find('%S')
+        if fname_start then
+          b:mark(i, fname_start - 1, pipe - fname_start - 1, 'ForgeComposeFile')
+        end
+        for pos, run in line:gmatch('()([+-]+)') do
+          if pos > pipe then
+            local stat_hl = run:sub(1, 1) == '+' and 'ForgeComposeAdded' or 'ForgeComposeRemoved'
+            b:mark(i, pos - 1, #run, stat_hl)
+          end
+        end
+      end
+    end
+    for _, m in ipairs(b.marks) do
+      if m.line >= stat_start then
+        vim.api.nvim_buf_set_extmark(buf, compose_ns, m.line - 1, m.col, {
+          end_col = m.end_col,
+          hl_group = m.hl,
+          priority = 200,
+        })
+      end
+    end
+  end
+
+  vim.api.nvim_create_autocmd('BufWriteCmd', {
+    buffer = buf,
+    callback = function()
+      local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      local content_lines = extract_content(buf_lines)
+      local pr_title = vim.trim((content_lines[1] or ''):gsub('^#+ *', ''))
+
+      local log = require('forge.logger')
+      if pr_title == '' then
+        log.warn('aborting: empty title')
+        vim.bo[buf].modified = false
+        vim.api.nvim_buf_delete(buf, { force = true })
+        return
+      end
+      local pr_body = vim.trim(table.concat(content_lines, '\n', 3))
+      if pr_body == '' then
+        log.warn('aborting: empty body')
+        vim.bo[buf].modified = false
+        vim.api.nvim_buf_delete(buf, { force = true })
+        return
+      end
+
+      local meta = parse_comment_metadata(buf_lines)
+      update_pr(
+        f,
+        num,
+        pr_title,
+        pr_body,
+        meta.draft,
+        original_draft,
+        meta.reviewers,
+        meta.labels,
+        meta.assignees,
+        meta.milestone,
+        buf
+      )
+    end,
+  })
+
+  vim.api.nvim_win_set_cursor(0, { 1, 2 })
+  vim.cmd('normal! v$h')
+  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-G>', true, false, true), 'n', false)
+end
+
 return M

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -33,6 +33,7 @@ local M = {}
 ---@field ci string|false
 ---@field browse string|false
 ---@field manage string|false
+---@field edit string|false
 ---@field create string|false
 ---@field filter string|false
 ---@field refresh string|false
@@ -167,6 +168,9 @@ local M = {}
 ---@field reopen_issue_cmd fun(self: forge.Forge, num: string): string[]
 ---@field draft_toggle_cmd fun(self: forge.Forge, num: string, is_draft: boolean): string[]?
 ---@field create_pr_cmd fun(self: forge.Forge, title: string, body: string, base: string, draft: boolean, reviewers: string[]?, labels: string[]?, assignees: string[]?, milestone: string?): string[]
+---@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, reviewers: string[]?, labels: string[]?, assignees: string[]?, milestone: string?): string[]
+---@field fetch_pr_details_cmd fun(self: forge.Forge, num: string): string[]
+---@field parse_pr_details fun(self: forge.Forge, json: table): { title: string, body: string, draft: boolean, reviewers: string[], labels: string[], assignees: string[], milestone: string }
 ---@field create_pr_web_cmd fun(self: forge.Forge): string[]?
 ---@field default_branch_cmd fun(self: forge.Forge): string[]
 ---@field checks_json_cmd (fun(self: forge.Forge, num: string): string[])?
@@ -193,7 +197,8 @@ local DEFAULTS = {
       worktree = '<c-w>',
       ci = '<c-t>',
       browse = '<c-x>',
-      manage = '<c-e>',
+      manage = '<c-m>',
+      edit = '<c-e>',
       create = '<c-a>',
       filter = '<c-o>',
       refresh = '<c-r>',
@@ -369,6 +374,7 @@ function M.config()
         'ci',
         'browse',
         'manage',
+        'edit',
         'create',
         'filter',
         'refresh',

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -289,6 +289,78 @@ function M:reopen_issue_cmd(num)
   return { 'gh', 'issue', 'reopen', num }
 end
 
+---@param num string
+---@return string[]
+function M:fetch_pr_details_cmd(num)
+  return {
+    'gh',
+    'pr',
+    'view',
+    num,
+    '--json',
+    'title,body,isDraft,labels,assignees,reviewRequests,milestone',
+  }
+end
+
+---@param num string
+---@param title string
+---@param body string
+---@param reviewers string[]?
+---@param labels string[]?
+---@param assignees string[]?
+---@param milestone string?
+---@return string[]
+function M:update_pr_cmd(num, title, body, reviewers, labels, assignees, milestone)
+  local cmd = { 'gh', 'pr', 'edit', num, '--title', title, '--body', body }
+  for _, r in ipairs(reviewers or {}) do
+    table.insert(cmd, '--add-reviewer')
+    table.insert(cmd, r)
+  end
+  for _, l in ipairs(labels or {}) do
+    table.insert(cmd, '--add-label')
+    table.insert(cmd, l)
+  end
+  for _, a in ipairs(assignees or {}) do
+    table.insert(cmd, '--add-assignee')
+    table.insert(cmd, a)
+  end
+  if milestone and milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, milestone)
+  end
+  return cmd
+end
+
+---@param json table
+---@return { title: string, body: string, draft: boolean, reviewers: string[], labels: string[], assignees: string[], milestone: string }
+function M:parse_pr_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, l.name or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.login or '')
+  end
+  local reviewers = {}
+  for _, r in ipairs(json.reviewRequests or {}) do
+    table.insert(reviewers, r.login or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
+  return {
+    title = json.title or '',
+    body = json.body or '',
+    draft = json.isDraft == true,
+    labels = labels,
+    assignees = assignees,
+    reviewers = reviewers,
+    milestone = milestone,
+  }
+end
+
 ---@param title string
 ---@param body string
 ---@param base string

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -312,6 +312,71 @@ function M:reopen_issue_cmd(num)
   return { 'glab', 'issue', 'reopen', num }
 end
 
+---@param num string
+---@return string[]
+function M:fetch_pr_details_cmd(num)
+  return { 'glab', 'mr', 'view', num, '--output', 'json' }
+end
+
+---@param num string
+---@param title string
+---@param body string
+---@param reviewers string[]?
+---@param labels string[]?
+---@param assignees string[]?
+---@param milestone string?
+---@return string[]
+function M:update_pr_cmd(num, title, body, reviewers, labels, assignees, milestone)
+  local cmd = { 'glab', 'mr', 'update', num, '--title', title, '--description', body }
+  for _, r in ipairs(reviewers or {}) do
+    table.insert(cmd, '--reviewer')
+    table.insert(cmd, r)
+  end
+  if labels and #labels > 0 then
+    table.insert(cmd, '--label')
+    table.insert(cmd, table.concat(labels, ','))
+  end
+  for _, a in ipairs(assignees or {}) do
+    table.insert(cmd, '--assignee')
+    table.insert(cmd, a)
+  end
+  if milestone and milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, milestone)
+  end
+  return cmd
+end
+
+---@param json table
+---@return { title: string, body: string, draft: boolean, reviewers: string[], labels: string[], assignees: string[], milestone: string }
+function M:parse_pr_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, type(l) == 'string' and l or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.username or '')
+  end
+  local reviewers = {}
+  for _, r in ipairs(json.reviewers or {}) do
+    table.insert(reviewers, r.username or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
+  return {
+    title = json.title or '',
+    body = json.description or '',
+    draft = json.draft == true,
+    labels = labels,
+    assignees = assignees,
+    reviewers = reviewers,
+    milestone = milestone,
+  }
+end
+
 ---@param title string
 ---@param body string
 ---@param base string

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -243,7 +243,7 @@ function M.create_pr(opts)
     local num = vim.trim(result.stdout or '')
     vim.schedule(function()
       if num ~= '' and num ~= 'null' then
-        log.warn(('%s #%s already exists for branch %s'):format(f.labels.pr_one, num, branch))
+        M.edit_pr(num)
         return
       end
 
@@ -315,6 +315,51 @@ function M.create_pr(opts)
             end
           end
         end)
+      end)
+    end)
+  end)
+end
+
+---@param num string
+function M.edit_pr(num)
+  local log = require('forge.logger')
+
+  local f = M.detect()
+  if not f then
+    log.warn('no forge detected')
+    return
+  end
+
+  local branch = vim.trim(vim.fn.system('git branch --show-current'))
+  if branch == '' then
+    log.warn('detached HEAD')
+    return
+  end
+
+  log.info(('fetching %s #%s...'):format(f.labels.pr_one, num))
+
+  vim.system(f:fetch_pr_details_cmd(num), { text = true }, function(result)
+    if result.code ~= 0 then
+      vim.schedule(function()
+        log.error('failed to fetch ' .. f.labels.pr_one .. ' #' .. num)
+      end)
+      return
+    end
+    local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+    if not ok or type(json) ~= 'table' then
+      vim.schedule(function()
+        log.error('failed to parse ' .. f.labels.pr_one .. ' details')
+      end)
+      return
+    end
+    local details = f:parse_pr_details(json)
+    vim.system(f:pr_base_cmd(num), { text = true }, function(base_result)
+      local base = vim.trim(base_result.stdout or '')
+      if base == '' then
+        base = 'main'
+      end
+      vim.schedule(function()
+        compose_mod.open_pr_edit(f, num, details, branch, base)
       end)
     end)
   end)

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -130,6 +130,9 @@ local function pr_action_fns(f, num)
     manage = function()
       M.pr_manage(f, num)
     end,
+    edit = function()
+      require('forge').edit_pr(num)
+    end,
   }
 end
 
@@ -546,6 +549,14 @@ function M.pr(state, f)
           fn = function(entry)
             if entry then
               pr_action_fns(f, entry.value).manage()
+            end
+          end,
+        },
+        {
+          name = 'edit',
+          fn = function(entry)
+            if entry then
+              pr_action_fns(f, entry.value).edit()
             end
           end,
         },

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -96,6 +96,15 @@ local function dispatch(args)
       forge_mod.create_pr(opts)
       return
     end
+    if action == 'edit' then
+      local num = pos[2]
+      if not num then
+        log.warn('missing PR number')
+        return
+      end
+      forge_mod.edit_pr(num)
+      return
+    end
     local num = pos[2]
     if not num then
       log.warn('missing argument')
@@ -314,7 +323,7 @@ local function complete(arglead, cmdline, _)
 
   local subcmds = { 'pr', 'issue', 'ci', 'release', 'browse', 'review', 'clear' }
   local sub_actions = {
-    pr = { 'checkout', 'diff', 'worktree', 'ci', 'browse', 'manage', 'create', '--state=' },
+    pr = { 'checkout', 'diff', 'worktree', 'ci', 'browse', 'manage', 'edit', 'create', '--state=' },
     issue = { 'browse', 'close', 'reopen', 'create', '--state=' },
     ci = { '--all' },
     release = { 'browse', 'delete' },


### PR DESCRIPTION
## Summary

Adds the ability to edit an existing PR through the same compose buffer UX used for creation. Closes #21.

### Entry points
- **`:Forge pr edit {num}`** — direct command to edit a specific PR
- **`<c-e>` in PR picker** — new keybinding opens edit buffer for the selected PR
- **Auto-redirect** — `:Forge pr create` on a branch with an existing PR now opens the edit buffer instead of bailing out with a warning

### Keybinding changes
- `edit` = `<c-e>` (previously `manage`)
- `manage` = `<c-m>` (new binding)

### Backend methods added (all 3 forges)

| Method | GitHub | GitLab | Codeberg |
|--------|--------|--------|----------|
| `fetch_pr_details_cmd(num)` | `gh pr view --json ...` | `glab mr view --output json` | `tea api /repos/:owner/:repo/pulls/{num}` |
| `update_pr_cmd(...)` | `gh pr edit` with `--add-*` flags | `glab mr update` | `tea pr edit` (title/body only) |
| `parse_pr_details(json)` | labels, assignees, reviewRequests, milestone | labels, assignees, reviewers, milestone | labels, assignees, milestone |

### Compose buffer for editing
- `open_pr_edit()` opens a compose buffer pre-filled with the PR's current title, body, and all metadata
- Buffer name: `forge://pr/{num}/edit`
- Comment block says "Editing Pull Request #N via github"
- On `:w`, calls `update_pr_cmd()` instead of `create_pr_cmd()`
- Draft toggle handled separately via `draft_toggle_cmd()` when draft state changes

### Files changed
- `lua/forge/github.lua` — +3 methods
- `lua/forge/gitlab.lua` — +3 methods
- `lua/forge/codeberg.lua` — +3 methods
- `lua/forge/compose.lua` — `update_pr()` + `open_pr_edit()`
- `lua/forge/init.lua` — `edit_pr()` + auto-redirect in `create_pr()`
- `lua/forge/pickers.lua` — `edit` action in PR picker
- `lua/forge/config.lua` — type annotations + keybinding defaults
- `plugin/forge.lua` — `:Forge pr edit` dispatch + tab completion

#### Test plan
- [x] All 158 existing tests pass
- [x] StyLua formatting clean
- [ ] Manual: `:Forge pr edit {num}` fetches and opens compose buffer
- [ ] Manual: `<c-e>` in PR picker opens edit buffer
- [ ] Manual: `:Forge pr create` on branch with existing PR auto-redirects to edit
- [ ] Manual: Editing title/body/metadata and writing updates the PR
- [ ] Manual: Changing draft state toggles draft on save