### PR TITLE
feat: structured JSON summary for GitHub CI per-job picker

### DIFF
--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -151,6 +151,7 @@ local M = {}
 ---@field check_log_cmd fun(self: forge.Forge, run_id: string, failed_only: boolean, job_id: string?): string[]
 ---@field steps_cmd (fun(self: forge.Forge, run_id: string): string[])?
 ---@field view_cmd (fun(self: forge.Forge, id: string, opts?: { job_id?: string, log?: boolean, failed?: boolean }): string[])?
+---@field summary_json_cmd (fun(self: forge.Forge, id: string): string[])?
 ---@field watch_cmd (fun(self: forge.Forge, id: string): string[])?
 ---@field run_status_cmd (fun(self: forge.Forge, id: string): string[])?
 ---@field live_tail_cmd (fun(self: forge.Forge, run_id: string, job_id: string?): string[])?

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -199,6 +199,29 @@ end
 
 ---@param id string
 ---@return string[]
+function M:summary_json_cmd(id)
+  local jq = table.concat({
+    '{name,status,conclusion,event,url,',
+    'jobs:[.jobs[]|{databaseId,name,status,conclusion,url,',
+    'startedAt,completedAt,',
+    'steps:[.steps[]|{name,status,conclusion,number}]}]}',
+  }, '')
+  return {
+    'gh',
+    'run',
+    'view',
+    id,
+    '-R',
+    nwo(),
+    '--json',
+    'name,status,conclusion,event,url,jobs',
+    '--jq',
+    jq,
+  }
+end
+
+---@param id string
+---@return string[]
 function M:watch_cmd(id)
   return { 'gh', 'run', 'watch', id, '-R', nwo() }
 end

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -814,6 +814,7 @@ end
 ---@field title string?
 ---@field in_progress boolean?
 ---@field status_cmd string[]?
+---@field json boolean?
 ---@field log_cmd_fn fun(job_id: string, failed: boolean): string[], forge.LogOpts
 
 local function parse_summary(raw_lines)
@@ -835,6 +836,76 @@ local function parse_summary(raw_lines)
   end
 
   return { lines = lines, hls = hls, jobs = jobs, job_lnums = job_lnums }
