### PR TITLE
feat: keep picker context for auxiliary actions

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -90,13 +90,18 @@ function M.pick(opts)
   for _, def in ipairs(opts.actions) do
     local key = def.name == 'default' and '<cr>' or bindings[def.name]
     if key then
-      fzf_actions[to_fzf_key(key)] = function(selected)
+      local action_fn = function(selected)
         if not selected[1] then
           def.fn(nil)
           return
         end
         local idx = tonumber(selected[1]:match('^(%d+)'))
         def.fn(picker_mod.selected(idx and opts.entries[idx] or nil))
+      end
+      if picker_mod.closes(def) then
+        fzf_actions[to_fzf_key(key)] = action_fn
+      else
+        fzf_actions[to_fzf_key(key)] = { fn = action_fn, noclose = true }
       end
     end
   end

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -69,6 +69,10 @@ function M.selected(entry)
   return entry
 end
 
+function M.closes(def)
+  return rawget(def, 'close') ~= false
+end
+
 ---@param opts forge.PickerOpts
 function M.pick(opts)
   local name = detect()

--- a/lua/forge/picker/snacks.lua
+++ b/lua/forge/picker/snacks.lua
@@ -30,7 +30,9 @@ function M.pick(opts)
       local action_name = 'forge_' .. def.name
       snacks_actions[action_name] = function(picker)
         local item = picker:current()
-        picker:close()
+        if picker_mod.closes(def) then
+          picker:close()
+        end
         def.fn(picker_mod.selected(item and item.value or nil))
       end
       if key == '<cr>' then

--- a/lua/forge/picker/telescope.lua
+++ b/lua/forge/picker/telescope.lua
@@ -49,7 +49,9 @@ function M.pick(opts)
           if key then
             local function action_fn()
               local entry = action_state.get_selected_entry()
-              actions.close(prompt_bufnr)
+              if picker_mod.closes(def) then
+                actions.close(prompt_bufnr)
+              end
               def.fn(picker_mod.selected(entry and entry.value or nil))
             end
             if key == '<cr>' then

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -24,14 +24,20 @@ end
 ---@param cmd string[]
 ---@param success_msg string
 ---@param fail_msg string
-local function run_forge_cmd(kind, num, label, cmd, success_msg, fail_msg)
+local function run_forge_cmd(kind, num, label, cmd, success_msg, fail_msg, on_success, on_failure)
   log.info(label .. ' ' .. kind .. ' #' .. num .. '...')
   vim.system(cmd, { text = true }, function(result)
     vim.schedule(function()
       if result.code == 0 then
         log.info(('%s %s #%s'):format(success_msg, kind, num))
+        if on_success then
+          on_success()
+        end
       else
         log.error(cmd_error(result, fail_msg))
+        if on_failure then
+          on_failure()
+        end
       end
     end)
   end)
@@ -68,23 +74,59 @@ end
 ---@param f forge.Forge
 ---@param num string
 ---@param is_open boolean
-local function issue_toggle_state(f, num, is_open)
+local function issue_toggle_state(f, num, is_open, on_success)
   if is_open then
-    run_forge_cmd('issue', num, 'closing', f:close_issue_cmd(num), 'closed', 'close failed')
+    run_forge_cmd(
+      'issue',
+      num,
+      'closing',
+      f:close_issue_cmd(num),
+      'closed',
+      'close failed',
+      on_success,
+      on_success
+    )
   else
-    run_forge_cmd('issue', num, 'reopening', f:reopen_issue_cmd(num), 'reopened', 'reopen failed')
+    run_forge_cmd(
+      'issue',
+      num,
+      'reopening',
+      f:reopen_issue_cmd(num),
+      'reopened',
+      'reopen failed',
+      on_success,
+      on_success
+    )
   end
 end
 
 ---@param f forge.Forge
 ---@param num string
 ---@param is_open boolean
-local function pr_toggle_state(f, num, is_open)
+local function pr_toggle_state(f, num, is_open, on_success)
   local kind = f.labels.pr_one
   if is_open then
-    run_forge_cmd(kind, num, 'closing', f:close_cmd(num), 'closed', 'close failed')
+    run_forge_cmd(
+      kind,
+      num,
+      'closing',
+      f:close_cmd(num),
+      'closed',
+      'close failed',
+      on_success,
+      on_success
+    )
   else
