### PR TITLE
fix: bind and document core git sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ without leaving your editor.
 - CI/CD: view runs per-branch or repo-wide, stream logs, filter by status
 - Code review via [diffs.nvim](https://github.com/barrettruth/diffs.nvim) with
   unified/split toggle and quickfix navigation
-- Commit and branch browsing with checkout, diff, and URL generation
+- Local git sections for branches, commits, and worktrees with checkout,
+  `git show`, switching, and forge web actions
 - File/line permalink generation and yanking
 - [fzf-lua](https://github.com/ibhagwan/fzf-lua) pickers with contextual
   keybinds
@@ -57,6 +58,9 @@ Configure via `vim.g.forge` before the plugin loads. All fields are optional:
 
 ```lua
 vim.g.forge = {
+  sections = { releases = false },
+  routes = { browse = 'browse.branch' },
+  keys = { commit = { browse = '<c-x>', yank = '<c-y>', refresh = '<c-r>' } },
   sources = { gitlab = { hosts = { 'gitlab.mycompany.com' } } },
   display = { icons = { open = '', merged = '', closed = '' } },
 }
@@ -76,6 +80,12 @@ vim.g.forge = {
 `<c-g>` to open the picker, select Pull Requests, then `ctrl-a` to compose. Or
 from a fugitive buffer: `cpr` (compose), `cpd` (draft), `cpf` (instant from
 commits), `cpw` (push and open web).
+
+**Q: What does `:Forge` show by default?**
+
+The root picker shows Pull Requests, Issues, CI, Branches, Commits, Worktrees,
+Browse, and Releases. Customize the list with `vim.g.forge.sections` and change
+where a section goes with `vim.g.forge.routes`.
 
 **Q: Does review mode require diffs.nvim?**
 

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -9,6 +9,9 @@ CONTENTS                                                 *forge.nvim-contents*
     `split`...............................................|forge-config-split|
     `ci`.....................................................|forge-config-ci|
     `sources`...........................................|forge-config-sources|
+    `contexts`.........................................|forge-config-contexts|
+    `sections`.........................................|forge-config-sections|
+    `routes`.............................................|forge-config-routes|
     `keys`.................................................|forge-config-keys|
     `display`...........................................|forge-config-display|
     `display.icons`...............................|forge-config-display-icons|
@@ -121,6 +124,46 @@ Top-level keys: ~
       }
 <
 
+`contexts`                                             *forge-config-contexts*
+  `table<string, boolean>`  (default `{ current = true }`)
+    Enable named context providers for the root picker. Disabled contexts are
+    hidden from route resolution.
+
+`sections`                                             *forge-config-sections*
+  `table<string, boolean>`  (default shown below)
+    Toggle root picker sections. Enabled sections appear in `:Forge`.
+
+  Defaults: >lua
+      sections = {
+        prs = true,
+        issues = true,
+        ci = true,
+        browse = true,
+        releases = true,
+        branches = true,
+        commits = true,
+        worktrees = true,
+      }
+<
+
+`routes`                                                 *forge-config-routes*
+  `table<string, string>`  (default shown below)
+    Map root picker sections to route aliases. Section names are also valid
+    arguments to `require('forge').open()`.
+
+  Defaults: >lua
+      routes = {
+        prs = 'prs.open',
+        issues = 'issues.open',
+        ci = 'ci.current_branch',
+        browse = 'browse.contextual',
+        releases = 'releases.all',
+        branches = 'branches.local',
+        commits = 'commits.current_branch',
+        worktrees = 'worktrees.list',
+      }
+<
+
 `keys`                                                     *forge-config-keys*
   `table|false`  (default shown below)
     Per-picker action bindings. Set to `false` to disable all picker-level
@@ -160,8 +203,27 @@ Top-level keys: ~
           filter = '<c-o>',
           refresh = '<c-r>',
         },
+        branch = {
+          browse = '<c-x>',
+          yank = '<c-y>',
+          refresh = '<c-r>',
+        },
+        commit = {
+          browse = '<c-x>',
+          yank = '<c-y>',
+          refresh = '<c-r>',
+        },
+        worktree = {
+          yank = '<c-y>',
+          refresh = '<c-r>',
+        },
       }
 <
+
+  Additional picker groups:
+    `keys.branch` supports `browse`, `yank`, and `refresh`.
+    `keys.commit` supports `browse`, `yank`, and `refresh`.
+    `keys.worktree` supports `yank` and `refresh`.
 
 `display`                                               *forge-config-display*
   Controls icons, column widths, and fetch limits used in picker
@@ -294,9 +356,9 @@ PICKERS                                                        *forge-pickers*
 
                                                                 *forge-picker*
 FORGE PICKER ~ The main entry point. Adapts based on the detected forge and
-current buffer. Lists: PRs/MRs, Issues, CI/CD, Releases, Open File. Items that
-require a forge are hidden when no forge is detected. "Open File" requires a
-named buffer on a branch.
+current buffer. Lists: PRs/MRs, Issues, CI/CD, Branches, Commits, Worktrees,
+Browse, Releases. Items that require a forge are hidden when no forge is
+detected. Browse file and line targets require a named buffer on a branch.
 
 When using fzf-lua, picker headers use fzf-lua's `FzfLuaHeaderBind` and
 `FzfLuaHeaderText` highlight groups.
@@ -346,6 +408,32 @@ In-progress views auto-refresh at the `ci.refresh` interval.
   `browse`      `<c-x>`          Open run/check URL in browser
   `filter`      `<c-o>`          Cycle filter: all -> failed -> passed -> running
   `refresh`     `<c-r>`          Re-fetch runs
+
+                                                         *forge-picker-branch*
+BRANCH PICKER ~ Lists local branches with upstream and tip commit summary.
+
+  Action      Default Key    Description ~
+  `checkout`    `<cr>`           Switch to the selected branch
+  `browse`      `<c-x>`          Open branch in browser
+  `yank`        `<c-y>`          Copy branch name to `+` register
+  `refresh`     `<c-r>`          Clear cache and re-fetch
+
+                                                         *forge-picker-commit*
+COMMIT PICKER ~ Lists commits for the selected branch.
+
+  Action      Default Key    Description ~
+  `show`        `<cr>`           Open `git show` in a terminal split
+  `browse`      `<c-x>`          Open commit in browser
+  `yank`        `<c-y>`          Copy commit SHA to `+` register
+  `refresh`     `<c-r>`          Clear cache and re-fetch
+
+                                                       *forge-picker-worktree*
+WORKTREE PICKER ~ Lists git worktrees for the current repository.
+
+  Action      Default Key    Description ~
+  `switch`      `<cr>`           Change Neovim's cwd to the selected worktree
+  `yank`        `<c-y>`          Copy worktree path to `+` register
+  `refresh`     `<c-r>`          Clear cache and re-fetch
 
                                                         *forge-picker-release*
 RELEASE PICKER ~ Lists releases with tag, title, and relative time. Draft and
@@ -525,6 +613,9 @@ support for features that vary:
   Issue create (assignees)     yes       yes       yes
   Issue create (milestone)     yes       yes       yes
   Issues                       yes       yes       yes
+  Branches                     yes       yes       yes
+  Commits                      yes       yes       yes
+  Worktrees                    yes       yes       yes
   Releases                     yes       yes       yes
   Release draft/prerelease     yes        -        yes
   Browse                       yes       yes       yes

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -250,6 +250,20 @@ local DEFAULTS = {
       filter = '<c-o>',
       refresh = '<c-r>',
     },
+    branch = {
+      browse = '<c-x>',
+      yank = '<c-y>',
+      refresh = '<c-r>',
+    },
+    commit = {
+      browse = '<c-x>',
+      yank = '<c-y>',
+      refresh = '<c-r>',
+    },
+    worktree = {
+      yank = '<c-y>',
+      refresh = '<c-r>',
+    },
     log = {
       close = 'q',
       next_step = ']]',
@@ -437,6 +451,27 @@ function M.config()
       vim.validate('forge.keys.release', keys.release, 'table')
       for _, k in ipairs({ 'browse', 'yank', 'delete', 'filter', 'refresh' }) do
         vim.validate('forge.keys.release.' .. k, keys.release[k], key_or_false, 'string or false')
+      end
+    end
+    local branch_keys = rawget(keys, 'branch')
+    if branch_keys ~= nil then
+      vim.validate('forge.keys.branch', branch_keys, 'table')
+      for _, k in ipairs({ 'browse', 'yank', 'refresh' }) do
+        vim.validate('forge.keys.branch.' .. k, branch_keys[k], key_or_false, 'string or false')
+      end
+    end
+    local commit_keys = rawget(keys, 'commit')
+    if commit_keys ~= nil then
+      vim.validate('forge.keys.commit', commit_keys, 'table')
+      for _, k in ipairs({ 'browse', 'yank', 'refresh' }) do
+        vim.validate('forge.keys.commit.' .. k, commit_keys[k], key_or_false, 'string or false')
+      end
+    end
+    local worktree_keys = rawget(keys, 'worktree')
+    if worktree_keys ~= nil then
+      vim.validate('forge.keys.worktree', worktree_keys, 'table')
+      for _, k in ipairs({ 'yank', 'refresh' }) do
+        vim.validate('forge.keys.worktree.' .. k, worktree_keys[k], key_or_false, 'string or false')
       end
     end
     if keys.log ~= nil then

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -41,6 +41,14 @@ describe('config', function()
     assert.is_nil(cfg.keys.ci.passed)
     assert.is_nil(cfg.keys.ci.running)
     assert.is_nil(cfg.keys.ci.all)
+    assert.equals('<c-x>', cfg.keys.branch.browse)
+    assert.equals('<c-y>', cfg.keys.branch.yank)
+    assert.equals('<c-r>', cfg.keys.branch.refresh)
+    assert.equals('<c-x>', cfg.keys.commit.browse)
+    assert.equals('<c-y>', cfg.keys.commit.yank)
+    assert.equals('<c-r>', cfg.keys.commit.refresh)
+    assert.equals('<c-y>', cfg.keys.worktree.yank)
+    assert.equals('<c-r>', cfg.keys.worktree.refresh)
   end)
 
   it('deep-merges partial user config', function()
@@ -50,6 +58,25 @@ describe('config', function()
     assert.equals('>', cfg.display.icons.open)
     assert.equals('m', cfg.display.icons.merged)
     assert.equals(45, cfg.display.widths.title)
+  end)
+
+  it('deep-merges git section key bindings', function()
+    vim.g.forge = {
+      keys = {
+        branch = { browse = '<c-b>' },
+        commit = { yank = false },
+        worktree = { refresh = '<c-f>' },
+      },
+    }
+    local cfg = forge.config()
+    assert.equals('<c-b>', cfg.keys.branch.browse)
+    assert.equals('<c-y>', cfg.keys.branch.yank)
+    assert.equals('<c-r>', cfg.keys.branch.refresh)
+    assert.equals('<c-x>', cfg.keys.commit.browse)
+    assert.is_false(cfg.keys.commit.yank)
+    assert.equals('<c-r>', cfg.keys.commit.refresh)
+    assert.equals('<c-y>', cfg.keys.worktree.yank)
+    assert.equals('<c-f>', cfg.keys.worktree.refresh)
   end)
 
   it('sets keys to false when user requests it', function()


### PR DESCRIPTION
## Summary
- add default key bindings for the new branch, commit, and worktree pickers so their browse, yank, and refresh actions are reachable out of the box
- validate the new `keys.branch`, `keys.commit`, and `keys.worktree` config groups
- update the README and vimdoc to document the new root picker sections and the related `sections`, `routes`, and git-section key configuration

#### Test plan
- [x] `bash ./scripts/ci.sh`