### PR TITLE
ci: use self-hosted runners

### DIFF
--- a/.github/workflows/luarocks-dev.yaml
+++ b/.github/workflows/luarocks-dev.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/luarocks.yaml
+++ b/.github/workflows/luarocks.yaml
@@ -11,7 +11,7 @@ jobs:
 
   publish:
     needs: quality
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     outputs:
       lua: ${{ steps.changes.outputs.lua }}
       markdown: ${{ steps.changes.outputs.markdown }}
@@ -38,7 +38,7 @@ jobs:
 
   lua-format:
     name: Lua Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -48,7 +48,7 @@ jobs:
 
   lua-lint:
     name: Lua Lint Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -58,7 +58,7 @@ jobs:
 
   lua-typecheck:
     name: Lua Type Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.lua == 'true' }}
     steps:
@@ -72,7 +72,7 @@ jobs:
 
   vimdoc-check:
     name: Vimdoc Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.vimdoc == 'true' }}
     steps:
@@ -82,7 +82,7 @@ jobs:
 
   nix-format:
     name: Nix Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.nix == 'true' }}
     steps:
@@ -92,7 +92,7 @@ jobs:
 
   markdown-format:
     name: Markdown Format Check
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, netcup, general]
     needs: changes
     if: ${{ needs.changes.outputs.markdown == 'true' }}
     steps:


### PR DESCRIPTION
## Summary
- Replace `runs-on: ubuntu-latest` with `runs-on: [self-hosted, linux, x64, netcup, general]` in all workflow files

#### Test plan
- [ ] All CI jobs run successfully on the self-hosted runner