-    run_forge_cmd(kind, num, 'reopening', f:reopen_cmd(num), 'reopened', 'reopen failed')
+    run_forge_cmd(
+      kind,
+      num,
+      'reopening',
+      f:reopen_cmd(num),
+      'reopened',
+      'reopen failed',
+      on_success,
+      on_success
+    )
   end
 end
 
@@ -178,7 +220,7 @@ end
 
 ---@param f forge.Forge
 ---@param num string
-local function pr_manage_picker(f, num)
+local function pr_manage_picker(f, num, parent_refresh)
   local forge_mod = require('forge')
   local kind = f.labels.pr_one
   log.info('loading more for ' .. kind .. ' #' .. num .. '...')
@@ -192,6 +234,9 @@ local function pr_manage_picker(f, num)
 
   local entries = {}
   local action_map = {}
+  local function reopen_self()
+    pr_manage_picker(f, num, parent_refresh)
+  end
 
   local function add(label, fn)
     table.insert(entries, {
@@ -207,7 +252,16 @@ local function pr_manage_picker(f, num)
 
   if can_write and is_open then
     add('Approve', function()
-      run_forge_cmd(kind, num, 'approving', f:approve_cmd(num), 'approved', 'approve failed')
+      run_forge_cmd(
+        kind,
+        num,
+        'approving',
+        f:approve_cmd(num),
+        'approved',
+        'approve failed',
+        reopen_self,
+        reopen_self
+      )
     end)
   end
 
@@ -220,7 +274,9 @@ local function pr_manage_picker(f, num)
           'merging (' .. method .. ')',
           f:merge_cmd(num, method),
           'merged (' .. method .. ')',
-          'merge failed'
+          'merge failed',
+          parent_refresh or reopen_self,
+          reopen_self
         )
       end)
     end
@@ -228,11 +284,29 @@ local function pr_manage_picker(f, num)
 
   if is_open then
     add('Close', function()
-      run_forge_cmd(kind, num, 'closing', f:close_cmd(num), 'closed', 'close failed')
+      run_forge_cmd(
+        kind,
+        num,
+        'closing',
+        f:close_cmd(num),
+        'closed',
+        'close failed',
+        parent_refresh or reopen_self,
+        reopen_self
+      )
     end)
   else
     add('Reopen', function()
-      run_forge_cmd(kind, num, 'reopening', f:reopen_cmd(num), 'reopened', 'reopen failed')
+      run_forge_cmd(
+        kind,
+        num,
+        'reopening',
+        f:reopen_cmd(num),
+        'reopened',
+        'reopen failed',
+        parent_refresh or reopen_self,
+        reopen_self
+      )
     end)
   end
 
@@ -241,7 +315,16 @@ local function pr_manage_picker(f, num)
     local draft_label = pr_state.is_draft and 'Mark as ready' or 'Mark as draft'
     local draft_done = pr_state.is_draft and 'marked as ready' or 'marked as draft'
     add(draft_label, function()
-      run_forge_cmd(kind, num, 'toggling draft', draft_cmd, draft_done, 'draft toggle failed')
+      run_forge_cmd(
+        kind,
+        num,
+        'toggling draft',
+        draft_cmd,
+        draft_done,
+        'draft toggle failed',
+        reopen_self,
+        reopen_self
+      )
     end)
   end
 
