### PR TITLE
feat: omnifunc completion for compose buffer metadata

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -318,6 +318,30 @@ function M:parse_pr_details(json)
   }
 end
 
+---@param field string
+---@return string[]?
+function M:completion_cmd(field)
+  if field == 'labels' then
+    return { 'sh', '-c', "tea api '/repos/:owner/:repo/labels' | jq -r '.[].name'" }
+  elseif field == 'assignees' or field == 'reviewers' or field == 'mentions' then
+    return { 'sh', '-c', "tea api '/repos/:owner/:repo/collaborators' | jq -r '.[].login'" }
+  elseif field == 'milestone' then
+    return {
+      'sh',
+      '-c',
+      "tea api '/repos/:owner/:repo/milestones?state=open' | jq -r '.[].title'",
+    }
+  elseif field == 'issues' then
+    return {
+      'sh',
+      '-c',
+      "tea api '/repos/:owner/:repo/issues?limit=50&type=issues' | jq -r '.[] | \"\\(.number)\\t\\(.title)\"'"
+        .. " && tea api '/repos/:owner/:repo/pulls?limit=50' | jq -r '.[] | \"\\(.number)\\t\\(.title)\"'",
+    }
+  end
+  return nil
+end
+
 ---@param title string
 ---@param body string
 ---@param base string

--- a/lua/forge/completion.lua
+++ b/lua/forge/completion.lua
@@ -1,0 +1,181 @@
+local M = {}
+
+---@type table<string, { data: string[]?, ts: number }>
+local cache = {}
+
+local TTL = 300
+
+---@type string?
+local last_context
+
+---@param line string
+---@return string?
+local function detect_field(line)
+  if line:match('^%s*Draft:') then
+    return 'draft'
+  elseif line:match('^%s*Labels:') then
+    return 'labels'
+  elseif line:match('^%s*Assignees:') then
+    return 'assignees'
+  elseif line:match('^%s*Reviewers:') then
+    return 'reviewers'
+  elseif line:match('^%s*Milestone:') then
+    return 'milestone'
+  end
+  return nil
+end
+
+---@return boolean
+local function in_comment_block()
+  local buf_lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+  local cur = vim.fn.line('.')
+  local inside = false
+  for i = 1, cur do
+    if buf_lines[i]:match('^<!--') then
+      inside = true
+    elseif buf_lines[i]:match('^%-%->') then
+      inside = false
+    end
+  end
+  return inside
+end
+
+---@param line string
+---@param col integer
+---@return string? trigger
+---@return integer? start_col
+local function detect_trigger(line, col)
+  local i = col - 1
+  while i > 0 do
+    local ch = line:sub(i, i)
+    if ch == '#' or ch == '@' then
+      if i == 1 or line:sub(i - 1, i - 1):match('[%s(]') then
+        return ch, i
+      end
+      return nil, nil
+    elseif not ch:match('[%w_%-]') then
+      return nil, nil
+    end
+    i = i - 1
+  end
+  return nil, nil
+end
+
+---@param field string
+---@param f forge.Forge
+---@return string[]
+local function fetch(field, f)
+  if field == 'draft' then
+    return { 'true', 'false' }
+  end
+
+  local now = os.time()
+  local key = f.name .. ':' .. field
+  local entry = cache[key]
+  if entry and entry.data and (now - entry.ts) < TTL then
+    return entry.data
+  end
+
+  local cmd = f:completion_cmd(field)
+  if not cmd then
+    return {}
+  end
+
+  local result = vim.system(cmd, { text = true }):wait()
+  if result.code ~= 0 then
+    return (entry and entry.data) or {}
+  end
+
+  local items = vim.split(vim.trim(result.stdout or ''), '\n', { plain = true, trimempty = true })
+  cache[key] = { data = items, ts = now }
+  return items
+end
+
+function M.clear()
+  cache = {}
+end
+
+---@param findstart integer
+---@param base string
+---@return integer|table[]
+function M.omnifunc(findstart, base)
+  local line = vim.api.nvim_get_current_line()
+  local col = vim.fn.col('.')
+
+  if findstart == 1 then
+    if in_comment_block() then
+      local field = detect_field(line)
+      if field then
+        last_context = 'field:' .. field
+        local i = col - 1
+        while i > 0 and line:sub(i, i):match('[^,%s]') do
+          i = i - 1
+        end
+        return i
+      end
+    end
+
+    local trigger, tpos = detect_trigger(line, col)
+    if trigger and tpos then
+      last_context = 'trigger:' .. trigger
+      return tpos
+    end
+
+    last_context = nil
+    return -1
+  end
+
+  if not last_context then
+    return {}
+  end
+
+  local f = require('forge').detect()
+  if not f then
+    return {}
+  end
+
+  local kind, value = last_context:match('^(%w+):(.+)$')
+
+  if kind == 'field' then
+    local candidates = fetch(value, f)
+    local items = {}
+    local lower_base = base:lower()
+    for _, word in ipairs(candidates) do
+      if word:lower():find(lower_base, 1, true) then
+        table.insert(items, { word = word, menu = '[Forge]' })
+      end
+    end
+    return items
+  end
+
+  if kind == 'trigger' then
+    if value == '#' then
+      local candidates = fetch('issues', f)
+      local items = {}
+      local lower_base = base:lower()
+      for _, entry in ipairs(candidates) do
+        local num, title = entry:match('^(%d+)\t(.+)$')
+        if num then
+          if num:find(lower_base, 1, true) or title:lower():find(lower_base, 1, true) then
+            table.insert(items, { word = '#' .. num, menu = title })
+          end
+        end
+      end
+      return items
+    elseif value == '@' then
+      local candidates = fetch('mentions', f)
+      local items = {}
+      local lower_base = base:lower()
+      for _, word in ipairs(candidates) do
+        if word:lower():find(lower_base, 1, true) then
+          table.insert(items, { word = '@' .. word, menu = '[User]' })
+        end
+      end
+      return items
+    end
+  end
+
+  return {}
+end
+
+return M

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -61,6 +61,7 @@ local function create_compose_buf(name)
   vim.bo[buf].bufhidden = 'wipe'
   vim.bo[buf].filetype = 'markdown'
   vim.bo[buf].swapfile = false
