### PR TITLE
feat: add <Plug> launchers for forge routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ luarocks install forge.nvim
 :help forge.nvim
 ```
 
+## `<Plug>` mappings
+
+forge.nvim exposes stateless `<Plug>` launchers for the root picker, exact
+routes, section aliases, and review actions. Section alias plugs respect
+`vim.g.forge.routes`; exact route plugs always open the named route.
+`<Plug>(forge-browse)` and `<Plug>(forge-browse-contextual)` are available in
+normal and visual mode, so visual selections include the selected line range for
+contextual browse targets.
+
+```lua
+vim.keymap.set('n', '<leader>gf', '<Plug>(forge)')
+vim.keymap.set('n', '<leader>gP', '<Plug>(forge-prs-open)')
+vim.keymap.set({ 'n', 'x' }, '<leader>gb', '<Plug>(forge-browse-contextual)')
+vim.keymap.set('n', '<leader>gr', '<Plug>(forge-review-toggle)')
+```
+
+See `:help forge-plug` for the full list.
+
 ## FAQ
 
 **Q: How do I configure forge.nvim?**

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -40,6 +40,7 @@ CONTENTS                                                 *forge.nvim-contents*
     `:Forge review end`....................................|:Forge-review-end|
     `:Forge review toggle`..............................|:Forge-review-toggle|
     `:Forge clear`..............................................|:Forge-clear|
+    PLUG MAPPINGS.............................................|forge-plug|
     PICKERS....................................................|forge-pickers|
     REVIEW......................................................|forge-review|
     COMPOSE BUFFER.............................................|forge-compose|
@@ -350,6 +351,84 @@ COMMANDS                                                              *:Forge*
     Clear all internal caches (forge detection, repo info, list data).
 
 All subcommands support tab completion.
+
+==============================================================================
+PLUG MAPPINGS                                                    *forge-plug*
+
+forge.nvim exposes stateless |<Plug>| mappings for root launchers, exact
+routes, configurable section aliases, and review actions. They are intended
+for user-defined mappings and do not add any additional Ex commands.
+
+Examples: >lua
+    vim.keymap.set('n', '<leader>gf', '<Plug>(forge)')
+    vim.keymap.set('n', '<leader>gP', '<Plug>(forge-prs-open)')
+    vim.keymap.set({'n', 'x'}, '<leader>gb', '<Plug>(forge-browse-contextual)')
+    vim.keymap.set('n', '<leader>gr', '<Plug>(forge-review-toggle)')
+<
+
+Alias plugs call `require('forge').open()` with the section name (`"prs"`,
+`"issues"`, etc.), so they respect `vim.g.forge.routes`. Exact route plugs
+call `require('forge').open()` with the full route name and ignore route
+aliases.
+
+`<Plug>(forge-browse)` and `<Plug>(forge-browse-contextual)` are available in
+normal and visual mode. When invoked in visual mode, contextual browse targets
+include the selected line range just like |:Forge-browse|.
+
+Alias plugs: ~
+                                                          *forge-plug-alias*
+  Mapping                          Modes      Action ~
+  `<Plug>(forge)`                    `n`        Open the root picker
+  `<Plug>(forge-prs)`                `n`        Open the configured `prs`
+                                              section route
+  `<Plug>(forge-issues)`             `n`        Open the configured `issues`
+                                              section route
+  `<Plug>(forge-ci)`                 `n`        Open the configured `ci`
+                                              section route
+  `<Plug>(forge-browse)`             `n`, `x`   Open the configured `browse`
+                                              section route
+  `<Plug>(forge-releases)`           `n`        Open the configured `releases`
+                                              section route
+  `<Plug>(forge-branches)`           `n`        Open the configured `branches`
+                                              section route
+  `<Plug>(forge-commits)`            `n`        Open the configured `commits`
+                                              section route
+  `<Plug>(forge-worktrees)`          `n`        Open the configured `worktrees`
+                                              section route
+
+Exact route plugs: ~
+                                                          *forge-plug-routes*
+  Mapping                                    Modes      Action ~
+  `<Plug>(forge-prs-open)`                     `n`        Open open PRs
+  `<Plug>(forge-prs-closed)`                   `n`        Open closed PRs
+  `<Plug>(forge-prs-all)`                      `n`        Open all PRs
+  `<Plug>(forge-issues-open)`                  `n`        Open open issues
+  `<Plug>(forge-issues-closed)`                `n`        Open closed issues
+  `<Plug>(forge-issues-all)`                   `n`        Open all issues
+  `<Plug>(forge-ci-current-branch)`            `n`        Open CI for the
+                                                        current branch
+  `<Plug>(forge-ci-all)`                       `n`        Open CI for all
+                                                        branches
+  `<Plug>(forge-browse-contextual)`            `n`, `x`   Open the current
+                                                        file, line, or selected
+                                                        range on the forge
+  `<Plug>(forge-browse-branch)`                `n`        Open the current
+                                                        branch on the forge
+  `<Plug>(forge-browse-commit)`                `n`        Open the current
+                                                        commit on the forge
+  `<Plug>(forge-releases-all)`                 `n`        Open all releases
+  `<Plug>(forge-releases-draft)`               `n`        Open draft releases
+  `<Plug>(forge-releases-prerelease)`          `n`        Open prereleases
+  `<Plug>(forge-branches-local)`               `n`        Open local branches
+  `<Plug>(forge-commits-current-branch)`       `n`        Open commits for the
+                                                        current branch
+  `<Plug>(forge-worktrees-list)`               `n`        Open worktrees
+
+Review plugs: ~
+                                                          *forge-plug-review*
+  Mapping                                  Modes      Action ~
+  `<Plug>(forge-review-toggle)`             `n`        Toggle review mode
+  `<Plug>(forge-review-end)`                `n`        End review mode
 
 ==============================================================================
 PICKERS                                                        *forge-pickers*

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -397,6 +397,56 @@ local function complete(arglead, cmdline, _)
   return {}
 end
 
+local function set_plug(mode, lhs, rhs)
+  vim.keymap.set(mode, ('<Plug>(%s)'):format(lhs), rhs)
+end
+
+local function open_route(route)
+  return function()
+    require('forge').open(route)
+  end
+end
+
+set_plug('n', 'forge', open_route(nil))
+
+for _, spec in ipairs({
+  { 'n', 'forge-prs-open', 'prs.open' },
+  { 'n', 'forge-prs-closed', 'prs.closed' },
+  { 'n', 'forge-prs-all', 'prs.all' },
+  { 'n', 'forge-issues-open', 'issues.open' },
+  { 'n', 'forge-issues-closed', 'issues.closed' },
+  { 'n', 'forge-issues-all', 'issues.all' },
+  { 'n', 'forge-ci-current-branch', 'ci.current_branch' },
+  { 'n', 'forge-ci-all', 'ci.all' },
+  { { 'n', 'x' }, 'forge-browse-contextual', 'browse.contextual' },
+  { 'n', 'forge-browse-branch', 'browse.branch' },
+  { 'n', 'forge-browse-commit', 'browse.commit' },
+  { 'n', 'forge-releases-all', 'releases.all' },
+  { 'n', 'forge-releases-draft', 'releases.draft' },
+  { 'n', 'forge-releases-prerelease', 'releases.prerelease' },
+  { 'n', 'forge-branches-local', 'branches.local' },
+  { 'n', 'forge-commits-current-branch', 'commits.current_branch' },
+  { 'n', 'forge-worktrees-list', 'worktrees.list' },
+  { 'n', 'forge-prs', 'prs' },
+  { 'n', 'forge-issues', 'issues' },
+  { 'n', 'forge-ci', 'ci' },
+  { { 'n', 'x' }, 'forge-browse', 'browse' },
+  { 'n', 'forge-releases', 'releases' },
+  { 'n', 'forge-branches', 'branches' },
+  { 'n', 'forge-commits', 'commits' },
+  { 'n', 'forge-worktrees', 'worktrees' },
+}) do
+  set_plug(spec[1], spec[2], open_route(spec[3]))
+end
+
+set_plug('n', 'forge-review-toggle', function()
+  require('forge.review').toggle()
+end)
+
+set_plug('n', 'forge-review-end', function()
+  require('forge.review').stop()
+end)
+
 vim.api.nvim_create_user_command('Forge', function(opts)
   local args = vim.split(vim.trim(opts.args), '%s+')
   if #args == 0 or args[1] == '' then

--- a/spec/plug_mappings_spec.lua
+++ b/spec/plug_mappings_spec.lua
@@ -1,0 +1,169 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+if not vim.api.nvim_get_commands({ builtin = false }).Forge then
+  dofile(vim.fn.getcwd() .. '/plugin/forge.lua')
+end
+
+local function mapping(lhs, mode)
+  return vim.fn.maparg(lhs, mode, false, true)
+end
+
+describe('<Plug> mappings', function()
+  local captured
+  local old_preload
+
+  local function stub_forge()
+    package.preload['forge'] = function()
+      return {
+        open = function(name)
+          captured.calls[#captured.calls + 1] = {
+            name = name == nil and vim.NIL or name,
+            mode = vim.fn.mode(),
+            line_v = vim.fn.line('v'),
+            line = vim.fn.line('.'),
+          }
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+  end
+
+  local function stub_review()
+    package.preload['forge.review'] = function()
+      return {
+        toggle = function()
+          captured.review[#captured.review + 1] = 'toggle'
+        end,
+        stop = function()
+          captured.review[#captured.review + 1] = 'end'
+        end,
+      }
+    end
+    package.loaded['forge.review'] = nil
+  end
+
+  before_each(function()
+    captured = {
+      calls = {},
+      review = {},
+    }
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.review'] = package.preload['forge.review'],
+    }
+    package.loaded['forge'] = nil
+    package.loaded['forge.review'] = nil
+  end)
+
+  after_each(function()
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.review'] = old_preload['forge.review']
+    package.loaded['forge'] = nil
+    package.loaded['forge.review'] = nil
+    vim.cmd('enew!')
+  end)
+
+  it('defines the root and exact route plugs in normal mode', function()
+    stub_forge()
+
+    local expected = {
+      { '<Plug>(forge)', vim.NIL },
+      { '<Plug>(forge-prs-open)', 'prs.open' },
+      { '<Plug>(forge-prs-closed)', 'prs.closed' },
+      { '<Plug>(forge-prs-all)', 'prs.all' },
+      { '<Plug>(forge-issues-open)', 'issues.open' },
+      { '<Plug>(forge-issues-closed)', 'issues.closed' },
+      { '<Plug>(forge-issues-all)', 'issues.all' },
+      { '<Plug>(forge-ci-current-branch)', 'ci.current_branch' },
+      { '<Plug>(forge-ci-all)', 'ci.all' },
+      { '<Plug>(forge-browse-contextual)', 'browse.contextual' },
+      { '<Plug>(forge-browse-branch)', 'browse.branch' },
+      { '<Plug>(forge-browse-commit)', 'browse.commit' },
+      { '<Plug>(forge-releases-all)', 'releases.all' },
+      { '<Plug>(forge-releases-draft)', 'releases.draft' },
+      { '<Plug>(forge-releases-prerelease)', 'releases.prerelease' },
+      { '<Plug>(forge-branches-local)', 'branches.local' },
+      { '<Plug>(forge-commits-current-branch)', 'commits.current_branch' },
+      { '<Plug>(forge-worktrees-list)', 'worktrees.list' },
+    }
+
+    for _, item in ipairs(expected) do
+      local map = mapping(item[1], 'n')
+      assert.equals(item[1], map.lhs)
+      assert.is_function(map.callback)
+      map.callback()
+    end
+
+    for i, item in ipairs(expected) do
+      assert.same(item[2], captured.calls[i].name)
+    end
+  end)
+
+  it('defines section alias plugs in normal mode', function()
+    stub_forge()
+
+    local expected = {
+      { '<Plug>(forge-prs)', 'prs' },
+      { '<Plug>(forge-issues)', 'issues' },
+      { '<Plug>(forge-ci)', 'ci' },
+      { '<Plug>(forge-browse)', 'browse' },
+      { '<Plug>(forge-releases)', 'releases' },
+      { '<Plug>(forge-branches)', 'branches' },
+      { '<Plug>(forge-commits)', 'commits' },
+      { '<Plug>(forge-worktrees)', 'worktrees' },
+    }
+
+    for _, item in ipairs(expected) do
+      local map = mapping(item[1], 'n')
+      assert.equals(item[1], map.lhs)
+      assert.is_function(map.callback)
+      map.callback()
+    end
+
+    for i, item in ipairs(expected) do
+      assert.same(item[2], captured.calls[i].name)
+    end
+  end)
+
+  it('defines review plugs in normal mode', function()
+    stub_review()
+
+    local toggle = mapping('<Plug>(forge-review-toggle)', 'n')
+    local stop = mapping('<Plug>(forge-review-end)', 'n')
+
+    assert.is_function(toggle.callback)
+    assert.is_function(stop.callback)
+
+    toggle.callback()
+    stop.callback()
+
+    assert.same({ 'toggle', 'end' }, captured.review)
+  end)
+
+  it('runs contextual browse plugs while visual mode is active', function()
+    stub_forge()
+
+    vim.cmd('new')
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three' })
+    vim.cmd('normal! ggVj')
+
+    local contextual = mapping('<Plug>(forge-browse-contextual)', 'x')
+    local alias = mapping('<Plug>(forge-browse)', 'x')
+
+    assert.is_function(contextual.callback)
+    assert.is_function(alias.callback)
+
+    contextual.callback()
+    alias.callback()
+
+    assert.same('browse.contextual', captured.calls[1].name)
+    assert.equals('V', captured.calls[1].mode)
+    assert.equals(1, captured.calls[1].line_v)
+    assert.equals(2, captured.calls[1].line)
+
+    assert.same('browse', captured.calls[2].name)
+    assert.equals('V', captured.calls[2].mode)
+    assert.equals(1, captured.calls[2].line_v)
+    assert.equals(2, captured.calls[2].line)
+  end)
+end)


### PR DESCRIPTION
## Summary
- expose `<Plug>` launchers for the root picker, exact routes, section aliases, and review actions
- support normal and visual browse plugs so contextual browse preserves selected ranges
- document the new mapping surface in the README and vimdoc and add regression coverage

Closes #64

#### Test plan
- [x] `busted spec/plug_mappings_spec.lua spec/routes_spec.lua spec/init_spec.lua`
- [x] `./scripts/ci.sh`