### PR TITLE
fix: resolve treesitter overlay conflict and improve highlight links

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -47,8 +47,10 @@ function ComposeBuilder:apply(buf, comment_start)
   end
   for i = comment_start, #self.lines do
     vim.api.nvim_buf_set_extmark(buf, compose_ns, i - 1, 0, {
+      end_col = #self.lines[i],
+      hl_group = 'ForgeComposeComment',
       line_hl_group = 'ForgeComposeComment',
-      priority = 200,
+      priority = 150,
     })
   end
 end

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -270,7 +270,7 @@ local DEFAULTS = {
 local hl_defaults = {
   -- TODO: https://github.com/barrettruth/forge.nvim/issues/33
   -- ForgeComposeComment = 'Comment',
-  ForgeComposeComment = { italic = true },
+  ForgeComposeComment = 'Comment',
   ForgeComposeBranch = 'Special',
   ForgeComposeForge = 'Label',
   ForgeComposeDraft = 'DiagnosticWarn',
@@ -291,9 +291,9 @@ local hl_defaults = {
   ForgeDim = 'Comment',
   ForgeLogJob = 'Title',
   ForgeLogStep = 'Function',
-  ForgeLogError = 'DiagnosticVirtualTextError',
+  ForgeLogError = 'DiagnosticError',
   ForgeLogErrorLabel = { bold = true },
-  ForgeLogWarning = 'DiagnosticVirtualTextWarn',
+  ForgeLogWarning = 'DiagnosticWarn',
   ForgeLogWarningLabel = { bold = true },
   ForgeLogSection = 'Function',
   ForgeLogCommand = 'Special',


### PR DESCRIPTION
## Summary

- **Treesitter conflict fix**: Replace `line_hl_group`-only extmarks on compose comment block with inline `hl_group` + `line_hl_group` at priority 150. This overrides treesitter's `@comment` captures (priority 100) while yielding to metadata extmarks (priority 200).
- **Restore `ForgeComposeComment = 'Comment'`**: The `{ italic = true }` workaround is no longer needed now that the inline highlight properly overrides treesitter.
- **Improve log highlight links**: Switch `ForgeLogError` and `ForgeLogWarning` from `DiagnosticVirtualTextError`/`DiagnosticVirtualTextWarn` to `DiagnosticError`/`DiagnosticWarn` — the VirtualText variants carry a background tint that looks odd as line highlights.

Closes #58

#### Test plan

- [x] All 165 tests pass
- [ ] Open a PR/issue compose buffer — verify comment block uses `Comment` highlight, metadata labels override it
- [ ] Verify no treesitter artifacts in the `<!-- ... -->` block
- [ ] Open CI log viewer — verify error/warning lines use proper highlight without VirtualText bg tint