### PR TITLE
feat(review): introduce a first-class session model

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -562,6 +562,22 @@ State: ~
     { base = 'origin/main', mode = 'unified' }
 <
   `base` is `nil` when no review is active.
+  `require('forge.review').current()` returns the active session: >lua
+    {
+      subject = {
+        kind = 'pr',
+        id = '42',
+        label = 'PR #42',
+        base_ref = 'origin/main',
+        head_ref = 'pr-42',
+      },
+      mode = 'unified',
+      files = {},
+      current_file = nil,
+      materialization = 'checkout',
+      repo_root = '/path/to/repo',
+    }
+<
 
 ==============================================================================
 COMPOSE BUFFER                                                 *forge-compose*
@@ -1028,6 +1044,10 @@ PUBLIC API: `require('forge.review')` ~
     Starts a review session. `base` is the diff range (e.g.
     `"origin/main"`, `"abc123^..abc123"`). `mode`: `"unified"` (default)
     or `"split"`.
+
+                                                      *forge.review.current()*
+`current()`
+    Returns the active review session, or `nil` if no review is active.
 
                                                          *forge.review.stop()*
 `stop()`

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -313,7 +313,21 @@ local function pr_action_fns(f, num)
             base = 'main'
           end
           local range = 'origin/' .. base
-          review.start(range)
+          local head = vim.trim(vim.fn.system('git branch --show-current'))
+          review.start_session({
+            subject = {
+              kind = 'pr',
+              id = num,
+              label = ('%s #%s'):format(kind, num),
+              base_ref = range,
+              head_ref = head,
+            },
+            mode = 'unified',
+            files = {},
+            current_file = nil,
+            materialization = co_result.code == 0 and 'checkout' or 'current',
+            repo_root = repo_root,
+          })
           local ok, commands = pcall(require, 'diffs.commands')
           if ok then
             commands.greview(range, { repo_root = repo_root })

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -4,6 +4,26 @@ local M = {}
 M.state = { base = nil, mode = 'unified' }
 
 local review_augroup = vim.api.nvim_create_augroup('ForgeReview', { clear = true })
+local active_session = nil
+local current_file = nil
+
+local function repo_root()
+  return vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
+end
+
+local function base_ref()
+  if active_session and active_session.subject then
+    return active_session.subject.base_ref
+  end
+  return M.state.base
+end
+
+local function open_unified(base, root)
+  local ok, commands = pcall(require, 'diffs.commands')
+  if ok then
+    commands.greview(base, { repo_root = root })
+  end
+end
 
 local function close_view()
   for _, win in ipairs(vim.api.nvim_list_wins()) do
@@ -17,13 +37,21 @@ local function close_view()
 end
 
 function M.stop()
+  active_session = nil
+  current_file = nil
   M.state.base = nil
   M.state.mode = 'unified'
   vim.api.nvim_clear_autocmds({ group = review_augroup })
 end
 
+function M.current()
+  return active_session
+end
+
 function M.toggle()
-  if not M.state.base then
+  local session = active_session
+  local base = base_ref()
+  if not base then
     return
   end
   if M.state.mode == 'unified' then
@@ -32,30 +60,55 @@ function M.toggle()
       return
     end
     local file = commands.review_file_at_line(vim.api.nvim_get_current_buf(), vim.fn.line('.'))
+    if session then
+      session.current_file = file
+      current_file = file
+      session.mode = 'split'
+    end
     M.state.mode = 'split'
     if file then
-      vim.cmd('edit ' .. vim.fn.fnameescape(file))
-      pcall(vim.cmd, 'Gvdiffsplit ' .. M.state.base)
+      local root = session and session.repo_root or repo_root()
+      local path = root ~= '' and (root .. '/' .. file) or file
+      vim.cmd('edit ' .. vim.fn.fnameescape(path))
+      pcall(vim.cmd, 'Gvdiffsplit ' .. base)
     end
   else
-    local current_file = vim.fn.expand('%:.')
-    close_view()
-    M.state.mode = 'unified'
-    local ok, commands = pcall(require, 'diffs.commands')
-    if ok then
-      commands.greview(M.state.base)
+    local file = vim.fn.expand('%:.')
+    if session and file ~= '' then
+      session.current_file = file
     end
-    if current_file ~= '' then
-      vim.fn.search('diff %-%-git a/' .. vim.pesc(current_file), 'cw')
+    if file ~= '' then
+      current_file = file
+    end
+    close_view()
+    if session then
+      session.mode = 'unified'
+    end
+    M.state.mode = 'unified'
+    open_unified(base, session and session.repo_root or repo_root())
+    local target = session and session.current_file or current_file
+    if target and target ~= '' then
+      vim.fn.search('diff %-%-git a/' .. vim.pesc(target), 'cw')
     end
   end
 end
 