+  vim.bo[buf].omnifunc = 'v:lua.require("forge.completion").omnifunc'
   return buf
 end
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -171,6 +171,7 @@ local M = {}
 ---@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, reviewers: string[]?, labels: string[]?, assignees: string[]?, milestone: string?): string[]
 ---@field fetch_pr_details_cmd fun(self: forge.Forge, num: string): string[]
 ---@field parse_pr_details fun(self: forge.Forge, json: table): { title: string, body: string, draft: boolean, reviewers: string[], labels: string[], assignees: string[], milestone: string }
+---@field completion_cmd (fun(self: forge.Forge, field: string): string[]?)?
 ---@field create_pr_web_cmd fun(self: forge.Forge): string[]?
 ---@field default_branch_cmd fun(self: forge.Forge): string[]
 ---@field checks_json_cmd (fun(self: forge.Forge, num: string): string[])?

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -361,6 +361,26 @@ function M:parse_pr_details(json)
   }
 end
 
+---@param field string
+---@return string[]?
+function M:completion_cmd(field)
+  if field == 'labels' then
+    return { 'gh', 'label', 'list', '--json', 'name', '--jq', '.[].name' }
+  elseif field == 'assignees' or field == 'reviewers' or field == 'mentions' then
+    return { 'gh', 'api', 'repos/' .. nwo() .. '/collaborators', '--jq', '.[].login' }
+  elseif field == 'milestone' then
+    return { 'gh', 'api', 'repos/' .. nwo() .. '/milestones', '--jq', '.[].title' }
+  elseif field == 'issues' then
+    return {
+      'sh',
+      '-c',
+      'gh issue list --limit 50 --state all --json number,title --jq \'.[] | "\\(.number)\\t\\(.title)"\''
+        .. ' && gh pr list --limit 50 --state all --json number,title --jq \'.[] | "\\(.number)\\t\\(.title)"\'',
+    }
+  end
+  return nil
+end
+
 ---@param title string
 ---@param body string
 ---@param base string

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -377,6 +377,26 @@ function M:parse_pr_details(json)
   }
 end
 
