### PR TITLE
feat: expose forge extensibility hooks

### DIFF
--- a/lua/forge/action.lua
+++ b/lua/forge/action.lua
@@ -1,0 +1,63 @@
+local M = {}
+
+local actions = {}
+
+actions.open = {
+  label = 'open',
+  fn = function(entry, opts)
+    if not entry then
+      return
+    end
+
+    local context = opts.context
+    if type(context) == 'table' then
+      context = context.id
+    end
+
+    require('forge.routes').open(entry.value, { context = context })
+  end,
+}
+
+function M.register(name, action)
+  if type(action) == 'function' then
+    action = { fn = action }
+  end
+  actions[name] = action
+end
+
+function M.get(name)
+  return actions[name]
+end
+
+function M.run(name, entry, opts)
+  local action = actions[name]
+  if not action then
+    return false, 'unknown action: ' .. name
+  end
+  action.fn(entry, opts or {})
+  return true
+end
+
+function M.bind(name, opts)
+  local action = actions[name]
+  if not action then
+    return nil, 'unknown action: ' .. name
+  end
+
+  opts = opts or {}
+  local close = rawget(opts, 'close')
+  if close == nil then
+    close = rawget(action, 'close')
+  end
+
+  return {
+    name = opts.name or name,
+    label = opts.label or action.label or name,
+    close = close,
+    fn = function(entry)
+      M.run(name, entry, opts)
+    end,
+  }
+end
+
+return M

--- a/lua/forge/client.lua
+++ b/lua/forge/client.lua
@@ -6,17 +6,7 @@ clients.picker = function(opts)
   require('forge.picker').pick({
     prompt = opts.prompt,
     entries = opts.entries,
-    actions = {
-      {
-        name = 'default',
-        label = 'open',
-        fn = function(entry)
-          if opts.on_select then
-            opts.on_select(entry)
-          end
-        end,
-      },
-    },
+    actions = opts.actions,
     picker_name = '_menu',
   })
 end

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -1,7 +1,10 @@
 local M = {}
 
+local action_mod = require('forge.action')
+local client_mod = require('forge.client')
 local compose_mod = require('forge.compose')
 local config_mod = require('forge.config')
+local context_mod = require('forge.context')
 local format_mod = require('forge.format')
 local template_mod = require('forge.template')
 
@@ -13,6 +16,12 @@ local sources = {}
 function M.register(name, source)
   sources[name] = source
 end
+
+M.register_source = M.register
+M.register_client = client_mod.register
+M.register_context_provider = context_mod.register
+M.register_action = action_mod.register
+M.run_action = action_mod.run
 
 ---@return table<string, forge.Forge>
 function M.registered_sources()

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local action = require('forge.action')
 local client = require('forge.client')
 local context = require('forge.context')
 local log = require('forge.logger')
@@ -227,18 +228,23 @@ local function open_root(ctx)
     return
   end
 