@@ -340,6 +423,7 @@ function M.checks(f, num, filter, cached_checks)
         {
           name = 'browse',
           label = 'web',
+          close = false,
           fn = function(entry)
             if entry and entry.value.link then
               vim.ui.open(entry.value.link)
@@ -551,6 +635,7 @@ function M.ci(f, branch, filter)
         {
           name = 'browse',
           label = 'web',
+          close = false,
           fn = function(entry)
             if entry and entry.value.url ~= '' then
               vim.ui.open(entry.value.url)
@@ -631,6 +716,10 @@ function M.pr(state, f)
     local state_field = pr_fields.state
     local state_map = {}
     local entries = {}
+    local function reopen_list()
+      forge_mod.clear_list(cache_key)
+      M.pr(state, f)
+    end
     for _, pr in ipairs(prs) do
       local num = tostring(pr[pr_fields.number] or '')
       local s = (pr[state_field] or ''):lower()
@@ -670,6 +759,7 @@ function M.pr(state, f)
         },
         {
           name = 'worktree',
+          close = false,
           fn = function(entry)
             if entry then
               pr_action_fns(f, entry.value).worktree()
@@ -688,6 +778,7 @@ function M.pr(state, f)
         {
           name = 'browse',
           label = 'web',
+          close = false,
           fn = function(entry)
             if entry then
               f:view_web(cli_kind, entry.value)
@@ -699,7 +790,7 @@ function M.pr(state, f)
           label = 'more',
           fn = function(entry)
             if entry then
-              pr_action_fns(f, entry.value).manage()
+              pr_manage_picker(f, entry.value, reopen_list)
             end
           end,
         },
@@ -721,7 +812,7 @@ function M.pr(state, f)
           name = 'close',
           fn = function(entry)
             if entry then
-              pr_toggle_state(f, entry.value, state_map[entry.value] ~= false)
+              pr_toggle_state(f, entry.value, state_map[entry.value] ~= false, reopen_list)
             end
           end,
         },
@@ -780,6 +871,10 @@ function M.issue(state, f)
     local state_field = issue_fields.state
     local state_map = {}
     local entries = {}
+    local function reopen_list()
+      forge_mod.clear_list(cache_key)
+      M.issue(state, f)
+    end
     for _, issue in ipairs(issues) do
       local n = tostring(issue[num_field] or '')
       local s = (issue[state_field] or ''):lower()
@@ -802,6 +897,7 @@ function M.issue(state, f)
         {
           name = 'default',
           label = 'open',
+          close = false,
           fn = function(entry)
             if entry then
               f:view_web(cli_kind, entry.value)
@@ -810,6 +906,7 @@ function M.issue(state, f)
         },
         {
           name = 'browse',
+          close = false,
           fn = function(entry)
             if entry then
               f:view_web(cli_kind, entry.value)
@@ -821,7 +918,7 @@ function M.issue(state, f)
           label = state == 'open' and 'close' or state == 'closed' and 'reopen' or 'toggle',
           fn = function(entry)
             if entry then
-              issue_toggle_state(f, entry.value, state_map[entry.value] ~= false)
+              issue_toggle_state(f, entry.value, state_map[entry.value] ~= false, reopen_list)
             end
           end,
         },
@@ -949,6 +1046,7 @@ function M.release(state, f)
         {
           name = 'browse',
           label = 'open',
+          close = false,
           fn = function(entry)
             if entry then
               f:browse_release(entry.value.tag)
@@ -958,6 +1056,7 @@ function M.release(state, f)
         {
           name = 'yank',
           label = 'copy',
+          close = false,
           fn = function(entry)
             if entry then
               local base = forge_mod.remote_web_url()
@@ -985,9 +1084,17 @@ function M.release(state, f)
                   'deleting',
                   f:delete_release_cmd(tag),
                   'deleted',
-                  'delete failed'
+                  'delete failed',
+                  function()
+                    forge_mod.clear_list(cache_key)
+                    M.release(state, f)
+                  end,
+                  function()
+                    M.release(state, f)
+                  end
                 )
-                forge_mod.clear_list(cache_key)
+              else
+                M.release(state, f)
               end
             end)
           end,

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -131,4 +131,34 @@ describe('fzf picker', function()
     captured.opts.actions.default({ '1\tNo open PRs' })
     assert.is_nil(selected)
   end)
+
+  it('keeps close=false actions open', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = { { '#42' } },
+          value = '42',
+        },
+      },
+      actions = {
+        {
+          name = 'browse',
+          label = 'browse',
+          close = false,
+          fn = function(entry)
+            selected = entry
+          end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.same('table', type(captured.opts.actions['ctrl-x']))
+    assert.is_true(captured.opts.actions['ctrl-x'].noclose)
+    captured.opts.actions['ctrl-x'].fn({ '1\t#42' })
+    assert.equals('42', selected.value)
+  end)
 end)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -44,6 +44,68 @@ local function fake_forge()
   }
 end
 