+---@param field string
+---@return string[]?
+function M:completion_cmd(field)
+  if field == 'labels' then
+    return { 'sh', '-c', "glab label list -F json | jq -r '.[].name'" }
+  elseif field == 'assignees' or field == 'reviewers' or field == 'mentions' then
+    return { 'sh', '-c', "glab api 'projects/:id/members/all?per_page=100' | jq -r '.[].username'" }
+  elseif field == 'milestone' then
+    return { 'sh', '-c', "glab api 'projects/:id/milestones?state=active' | jq -r '.[].title'" }
+  elseif field == 'issues' then
+    return {
+      'sh',
+      '-c',
+      'glab issue list --per-page 50 -F json | jq -r \'.[] | "\\(.iid)\\t\\(.title)"\''
+        .. ' && glab mr list --per-page 50 -F json | jq -r \'.[] | "\\(.iid)\\t\\(.title)"\'',
+    }
+  end
+  return nil
+end
+
 ---@param title string
 ---@param body string
 ---@param base string


### PR DESCRIPTION
## Summary

Adds context-aware completion for metadata fields in compose buffers (PR create, PR edit, issue create). Closes #45.

When the cursor is on a `Labels:`, `Assignees:`, `Reviewers:`, or `Milestone:` line inside the compose comment block, completion candidates are fetched from the forge API and offered via Neovim's built-in `omnifunc`.

### How it works

- **`lua/forge/completion.lua`** — new module implementing the omnifunc
  - Detects which metadata field the cursor is on via line pattern matching
  - Fetches candidates from `f:completion_cmd(field)` (newline-delimited output)
  - Caches results per-forge per-field with a 5-minute TTL
  - Filters by typed prefix (case-insensitive)

- **`completion_cmd(field)`** — new backend method on all 3 forges:

  | Field | GitHub | GitLab | Codeberg |
  |-------|--------|--------|----------|
  | labels | `gh label list --json name --jq .[].name` | `glab label list` | `tea api /repos/:owner/:repo/labels` |
  | assignees/reviewers | `gh api repos/{nwo}/collaborators --jq .[].login` | `glab api projects/:id/members/all` | `tea api /repos/:owner/:repo/collaborators` |
  | milestone | `gh api repos/{nwo}/milestones --jq .[].title` | `glab api projects/:id/milestones?state=active` | `tea api /repos/:owner/:repo/milestones?state=open` |

- **`compose.lua`** — sets `omnifunc` on all compose buffers via `create_compose_buf()`

### User experience

- **With blink.cmp or nvim-cmp**: completions appear automatically (both plugins pick up omnifunc sources)
- **Without a completion plugin**: trigger with `Ctrl-X Ctrl-O` (standard Vim omni-completion)
- Completions only activate on metadata lines inside the `<!-- -->` comment block — no interference with title/body editing

### Files changed
- `lua/forge/completion.lua` — new (omnifunc + cache)
- `lua/forge/compose.lua` — +1 line (set omnifunc)
- `lua/forge/github.lua` — +`completion_cmd()`
- `lua/forge/gitlab.lua` — +`completion_cmd()`
- `lua/forge/codeberg.lua` — +`completion_cmd()`
- `lua/forge/config.lua` — +type annotation

#### Test plan
- [x] All 158 existing tests pass
- [x] StyLua formatting clean
- [ ] Manual: open compose buffer, cursor on Labels line, Ctrl-X Ctrl-O shows repo labels
- [ ] Manual: cursor on Assignees line shows collaborators
- [ ] Manual: cursor on Milestone line shows milestones
- [ ] Manual: completions are cached (second trigger is instant)
- [ ] Manual: works with blink.cmp auto-completion