+end
+
+local json_status_icon = {
+  success = '✓',
+  failure = 'X',
+  skipped = '-',
+  cancelled = '-',
+  in_progress = '~',
+  queued = '*',
+}
+
+local json_status_hl = {
+  success = 'ForgePass',
+  failure = 'ForgeFail',
+  skipped = 'ForgeLogDim',
+  cancelled = 'ForgeLogDim',
+  in_progress = 'ForgePending',
+  queued = 'ForgePending',
+}
+
+local function parse_summary_json(data)
+  local lines = {}
+  local hls_list = {}
+  local jobs = {}
+  local job_lnums = {}
+
+  local run_status = (data.conclusion and data.conclusion ~= '') and data.conclusion or data.status
+  local icon = json_status_icon[run_status] or '*'
+  local header = ('%s %s'):format(icon, data.name or 'run')
+  lines[#lines + 1] = header
+  local hl_grp = json_status_hl[run_status] or 'ForgePending'
+  hls_list[#hls_list + 1] = { { col = 0, end_col = #icon, group = hl_grp } }
+
+  lines[#lines + 1] = ''
+  hls_list[#hls_list + 1] = {}
+
+  for _, job in ipairs(data.jobs or {}) do
+    local jstatus = (job.conclusion and job.conclusion ~= '') and job.conclusion or job.status
+    local jicon = json_status_icon[jstatus] or '*'
+    local dur = format_duration(job.startedAt, job.completedAt)
+    local line = ('%s %s'):format(jicon, job.name or 'job')
+    if dur then
+      line = line .. ('  (%s)'):format(dur)
+    end
+    if jstatus == 'in_progress' and job.steps then
+      local done, total = 0, 0
+      for _, s in ipairs(job.steps) do
+        total = total + 1
+        local sc = (s.conclusion and s.conclusion ~= '') and s.conclusion or s.status
+        if sc == 'success' or sc == 'failure' or sc == 'skipped' then
+          done = done + 1
+        end
+      end
+      if total > 0 then
+        line = line .. ('  [%d/%d]'):format(done, total)
+      end
+    end
+    lines[#lines + 1] = line
+    local jhl_grp = json_status_hl[jstatus] or 'ForgePending'
+    hls_list[#hls_list + 1] = { { col = 0, end_col = #jicon, group = jhl_grp } }
+
+    local job_id = tostring(job.databaseId or '')
+    if job_id ~= '' then
+      local failed = jstatus == 'failure'
+      jobs[#lines] = { id = job_id, failed = failed }
+      job_lnums[#job_lnums + 1] = #lines
+    end
+  end
+
+  return { lines = lines, hls = hls_list, jobs = jobs, job_lnums = job_lnums }
 end
 
 ---@param cmd string[]
@@ -902,11 +973,20 @@ function M.open_summary(cmd, opts, reuse_buf)
         return
       end
 
-      local raw_lines = vim.split(stdout, '\n', { plain = true })
-      if raw_lines[#raw_lines] == '' then
-        raw_lines[#raw_lines] = nil
+      local parsed
+      if opts.json then
+        local ok, data = pcall(vim.json.decode, stdout)
+        if ok and data then
+          parsed = parse_summary_json(data)
+        end
       end
-      local parsed = parse_summary(raw_lines)
+      if not parsed then
+        local raw_lines = vim.split(stdout, '\n', { plain = true })
+        if raw_lines[#raw_lines] == '' then
+          raw_lines[#raw_lines] = nil
+        end
+        parsed = parse_summary(raw_lines)
+      end
 
       vim.bo[buf].modifiable = true
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, parsed.lines)
@@ -1011,5 +1091,7 @@ end
 M._strip_ansi = strip_ansi
 M._parse_github = parse_github
 M._parse_gitlab = parse_gitlab
+M._parse_summary = parse_summary
+M._parse_summary_json = parse_summary_json
 
 return M

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -391,7 +391,29 @@ function M.ci(f, branch)
               or s == 'running'
             local url = run.url ~= '' and run.url or nil
             local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id) or nil
-            if f.view_cmd then
+            if f.summary_json_cmd then
+              require('forge.log').open_summary(f:summary_json_cmd(run.id), {
+                forge_name = f.name,
+                run_id = run.id,
+                url = url,
+                title = run.name or run.id,
+                in_progress = in_progress,
+                status_cmd = status_cmd,
+                json = true,
+                log_cmd_fn = function(job_id, failed)
+                  return f:check_log_cmd(run.id, failed, job_id),
+                    {
+                      forge_name = f.name,
+                      url = url,
+                      title = (run.name or run.id) .. ' / ' .. (job_id or ''),
+                      steps_cmd = f.steps_cmd and f:steps_cmd(run.id) or nil,
+                      job_id = job_id,
+                      in_progress = in_progress,
+                      status_cmd = status_cmd,
+                    }
+                end,
+              })
+            elseif f.view_cmd then
               require('forge.log').open_summary(f:view_cmd(run.id), {
                 forge_name = f.name,
                 run_id = run.id,

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -4,6 +4,8 @@ local log_mod = require('forge.log')
 local strip_ansi = log_mod._strip_ansi
 local parse_github = log_mod._parse_github
 local parse_gitlab = log_mod._parse_gitlab
+local parse_summary = log_mod._parse_summary
+local parse_summary_json = log_mod._parse_summary_json
 
 describe('strip_ansi', function()
   it('strips SGR codes and extracts highlights', function()
@@ -322,5 +324,131 @@ describe('parse_gitlab', function()
     assert.equals('First', result.lines[1].text)
     assert.equals('Second', result.lines[3].text)
     assert.equals(2, #result.headers)
+  end)
+end)
+
+describe('parse_summary', function()
+  it('extracts job IDs from text output', function()
+    local result = parse_summary({
+      '\027[32m✓\027[0m lint (ID 12345)',
+      '\027[31mX\027[0m test (ID 67890)',
+      '\027[32m✓\027[0m deploy (ID 11111)',
+    })
+    assert.equals(3, #result.lines)
+    assert.equals(3, #result.job_lnums)
+    assert.same({ id = '12345', failed = false }, result.jobs[1])
+    assert.same({ id = '67890', failed = true }, result.jobs[2])
+    assert.same({ id = '11111', failed = false }, result.jobs[3])
+  end)
+
+  it('handles empty output', function()
+    local result = parse_summary({})
+    assert.equals(0, #result.lines)
+    assert.equals(0, #result.job_lnums)
+  end)
+end)
+
+describe('parse_summary_json', function()
+  it('renders completed run with multiple jobs', function()
+    local result = parse_summary_json({
+      name = 'CI',
+      status = 'completed',
+      conclusion = 'success',
+      jobs = {
+        {
+          databaseId = 100,
+          name = 'lint',
+          status = 'completed',
+          conclusion = 'success',
+          startedAt = '2024-01-01T00:00:00Z',
+          completedAt = '2024-01-01T00:01:30Z',
+          steps = {},
+        },
+        {
+          databaseId = 200,
+          name = 'test',
+          status = 'completed',
+          conclusion = 'failure',
+          startedAt = '2024-01-01T00:00:00Z',
+          completedAt = '2024-01-01T00:05:00Z',
+          steps = {},
+        },
+      },
+    })
+    assert.truthy(result.lines[1]:match('^✓ CI'))
+    assert.truthy(result.lines[3]:match('^✓ lint'))
+    assert.truthy(result.lines[3]:match('1m 30s'))
+    assert.truthy(result.lines[4]:match('^X test'))
+    assert.same({ id = '100', failed = false }, result.jobs[3])
+    assert.same({ id = '200', failed = true }, result.jobs[4])
+    assert.equals(2, #result.job_lnums)
+  end)
+
+  it('shows step progress for in-progress jobs', function()
+    local result = parse_summary_json({
+      name = 'Build',
+      status = 'in_progress',
+      conclusion = '',
+      jobs = {
+        {
+          databaseId = 300,
+          name = 'compile',
+          status = 'in_progress',
+          conclusion = '',
+          steps = {
+            { name = 'Checkout', status = 'completed', conclusion = 'success', number = 1 },
+            { name = 'Setup', status = 'completed', conclusion = 'success', number = 2 },
+            { name = 'Build', status = 'in_progress', conclusion = '', number = 3 },
+            { name = 'Test', status = 'queued', conclusion = '', number = 4 },
+          },
+        },
+      },
+    })
+    assert.truthy(result.lines[1]:match('^~ Build'))
+    assert.truthy(result.lines[3]:match('%[2/4%]'))
+  end)
+
+  it('renders header with run name and status icon', function()
+    local result = parse_summary_json({
+      name = 'Deploy',
+      status = 'completed',
+      conclusion = 'failure',
+      jobs = {},
+    })
+    assert.equals('X Deploy', result.lines[1])
+    assert.equals(1, #result.hls[1])
+    assert.equals('ForgeFail', result.hls[1][1].group)
+  end)
+
+  it('handles empty jobs list', function()
+    local result = parse_summary_json({
+      name = 'Empty',
+      status = 'completed',
+      conclusion = 'success',
+      jobs = {},
+    })
+    assert.equals(2, #result.lines)
+    assert.equals(0, #result.job_lnums)
+  end)
+
+  it('uses correct icons for queued and in_progress status', function()
+    local result = parse_summary_json({
+      name = 'Pipeline',
+      status = 'queued',
+      conclusion = '',
+      jobs = {
+        {
+          databaseId = 400,
+          name = 'waiting',
+          status = 'queued',
+          conclusion = '',
+          steps = {},
+        },
+      },
+    })
+    assert.truthy(result.lines[1]:match('^%* Pipeline'))
+    assert.truthy(result.lines[3]:match('^%* waiting'))
+    assert.equals('ForgePending', result.hls[1][1].group)
+    assert.equals('ForgePending', result.hls[3][1].group)
   end)
 end)


### PR DESCRIPTION
## Summary

- Add `summary_json_cmd` to GitHub backend — fetches run data as structured JSON with jq, including jobs with `databaseId`, status, duration, and step details
- Add `parse_summary_json` in `log.lua` — renders a compact summary with status icons (`✓`/`X`/`~`/`*`/`-`), durations, and step progress counters (`[2/4]`) for in-progress jobs
- CI picker now prefers JSON summary when `summary_json_cmd` is available, with graceful fallback to text parsing for other forges
- Add `json` flag to `forge.SummaryOpts` to toggle JSON vs text parsing in `open_summary`
- 7 new tests covering `parse_summary` (text ID extraction) and `parse_summary_json` (completed runs, in-progress step counting, header rendering, empty jobs, queued/in_progress icons)

Closes #18

#### Test plan

- [x] All 165 tests pass (158 existing + 7 new)
- [ ] Open CI picker on a GitHub repo, select a run — verify JSON summary renders with status icons and durations
- [ ] Select an in-progress run — verify step progress counters appear
- [ ] Press `<cr>` on a job line — verify it drills into per-job logs
- [ ] Open CI picker on a non-GitHub forge — verify text fallback still works