+local function fake_issue_forge()
+  return {
+    labels = { issue = 'Issues' },
+    kinds = { issue = 'issue' },
+    issue_fields = {
+      number = 'number',
+      title = 'title',
+      state = 'state',
+      author = 'author',
+      created_at = 'created_at',
+    },
+    view_web = function() end,
+    close_issue_cmd = function(_, num)
+      return { 'close', num }
+    end,
+    reopen_issue_cmd = function(_, num)
+      return { 'reopen', num }
+    end,
+  }
+end
+
+local function fake_ci_forge()
+  return {
+    labels = { ci = 'CI', pr_one = 'PR' },
+    check_log_cmd = function(_, run_id)
+      return { 'log', run_id }
+    end,
+    list_runs_json_cmd = function(_, branch)
+      return { 'runs', branch or '' }
+    end,
+    normalize_run = function(_, run)
+      return run
+    end,
+  }
+end
+
+local function fake_release_forge()
+  return {
+    release_fields = {
+      tag = 'tag',
+      title = 'title',
+      is_draft = 'is_draft',
+      is_prerelease = 'is_prerelease',
+    },
+    browse_release = function() end,
+    delete_release_cmd = function(_, tag)
+      return { 'delete', tag }
+    end,
+    list_releases_json_cmd = function()
+      return { 'releases' }
+    end,
+  }
+end
+
+local function action_by_name(name)
+  for _, def in ipairs(captured.actions) do
+    if def.name == name then
+      return def
+    end
+  end
+end
+
 describe('pickers', function()
   local old_preload
 
@@ -106,6 +168,37 @@ describe('pickers', function()
             { ' ' .. (pr.title or '') },
           }
         end,
+        format_issue = function(issue)
+          return {
+            { '#' .. tostring(issue.number) },
+            { ' ' .. (issue.title or '') },
+          }
+        end,
+        format_check = function(check)
+          return {
+            { check.name or '' },
+          }
+        end,
+        filter_checks = function(checks)
+          return checks
+        end,
+        format_run = function(run)
+          return {
+            { run.name or '' },
+          }
+        end,
+        filter_runs = function(runs)
+          return runs
+        end,
+        format_release = function(rel)
+          return {
+            { tostring(rel.tag or '') },
+            { ' ' .. (rel.title or '') },
+          }
+        end,
+        remote_web_url = function()
+          return 'https://example.com/repo'
+        end,
         repo_info = function(f)
           return f:repo_info()
         end,
@@ -156,6 +249,17 @@ describe('pickers', function()
     assert.is_nil(labels.refresh)
   end)
 
+  it('keeps auxiliary PR actions open', function()
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+
+    assert.is_not_nil(captured)
+    assert.is_false(rawget(action_by_name('browse'), 'close'))
+    assert.is_false(rawget(action_by_name('worktree'), 'close'))
+    assert.is_nil(rawget(action_by_name('checkout'), 'close'))
+    assert.is_nil(rawget(action_by_name('manage'), 'close'))
+  end)
+
   it('shows edit inside the more picker', function()
     local pickers = require('forge.pickers')
     pickers.pr_manage(fake_forge(), '42')
@@ -181,6 +285,20 @@ describe('pickers', function()
     assert.equals('PRs (open · 0)> ', captured.prompt)
     assert.equals('No open PRs', captured.entries[1].display[1][1])
     assert.is_true(captured.entries[1].placeholder)
+  end)
+
+  it('keeps issue web actions open', function()
+    cache['issue:all'] = {
+      { number = 7, title = 'Bug', state = 'OPEN', author = 'alice', created_at = '' },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.issue('all', fake_issue_forge())
+
+    assert.is_not_nil(captured)
+    assert.is_false(rawget(action_by_name('default'), 'close'))
+    assert.is_false(rawget(action_by_name('browse'), 'close'))
+    assert.is_nil(rawget(action_by_name('close'), 'close'))
   end)
 
   it('keeps the issue header affordance on the default open action only', function()
@@ -250,5 +368,62 @@ describe('pickers', function()
     assert.is_nil(labels.create)
     assert.is_nil(labels.filter)
     assert.is_nil(labels.refresh)
+  end)
+
+  it('keeps check and CI web actions open', function()
+    local pickers = require('forge.pickers')
+    pickers.checks(fake_ci_forge(), '42', 'all', {
+      { name = 'lint', link = 'https://example.com/check', bucket = 'pass' },
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_false(rawget(action_by_name('browse'), 'close'))
+    assert.is_nil(rawget(action_by_name('log'), 'close'))
+
+    local old_system = vim.system
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '1',
+            name = 'CI',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com',
+          },
+        }),
+      })
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    pickers.ci(fake_ci_forge(), 'main', 'all')
+    vim.wait(100, function()
+      return captured and captured.prompt == 'CI (main, all · 1)> '
+    end)
+    vim.system = old_system
+
+    assert.is_not_nil(captured)
+    assert.is_false(rawget(action_by_name('browse'), 'close'))
+    assert.is_nil(rawget(action_by_name('log'), 'close'))
+    assert.is_nil(rawget(action_by_name('watch'), 'close'))
+  end)
+
+  it('keeps release browse and copy actions open', function()
+    cache['release:all'] = {
+      { tag = 'v1.0.0', title = 'First', is_draft = false, is_prerelease = false },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.release('all', fake_release_forge())
+
+    assert.is_not_nil(captured)
+    assert.is_false(rawget(action_by_name('browse'), 'close'))
+    assert.is_false(rawget(action_by_name('yank'), 'close'))
+    assert.is_nil(rawget(action_by_name('delete'), 'close'))
   end)
 end)

--- a/spec/snacks_picker_spec.lua
+++ b/spec/snacks_picker_spec.lua
@@ -1,0 +1,123 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local captured
+local selected
+local close_calls
+
+describe('snacks picker', function()
+  local old_preload
+
+  before_each(function()
+    captured = nil
+    selected = nil
+    close_calls = 0
+    old_preload = {
+      ['snacks'] = package.preload['snacks'],
+      ['forge'] = package.preload['forge'],
+      ['forge.picker.snacks'] = package.loaded['forge.picker.snacks'],
+      ['forge.picker'] = package.loaded['forge.picker'],
+    }
+
+    package.preload['snacks'] = function()
+      return {
+        picker = function(opts)
+          captured = opts
+        end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = require('forge.config').config,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.snacks'] = nil
+    vim.g.forge = nil
+  end)
+
+  after_each(function()
+    package.preload['snacks'] = old_preload['snacks']
+    package.preload['forge'] = old_preload['forge']
+    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.picker'] = old_preload['forge.picker']
+    package.loaded['forge.picker.snacks'] = old_preload['forge.picker.snacks']
+  end)
+
+  it('keeps close=false actions open', function()
+    local picker = require('forge.picker.snacks')
+    local entry = {
+      display = { { '#42' } },
+      value = '42',
+    }
+
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = { entry },
+      actions = {
+        {
+          name = 'browse',
+          label = 'web',
+          close = false,
+          fn = function(item)
+            selected = item
+          end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    local picker_obj = {
+      current = function()
+        return captured.items[1]
+      end,
+      close = function()
+        close_calls = close_calls + 1
+      end,
+    }
+
+    captured.actions.forge_browse(picker_obj)
+    assert.equals(0, close_calls)
+    assert.equals('42', selected.value)
+  end)
+
+  it('closes actions by default', function()
+    local picker = require('forge.picker.snacks')
+    local entry = {
+      display = { { '#42' } },
+      value = '42',
+    }
+
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = { entry },
+      actions = {
+        {
+          name = 'checkout',
+          label = 'checkout',
+          fn = function(item)
+            selected = item
+          end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    local picker_obj = {
+      current = function()
+        return captured.items[1]
+      end,
+      close = function()
+        close_calls = close_calls + 1
+      end,
+    }
+
+    captured.actions.forge_checkout(picker_obj)
+    assert.equals(1, close_calls)
+    assert.equals('42', selected.value)
+  end)
+end)

--- a/spec/telescope_picker_spec.lua
+++ b/spec/telescope_picker_spec.lua
@@ -1,0 +1,195 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local captured
+local selected
+local close_calls
+
+describe('telescope picker', function()
+  local old_preload
+
+  before_each(function()
+    captured = {
+      maps = { i = {}, n = {} },
+      selected_entry = nil,
+      default_action = nil,
+    }
+    selected = nil
+    close_calls = 0
+    old_preload = {
+      ['telescope.pickers'] = package.preload['telescope.pickers'],
+      ['telescope.finders'] = package.preload['telescope.finders'],
+      ['telescope.config'] = package.preload['telescope.config'],
+      ['telescope.actions'] = package.preload['telescope.actions'],
+      ['telescope.actions.state'] = package.preload['telescope.actions.state'],
+      ['forge'] = package.preload['forge'],
+      ['forge.picker.telescope'] = package.loaded['forge.picker.telescope'],
+      ['forge.picker'] = package.loaded['forge.picker'],
+    }
+
+    package.preload['telescope.pickers'] = function()
+      return {
+        new = function(_, opts)
+          captured.opts = opts
+          return {
+            find = function()
+              opts.attach_mappings(17, function(mode, key, fn)
+                captured.maps[mode][key] = fn
+              end)
+            end,
+          }
+        end,
+      }
+    end
+
+    package.preload['telescope.finders'] = function()
+      return {
+        new_table = function(opts)
+          return opts
+        end,
+      }
+    end
+
+    package.preload['telescope.config'] = function()
+      return {
+        values = {
+          generic_sorter = function()
+            return function() end
+          end,
+        },
+      }
+    end
+
+    package.preload['telescope.actions'] = function()
+      return {
+        close = function()
+          close_calls = close_calls + 1
+        end,
+        select_default = {
+          replace = function(_, fn)
+            captured.default_action = fn
+          end,
+        },
+      }
+    end
+
+    package.preload['telescope.actions.state'] = function()
+      return {
+        get_selected_entry = function()
+          return captured.selected_entry
+        end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = require('forge.config').config,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.telescope'] = nil
+    vim.g.forge = nil
+  end)
+
+  after_each(function()
+    package.preload['telescope.pickers'] = old_preload['telescope.pickers']
+    package.preload['telescope.finders'] = old_preload['telescope.finders']
+    package.preload['telescope.config'] = old_preload['telescope.config']
+    package.preload['telescope.actions'] = old_preload['telescope.actions']
+    package.preload['telescope.actions.state'] = old_preload['telescope.actions.state']
+    package.preload['forge'] = old_preload['forge']
+    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.picker'] = old_preload['forge.picker']
+    package.loaded['forge.picker.telescope'] = old_preload['forge.picker.telescope']
+  end)
+
+  it('keeps default close=false actions open', function()
+    local picker = require('forge.picker.telescope')
+    local entry = {
+      display = { { '#42' } },
+      value = '42',
+    }
+    captured.selected_entry = { value = entry }
+
+    picker.pick({
+      prompt = 'Issues> ',
+      entries = { entry },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          close = false,
+          fn = function(item)
+            selected = item
+          end,
+        },
+      },
+      picker_name = 'issue',
+    })
+
+    assert.is_not_nil(captured.default_action)
+    captured.default_action()
+    assert.equals(0, close_calls)
+    assert.equals('42', selected.value)
+  end)
+
+  it('closes default actions by default', function()
+    local picker = require('forge.picker.telescope')
+    local entry = {
+      display = { { '#42' } },
+      value = '42',
+    }
+    captured.selected_entry = { value = entry }
+
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = { entry },
+      actions = {
+        {
+          name = 'default',
+          label = 'checkout',
+          fn = function(item)
+            selected = item
+          end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    captured.default_action()
+    assert.equals(1, close_calls)
+    assert.equals('42', selected.value)
+  end)
+
+  it('keeps mapped close=false actions open', function()
+    local picker = require('forge.picker.telescope')
+    local entry = {
+      display = { { '#42' } },
+      value = '42',
+    }
+    captured.selected_entry = { value = entry }
+
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = { entry },
+      actions = {
+        {
+          name = 'browse',
+          label = 'web',
+          close = false,
+          fn = function(item)
+            selected = item
+          end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    captured.maps.i['<c-x>']()
+    assert.equals(0, close_calls)
+    assert.equals('42', selected.value)
+  end)
+end)


### PR DESCRIPTION
## Summary
- keep non-consuming picker actions like web open, copy, and PR worktree open across all picker backends
- reopen or refresh the relevant picker after mutating actions so list workflows stay in context instead of dead-ending
- add backend and picker specs covering close-vs-stay behavior for fzf-lua, Telescope, and Snacks

#### Test plan
- [x] bash scripts/ci.sh
- [x] busted spec/fzf_picker_spec.lua spec/telescope_picker_spec.lua spec/snacks_picker_spec.lua spec/pickers_spec.lua