-  local ok, err = client.open_root(client_name, {
+  local default_action, action_err = action.bind('open', {
+    name = 'default',
+    context = ctx.id,
+  })
+  if not default_action then
+    log.error(action_err)
+    return
+  end
+
+  local ok, client_err = client.open_root(client_name, {
     context = ctx,
     prompt = prompt(ctx),
     entries = entries,
-    on_select = function(entry)
-      if entry then
-        M.open(entry.value, { context = ctx.id })
-      end
-    end,
+    actions = { default_action },
   })
-  if not ok and err then
-    log.error(err)
+  if not ok and client_err then
+    log.error(client_err)
   end
 end
 

--- a/spec/action_spec.lua
+++ b/spec/action_spec.lua
@@ -1,0 +1,68 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local captured
+local old_preload
+
+describe('action', function()
+  before_each(function()
+    captured = nil
+
+    old_preload = {
+      ['forge.routes'] = package.preload['forge.routes'],
+    }
+
+    package.preload['forge.routes'] = function()
+      return {
+        open = function(name, opts)
+          captured = {
+            name = name,
+            opts = opts,
+          }
+        end,
+      }
+    end
+
+    package.loaded['forge.routes'] = nil
+    package.loaded['forge.action'] = nil
+  end)
+
+  after_each(function()
+    package.preload['forge.routes'] = old_preload['forge.routes']
+    package.loaded['forge.routes'] = nil
+    package.loaded['forge.action'] = nil
+  end)
+
+  it('binds the built-in open action to route dispatch', function()
+    local def = require('forge.action').bind('open', {
+      name = 'default',
+      context = 'workspace',
+    })
+
+    def.fn({ value = 'issues.open' })
+
+    assert.equals('issues.open', captured.name)
+    assert.equals('workspace', captured.opts.context)
+  end)
+
+  it('runs custom registered actions', function()
+    require('forge.action').register('ping', function(entry, opts)
+      captured = {
+        entry = entry,
+        opts = opts,
+      }
+    end)
+
+    local ok = require('forge.action').run('ping', { value = 'x' }, { count = 2 })
+
+    assert.is_true(ok)
+    assert.equals('x', captured.entry.value)
+    assert.equals(2, captured.opts.count)
+  end)
+
+  it('returns an error for unknown actions', function()
+    local ok, err = require('forge.action').run('missing', nil, {})
+
+    assert.is_false(ok)
+    assert.equals('unknown action: missing', err)
+  end)
+end)

--- a/spec/client_spec.lua
+++ b/spec/client_spec.lua
@@ -1,13 +1,11 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 local captured
-local selected
 local old_preload
 
 describe('client', function()
   before_each(function()
     captured = nil
-    selected = nil
 
     old_preload = {
       ['forge.picker'] = package.preload['forge.picker'],
@@ -36,18 +34,25 @@ describe('client', function()
     local ok = require('forge.client').open_root('picker', {
       prompt = 'Git> ',
       entries = { entry },
-      on_select = function(item)
-        selected = item
-      end,
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(item)
+            captured.selected = item
+          end,
+        },
+      },
     })
 
     assert.is_true(ok)
     assert.equals('Git> ', captured.prompt)
     assert.same({ entry }, captured.entries)
+    assert.equals('default', captured.actions[1].name)
 
     captured.actions[1].fn(entry)
 
-    assert.same(entry, selected)
+    assert.same(entry, captured.selected)
   end)
 
   it('returns an error for unknown clients', function()

--- a/spec/extensibility_spec.lua
+++ b/spec/extensibility_spec.lua
@@ -1,0 +1,86 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+package.preload['fzf-lua.utils'] = function()
+  return {
+    ansi_from_hl = function(_, text)
+      return text
+    end,
+  }
+end
+
+local forge = require('forge')
+
+describe('extensibility', function()
+  local client_name = 'custom-test-client'
+  local context_name = 'workspace-test-context'
+  local action_name = 'custom-test-action'
+  local captured
+
+  before_each(function()
+    captured = nil
+  end)
+
+  after_each(function()
+    vim.g.forge = nil
+  end)
+
+  it('exposes the public extensibility helpers', function()
+    assert.is_function(forge.register_client)
+    assert.is_function(forge.register_context_provider)
+    assert.is_function(forge.register_action)
+    assert.is_function(forge.run_action)
+  end)
+
+  it('uses a registered custom client for the root picker', function()
+    forge.register_context_provider(context_name, function()
+      return {
+        id = context_name,
+        branch = 'main',
+        head = 'abc123',
+        forge = {
+          name = 'github',
+          labels = {
+            pr_full = 'PRs',
+            issue = 'Issues',
+            ci = 'CI',
+          },
+        },
+      }
+    end)
+
+    forge.register_client(client_name, function(opts)
+      captured = opts
+    end)
+
+    vim.g.forge = {
+      client = client_name,
+      context = context_name,
+      contexts = {
+        current = true,
+        [context_name] = true,
+      },
+    }
+
+    forge.open()
+
+    assert.is_not_nil(captured)
+    assert.equals('Github> ', captured.prompt)
+    assert.equals('default', captured.actions[1].name)
+    assert.is_true(#captured.entries > 0)
+  end)
+
+  it('runs registered custom actions through the public API', function()
+    forge.register_action(action_name, function(entry, opts)
+      captured = {
+        entry = entry,
+        opts = opts,
+      }
+    end)
+
+    local ok = forge.run_action(action_name, { value = 'route' }, { context = 'current' })
+
+    assert.is_true(ok)
+    assert.equals('route', captured.entry.value)
+    assert.equals('current', captured.opts.context)
+  end)
+end)


### PR DESCRIPTION
## Summary
- expose public registration APIs for custom clients, context providers, and actions
- add a shared action registry and route the built-in root picker through it
- cover the new public extensibility surface with focused specs

#### Test plan
- [x] nix develop .#ci --command busted
- [x] ./scripts/ci.sh