----@param base string
----@param mode string?
-function M.start(base, mode)
-  M.state.base = base
-  M.state.mode = mode or 'unified'
+function M.start_session(session)
+  M.stop()
+  session = vim.deepcopy(session)
+  session.files = session.files or {}
+  session.mode = session.mode or 'unified'
+  session.current_file = session.current_file or nil
+  session.materialization = session.materialization or 'current'
+  session.repo_root = session.repo_root or repo_root()
+  active_session = session
+  current_file = session.current_file
+  if session.subject and session.subject.base_ref then
+    M.state.base = session.subject.base_ref
+  else
+    M.state.base = nil
+  end
+  M.state.mode = session.mode
   vim.api.nvim_clear_autocmds({ group = review_augroup })
   vim.api.nvim_create_autocmd('BufWipeout', {
     group = review_augroup,
@@ -64,11 +117,32 @@ function M.start(base, mode)
   })
 end
 
+---@param base string
+---@param mode string?
+function M.start(base, mode)
+  M.start_session({
+    subject = {
+      kind = 'ref',
+      id = base,
+      label = base,
+      base_ref = base,
+      head_ref = vim.trim(vim.fn.system('git rev-parse --show-current')),
+    },
+    mode = mode or 'unified',
+    files = {},
+    current_file = nil,
+    materialization = 'current',
+    repo_root = repo_root(),
+  })
+end
+
 ---@param nav_cmd string
 ---@return function
 function M.nav(nav_cmd)
   return function()
-    if M.state.base and M.state.mode == 'split' then
+    local session = active_session
+    local base = base_ref()
+    if base and M.state.mode == 'split' then
       close_view()
     end
     local wrap = {
@@ -82,8 +156,15 @@ function M.nav(nav_cmd)
         return
       end
     end
-    if M.state.base and M.state.mode == 'split' then
-      pcall(vim.cmd, 'Gvdiffsplit ' .. M.state.base)
+    if base and M.state.mode == 'split' then
+      pcall(vim.cmd, 'Gvdiffsplit ' .. base)
+      if session and session.repo_root then
+        local file = vim.fn.expand('%:.')
+        if file ~= '' then
+          session.current_file = file
+          current_file = file
+        end
+      end
     end
   end
 end

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -1,0 +1,74 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('review session', function()
+  local review
+
+  before_each(function()
+    package.loaded['forge.review'] = nil
+    review = require('forge.review')
+    review.stop()
+  end)
+
+  after_each(function()
+    review.stop()
+    package.loaded['forge.review'] = nil
+  end)
+
+  it('stores a first-class session in review state', function()
+    review.start_session({
+      subject = {
+        kind = 'pr',
+        id = '42',
+        label = 'PR #42',
+        base_ref = 'origin/main',
+        head_ref = 'pr-42',
+      },
+      mode = 'unified',
+      files = {
+        { path = 'lua/forge/review.lua' },
+      },
+      current_file = 'lua/forge/review.lua',
+      materialization = 'checkout',
+      repo_root = '/repo',
+    })
+
+    assert.equals('origin/main', review.state.base)
+    assert.equals('unified', review.state.mode)
+    assert.equals('pr', review.current().subject.kind)
+    assert.equals('42', review.current().subject.id)
+    assert.equals('PR #42', review.current().subject.label)
+    assert.equals('origin/main', review.current().subject.base_ref)
+    assert.equals('pr-42', review.current().subject.head_ref)
+    assert.equals('lua/forge/review.lua', review.current().current_file)
+    assert.equals('checkout', review.current().materialization)
+    assert.equals('/repo', review.current().repo_root)
+  end)
+
+  it('keeps the legacy start helper available', function()
+    review.start('origin/main')
+
+    assert.equals('origin/main', review.state.base)
+    assert.equals('unified', review.state.mode)
+    assert.equals('ref', review.current().subject.kind)
+    assert.equals('origin/main', review.current().subject.base_ref)
+  end)
+
+  it('clears session state on stop', function()
+    review.start_session({
+      subject = {
+        kind = 'pr',
+        id = '42',
+        label = 'PR #42',
+        base_ref = 'origin/main',
+        head_ref = 'pr-42',
+      },
+      repo_root = '/repo',
+    })
+
+    review.stop()
+
+    assert.is_nil(review.state.base)
+    assert.equals('unified', review.state.mode)
+    assert.is_nil(review.current())
+  end)
+end)


### PR DESCRIPTION
## Problem

PR review still behaved like a thin diff action because forge only tracked a base ref and a display mode. That left no stable session model for subject metadata, later file indexing, or view transitions.

## Solution

Introduce structured review session state in `lua/forge/review.lua`, populate it when PR review starts, and document and test the new session foundation so later review workflow work can build on it cleanly.