### PR TITLE
fix(pr): rename diff actions to review

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ without leaving your editor.
 
 - Automatic forge detection from git remote (`gh`, `glab`, `tea`)
 - PR lifecycle: list, create (compose buffer with template discovery, diff stat,
-  reviewers), checkout, worktree, review diff, merge, approve, close/reopen,
-  draft toggle
+  reviewers), checkout, worktree, review, merge, approve, close/reopen, draft
+  toggle
 - Issue management: list, browse, close/reopen, state filtering
 - CI/CD: view runs per-branch or repo-wide, stream logs, filter by status
 - Code review via [diffs.nvim](https://github.com/barrettruth/diffs.nvim) with

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -22,7 +22,7 @@ CONTENTS                                                 *forge.nvim-contents*
     `:Forge pr` [{flags}]..........................................|:Forge-pr|
     `:Forge pr create` [{flags}]............................|:Forge-pr-create|
     `:Forge pr checkout` {num}............................|:Forge-pr-checkout|
-    `:Forge pr diff` {num}....................................|:Forge-pr-diff|
+    `:Forge pr review` {num}................................|:Forge-pr-review|
     `:Forge pr worktree` {num}............................|:Forge-pr-worktree|
     `:Forge pr ci` {num}........................................|:Forge-pr-ci|
     `:Forge pr browse` {num}................................|:Forge-pr-browse|
@@ -175,7 +175,7 @@ Top-level keys: ~
   Defaults: >lua
       keys = {
         pr = {
-          diff = '<c-d>',
+          review = '<c-d>',
           worktree = '<c-w>',
           ci = '<c-t>',
           browse = '<c-x>',
@@ -220,6 +220,9 @@ Top-level keys: ~
         },
       }
 <
+
+  `keys.pr.review` is the canonical PR review binding. `keys.pr.diff` is
+  still accepted as a legacy alias.
 
   Additional picker groups:
     `keys.branch` supports `browse`, `yank`, and `refresh`.
@@ -284,8 +287,11 @@ COMMANDS                                                              *:Forge*
 `:Forge pr checkout` {num}                                *:Forge-pr-checkout*
     Check out the branch for PR `{num}`.
 
-`:Forge pr diff` {num}                                        *:Forge-pr-diff*
+`:Forge pr review` {num}                                    *:Forge-pr-review*
     Start a review for PR `{num}` (|forge-review|).
+
+`:Forge pr diff` {num}                                        *:Forge-pr-diff*
+    Legacy alias for `:Forge pr review {num}`.
 
 `:Forge pr worktree` {num}                                *:Forge-pr-worktree*
     Fetch PR `{num}` and create a git worktree.
@@ -451,7 +457,7 @@ PR PICKER ~ Lists PRs/MRs with number, title, author, and relative time.
 
   Action      Default Key    Description ~
   `more`        `<cr>`           Open more picker
-  `diff`        `<c-d>`          Start review (|forge-review|)
+  `review`      `<c-d>`          Start review (|forge-review|)
   `worktree`    `<c-w>`          Create worktree from PR
   `ci`          `<c-t>`          Open CI checks picker for this PR
   `browse`      `<c-x>`          Open PR in browser
@@ -538,7 +544,7 @@ Requires diffs.nvim for unified view and vim-fugitive for split view.
 
 Starting a review: ~
 - `<c-d>` on a PR in the PR picker
-- `:Forge pr diff {num}`
+- `:Forge pr review {num}`
 
 Unified view (default): ~
   diffs.nvim renders a combined diff in a `diffs://review:*` buffer with
@@ -1004,8 +1010,9 @@ PUBLIC API: `require('forge.pickers')` ~
                                                *forge.pickers.pr_action_fns()*
 `pr_action_fns(f, num)`
     Returns `table<string, function>`. Action functions for PR `num`,
-    keyed by action name (`"checkout"`, `"diff"`, `"worktree"`,
-    `"browse"`, `"ci"`, `"manage"`, `"edit"`).
+    keyed by action name (`"checkout"`, `"review"`, `"worktree"`,
+    `"browse"`, `"ci"`, `"manage"`, `"edit"`). `"diff"` remains
+    available as a legacy alias.
 
                                                  *forge.pickers.issue_close()*
 `issue_close(f, num)`

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -221,6 +221,7 @@ local DEFAULTS = {
   },
   keys = {
     pr = {
+      review = '<c-d>',
       diff = '<c-d>',
       worktree = '<c-w>',
       ci = '<c-t>',
@@ -411,6 +412,7 @@ function M.config()
       vim.validate('forge.keys.pr', keys.pr, 'table')
       for _, k in ipairs({
         'checkout',
+        'review',
         'diff',
         'worktree',
         'ci',
@@ -507,6 +509,22 @@ function M.config()
 
   for name, route in pairs(cfg.routes) do
     vim.validate('forge.routes.' .. name, route, 'string')
+  end
+
+  if type(cfg.keys) == 'table' then
+    local pr_keys = rawget(cfg.keys, 'pr')
+    local user_keys = type(user.keys) == 'table' and user.keys or nil
+    local user_pr_keys = type(user_keys) == 'table' and rawget(user_keys, 'pr') or nil
+    if type(pr_keys) == 'table' then
+      if type(user_pr_keys) == 'table' and user_pr_keys.review ~= nil then
+        pr_keys.review = user_pr_keys.review
+      elseif type(user_pr_keys) == 'table' and user_pr_keys.diff ~= nil then
+        pr_keys.review = user_pr_keys.diff
+      elseif pr_keys.review == nil then
+        pr_keys.review = pr_keys.diff
+      end
+      pr_keys.diff = pr_keys.review
+    end
   end
 
   return cfg

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -294,6 +294,35 @@ end
 ---@return table<string, function>
 local function pr_action_fns(f, num)
   local kind = f.labels.pr_one
+  local function review_pr()
+    local review = require('forge.review')
+    local repo_root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
+
+    log.info(('reviewing %s #%s...'):format(kind, num))
+    vim.system(f:checkout_cmd(num), { text = true }, function(co_result)
+      if co_result.code ~= 0 then
+        vim.schedule(function()
+          log.debug('checkout skipped, proceeding with review')
+        end)
+      end
+
+      vim.system(f:pr_base_cmd(num), { text = true }, function(base_result)
+        vim.schedule(function()
+          local base = vim.trim(base_result.stdout or '')
+          if base == '' or base_result.code ~= 0 then
+            base = 'main'
+          end
+          local range = 'origin/' .. base
+          review.start(range)
+          local ok, commands = pcall(require, 'diffs.commands')
+          if ok then
+            commands.greview(range, { repo_root = repo_root })
+          end
+          log.debug(('review ready for %s #%s against %s'):format(kind, num, base))
+        end)
+      end)
+    end)
+  end
   return {
     checkout = function()
       log.info(('checking out %s #%s...'):format(kind, num))
@@ -331,35 +360,8 @@ local function pr_action_fns(f, num)
         end)
       end)
     end,
-    diff = function()
-      local review = require('forge.review')
-      local repo_root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
-
-      log.info(('reviewing %s #%s...'):format(kind, num))
-      vim.system(f:checkout_cmd(num), { text = true }, function(co_result)
-        if co_result.code ~= 0 then
-          vim.schedule(function()
-            log.debug('checkout skipped, proceeding with diff')
-          end)
-        end
-
-        vim.system(f:pr_base_cmd(num), { text = true }, function(base_result)
-          vim.schedule(function()
-            local base = vim.trim(base_result.stdout or '')
-            if base == '' or base_result.code ~= 0 then
-              base = 'main'
-            end
-            local range = 'origin/' .. base
-            review.start(range)
-            local ok, commands = pcall(require, 'diffs.commands')
-            if ok then
-              commands.greview(range, { repo_root = repo_root })
-            end
-            log.debug(('review ready for %s #%s against %s'):format(kind, num, base))
-          end)
-        end)
-      end)
-    end,
+    review = review_pr,
+    diff = review_pr,
     ci = function()
       if f.capabilities.per_pr_checks then
         M.checks(f, num)
@@ -917,11 +919,11 @@ function M.pr(state, f)
           end,
         },
         {
-          name = 'diff',
-          label = 'diff',
+          name = 'review',
+          label = 'review',
           fn = function(entry)
             if entry then
-              pr_action_fns(f, entry.value).diff()
+              pr_action_fns(f, entry.value).review()
             end
           end,
         },

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -112,8 +112,8 @@ local function dispatch(args)
     end
     if action == 'checkout' then
       pickers.pr_actions(f, num).checkout()
-    elseif action == 'diff' then
-      pickers.pr_actions(f, num).diff()
+    elseif action == 'review' or action == 'diff' then
+      pickers.pr_actions(f, num).review()
     elseif action == 'worktree' then
       pickers.pr_actions(f, num).worktree()
     elseif action == 'ci' then
@@ -322,7 +322,7 @@ local function complete(arglead, cmdline, _)
   local sub_actions = {
     pr = {
       'checkout',
-      'diff',
+      'review',
       'worktree',
       'ci',
       'browse',

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -1,0 +1,103 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe(':Forge command', function()
+  local captured
+  local old_preload
+
+  before_each(function()
+    captured = {
+      pr_action_num = nil,
+      reviews = {},
+      warnings = {},
+    }
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.pickers'] = package.preload['forge.pickers'],
+    }
+
+    package.preload['forge.logger'] = function()
+      return {
+        warn = function(msg)
+          table.insert(captured.warnings, msg)
+        end,
+        info = function() end,
+        debug = function() end,
+        error = function() end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        detect = function()
+          return {
+            capabilities = {
+              per_pr_checks = true,
+            },
+            labels = {
+              pr_one = 'PR',
+            },
+            kinds = {
+              pr = 'pr',
+            },
+          }
+        end,
+        open = function() end,
+      }
+    end
+
+    package.preload['forge.pickers'] = function()
+      return {
+        pr_actions = function(_, num)
+          captured.pr_action_num = num
+          return {
+            review = function()
+              table.insert(captured.reviews, num)
+            end,
+          }
+        end,
+        checks = function() end,
+        ci = function() end,
+        pr_manage = function() end,
+        pr_close = function() end,
+        pr_reopen = function() end,
+      }
+    end
+
+    if vim.api.nvim_get_commands({ builtin = false }).Forge then
+      vim.api.nvim_del_user_command('Forge')
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.pickers'] = nil
+
+    dofile(vim.fn.getcwd() .. '/plugin/forge.lua')
+  end)
+
+  after_each(function()
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.pickers'] = old_preload['forge.pickers']
+    package.loaded['forge'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.pickers'] = nil
+    if vim.api.nvim_get_commands({ builtin = false }).Forge then
+      vim.api.nvim_del_user_command('Forge')
+    end
+  end)
+
+  it('dispatches :Forge pr review to the PR review action', function()
+    vim.cmd('Forge pr review 42')
+
+    assert.equals('42', captured.pr_action_num)
+    assert.same({ '42' }, captured.reviews)
+  end)
+
+  it('keeps :Forge pr diff as an alias for the PR review action', function()
+    vim.cmd('Forge pr diff 7')
+
+    assert.equals('7', captured.pr_action_num)
+    assert.same({ '7' }, captured.reviews)
+  end)
+end)

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -508,6 +508,20 @@ describe('config validation', function()
     assert.is_false(cfg.keys.pr.checkout)
   end)
 
+  it('accepts review key binding and keeps the diff alias available', function()
+    vim.g.forge = { keys = { pr = { review = '<leader>r' } } }
+    local cfg = forge.config()
+    assert.equals('<leader>r', cfg.keys.pr.review)
+    assert.equals('<leader>r', cfg.keys.pr.diff)
+  end)
+
+  it('maps the legacy diff key binding onto review', function()
+    vim.g.forge = { keys = { pr = { diff = '<leader>d' } } }
+    local cfg = forge.config()
+    assert.equals('<leader>d', cfg.keys.pr.review)
+    assert.equals('<leader>d', cfg.keys.pr.diff)
+  end)
+
   it('rejects keys as a string', function()
     vim.g.forge = { keys = 'none' }
     assert.has_error(function()


### PR DESCRIPTION
## Problem

PR review is the primary workflow, but the picker, command, and config still exposed it as `diff`. That made the user-facing terminology inconsistent with the actual review session flow.

## Solution

Make `review` the canonical PR action and `:Forge pr review` command, update the docs and regression coverage, and keep `diff` plus `keys.pr.diff` as backward-compatible aliases.