### PR TITLE
fix: preserve CI buffers during refresh

### DIFF
--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -684,7 +684,9 @@ function M.open(cmd, opts, reuse_buf)
   local buf
   local saved_cursor
   local old_line_count
+  local reusing = false
   if reuse_buf and vim.api.nvim_buf_is_valid(reuse_buf) then
+    reusing = true
     buf = reuse_buf
     old_line_count = vim.api.nvim_buf_line_count(buf)
     local wins = vim.fn.win_findbuf(buf)
@@ -717,9 +719,11 @@ function M.open(cmd, opts, reuse_buf)
       end,
     })
   end
-  vim.bo[buf].modifiable = true
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'Loading...' })
-  vim.bo[buf].modifiable = false
+  if not reusing then
+    vim.bo[buf].modifiable = true
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'Loading...' })
+    vim.bo[buf].modifiable = false
+  end
 
   local log_result, steps
   local pending = opts.steps_cmd and 2 or 1
@@ -915,7 +919,9 @@ function M.open_summary(cmd, opts, reuse_buf)
   local buf
   local saved_cursor
   local old_line_count
+  local reusing = false
   if reuse_buf and vim.api.nvim_buf_is_valid(reuse_buf) then
+    reusing = true
     buf = reuse_buf
     old_line_count = vim.api.nvim_buf_line_count(buf)
     local wins = vim.fn.win_findbuf(buf)
@@ -951,9 +957,11 @@ function M.open_summary(cmd, opts, reuse_buf)
     })
   end
 
-  vim.bo[buf].modifiable = true
-  vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'Loading...' })
-  vim.bo[buf].modifiable = false
+  if not reusing then
+    vim.bo[buf].modifiable = true
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'Loading...' })
+    vim.bo[buf].modifiable = false
+  end
 
   local proc = vim.system(cmd, { text = true }, function(result)
     vim.schedule(function()
@@ -1008,7 +1016,7 @@ function M.open_summary(cmd, opts, reuse_buf)
         jobs = parsed.jobs,
       }
 
-      if not reuse_buf then
+      if not reusing then
         local cfg = require('forge').config()
         if cfg.keys ~= false then
           local keys = cfg.keys.log or {}

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -452,3 +452,59 @@ describe('parse_summary_json', function()
     assert.equals('ForgePending', result.hls[3][1].group)
   end)
 end)
+
+describe('buffer reuse refreshes', function()
+  local original_system
+
+  before_each(function()
+    original_system = vim.system
+  end)
+
+  after_each(function()
+    vim.system = original_system
+  end)
+
+  local function stub_pending_system()
+    local calls = {}
+    vim.system = function(cmd, opts, cb)
+      calls[#calls + 1] = {
+        cmd = cmd,
+        opts = opts,
+        cb = cb,
+      }
+      return {
+        kill = function() end,
+      }
+    end
+    return calls
+  end
+
+  it('keeps existing log lines visible while a reused log buffer refreshes', function()
+    local calls = stub_pending_system()
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'old log line' })
+
+    log_mod.open({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      title = 'ci',
+    }, buf)
+
+    assert.equals(1, #calls)
+    assert.same({ 'old log line' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+  end)
+
+  it('keeps existing summary lines visible while a reused summary buffer refreshes', function()
+    local calls = stub_pending_system()
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'old summary line' })
+
+    log_mod.open_summary({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      run_id = '123',
+      title = 'summary',
+    }, buf)
+
+    assert.equals(1, #calls)
+    assert.same({ 'old summary line' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+  end)
+end)


### PR DESCRIPTION
## Summary
- keep existing CI summary and log content visible while a reused buffer refresh is pending
- avoid flashing CI views back to `Loading...` during manual and auto refreshes
- add regression coverage for reused log and summary buffers

Closes #74

#### Test plan
- [x] `busted spec/log_spec.lua`
- [x] `./scripts/ci.sh`