### PR TITLE
fix(picker): search over hidden picker keys

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -58,11 +58,14 @@ local function render(segments)
 end
 
 local function render_line(index, entry)
+  local picker_mod = require('forge.picker')
   local text = render(entry.display)
   if vim.trim(text) == '' then
     return nil
   end
-  return ('%d\t%s'):format(index, text)
+  local ordinal = picker_mod.ordinal(entry)
+  ordinal = ordinal:gsub('[\r\n\t]', ' ')
+  return ('%d\t%s\t%s'):format(index, ordinal, text)
 end
 
 ---@param actions forge.PickerActionDef[]
@@ -180,7 +183,8 @@ function M.pick(opts)
       ['--ansi'] = '',
       ['--header'] = render_header(opts.actions, bindings),
       ['--no-multi'] = '',
-      ['--with-nth'] = '2..',
+      ['--with-nth'] = '3..',
+      ['--nth'] = '2',
       ['--delimiter'] = '\t',
     },
     actions = fzf_actions,

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -57,15 +57,15 @@ local function render(segments)
   return table.concat(parts)
 end
 
-local function render_line(index, entry)
+local function render_line(index, picker_name, entry)
   local picker_mod = require('forge.picker')
   local text = render(entry.display)
   if vim.trim(text) == '' then
     return nil
   end
-  local ordinal = picker_mod.ordinal(entry)
-  ordinal = ordinal:gsub('[\r\n\t]', ' ')
-  return ('%d\t%s\t%s'):format(index, ordinal, text)
+  local search_key = picker_mod.search_key(picker_name, entry)
+  search_key = search_key:gsub('[\r\n\t]', ' ')
+  return ('%d\t%s\t%s'):format(index, search_key, text)
 end
 
 ---@param actions forge.PickerActionDef[]
@@ -113,7 +113,7 @@ function M.pick(opts)
       local next_index = 0
       for i, entry in ipairs(entries) do
         next_index = i
-        local line = render_line(i, entry)
+        local line = render_line(i, opts.picker_name, entry)
         if line then
           fzf_cb(line)
         end
@@ -125,7 +125,7 @@ function M.pick(opts)
         end
         next_index = next_index + 1
         entries[next_index] = entry
-        local line = render_line(next_index, entry)
+        local line = render_line(next_index, opts.picker_name, entry)
         if line then
           fzf_cb(line)
         end
@@ -134,7 +134,7 @@ function M.pick(opts)
   else
     lines = {}
     for i, entry in ipairs(entries) do
-      local line = render_line(i, entry)
+      local line = render_line(i, opts.picker_name, entry)
       if line then
         lines[#lines + 1] = line
       end

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -26,6 +26,125 @@ M.backends = {
 
 M.detect_order = { 'fzf-lua' }
 
+local root_search_terms = {
+  ['prs.all'] = { 'prs', 'pull', 'requests', 'reviews' },
+  ['prs.open'] = { 'prs', 'pull', 'requests', 'reviews' },
+  ['prs.closed'] = { 'prs', 'pull', 'requests', 'reviews' },
+  ['issues.all'] = { 'issues', 'bugs', 'tickets' },
+  ['issues.open'] = { 'issues', 'bugs', 'tickets' },
+  ['issues.closed'] = { 'issues', 'bugs', 'tickets' },
+  ['ci.all'] = { 'ci', 'checks', 'runs', 'actions' },
+  ['ci.current_branch'] = { 'ci', 'checks', 'runs', 'actions' },
+  ['branches.local'] = { 'branches', 'refs' },
+  ['commits.current_branch'] = { 'commits', 'history', 'log' },
+  ['worktrees.list'] = { 'worktrees', 'trees' },
+  ['browse.contextual'] = { 'browse', 'web' },
+  ['browse.branch'] = { 'browse', 'web' },
+  ['browse.commit'] = { 'browse', 'web' },
+  ['releases.all'] = { 'releases', 'tags' },
+  ['releases.draft'] = { 'releases', 'tags' },
+  ['releases.prerelease'] = { 'releases', 'tags' },
+}
+
+local function flatten_display(entry)
+  local parts = {}
+  for _, seg in ipairs(entry.display or {}) do
+    parts[#parts + 1] = seg[1]
+  end
+  return table.concat(parts)
+end
+
+local function join_search_terms(parts)
+  local items = {}
+  for _, part in ipairs(parts) do
+    if type(part) == 'string' then
+      local text = vim.trim(part)
+      if text ~= '' then
+        items[#items + 1] = text
+      end
+    end
+  end
+  return table.concat(items, ' ')
+end
+
+local function menu_search_key(entry)
+  local value = entry.value
+  if type(value) == 'table' then
+    if value.path then
+      return join_search_terms({ value.path, value.old_path or '' })
+    end
+    if value.name and value.display and value.dir then
+      local slug = value.name:gsub('%.ya?ml$', ''):gsub('%.md$', '')
+      return join_search_terms({ value.display, slug })
+    end
+  elseif type(value) == 'string' then
+    local root_terms = root_search_terms[value]
+    if root_terms then
+      local display = flatten_display(entry)
+      return join_search_terms(vim.list_extend({ display }, vim.deepcopy(root_terms)))
+    end
+    return value
+  end
+  return M.ordinal(entry)
+end
+
+M.search_keys = {
+  _menu = menu_search_key,
+  pr = function(entry)
+    return M.ordinal(entry)
+  end,
+  issue = function(entry)
+    return M.ordinal(entry)
+  end,
+  ci = function(entry)
+    local value = entry.value
+    if type(value) == 'table' then
+      return join_search_terms({ value.name or '', value.branch or '' })
+    end
+    return M.ordinal(entry)
+  end,
+  branch = function(entry)
+    local value = entry.value
+    if type(value) == 'table' and value.name then
+      return value.name
+    end
+    return M.ordinal(entry)
+  end,
+  commit = function(entry)
+    local value = entry.value
+    if type(value) == 'table' then
+      return join_search_terms({
+        value.sha or '',
+        value.short_sha or '',
+        value.subject or '',
+        value.author or '',
+      })
+    end
+    return M.ordinal(entry)
+  end,
+  worktree = function(entry)
+    local value = entry.value
+    if type(value) == 'table' and value.path then
+      local key = value.branch ~= '' and value.branch or vim.fs.basename(value.path)
+      if value.detached and value.short_head ~= '' then
+        key = join_search_terms({ key, value.short_head })
+      end
+      return key
+    end
+    return M.ordinal(entry)
+  end,
+  release = function(entry)
+    local value = entry.value
+    if type(value) == 'table' then
+      return join_search_terms({
+        value.tag or '',
+        type(value.rel) == 'table' and value.rel.title or '',
+      })
+    end
+    return M.ordinal(entry)
+  end,
+}
+
 ---@return string
 local function detect()
   local cfg = require('forge').config()
@@ -47,11 +166,18 @@ function M.ordinal(entry)
   if entry.ordinal then
     return entry.ordinal
   end
-  local parts = {}
-  for _, seg in ipairs(entry.display) do
-    table.insert(parts, seg[1])
+  return flatten_display(entry)
+end
+
+---@param picker_name string
+---@param entry forge.PickerEntry
+---@return string
+function M.search_key(picker_name, entry)
+  local builder = M.search_keys[picker_name]
+  if builder then
+    return builder(entry)
   end
-  return table.concat(parts)
+  return M.ordinal(entry)
 end
 
 ---@return string

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1850,12 +1850,7 @@ function M.branches(ctx)
       entries[#entries + 1] = {
         display = branch_display(item, plan),
         value = item,
-        ordinal = table.concat({
-          item.name,
-          item.upstream,
-          item.subject,
-          item.worktree_path or '',
-        }, ' '),
+        ordinal = item.name,
       }
     end
     local count = #entries
@@ -2131,10 +2126,14 @@ function M.worktrees(ctx)
     local plan = worktree_layout(worktrees)
     local entries = {}
     for _, item in ipairs(worktrees) do
+      local ordinal = item.branch ~= '' and item.branch or vim.fs.basename(item.path)
+      if item.detached and item.short_head ~= '' then
+        ordinal = ordinal .. ' ' .. item.short_head
+      end
       entries[#entries + 1] = {
         display = worktree_display(item, plan),
         value = item,
-        ordinal = item.path .. ' ' .. worktree_label(item) .. ' ' .. item.short_head,
+        ordinal = ordinal,
       }
     end
     local count = #entries

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1850,7 +1850,6 @@ function M.branches(ctx)
       entries[#entries + 1] = {
         display = branch_display(item, plan),
         value = item,
-        ordinal = item.name,
       }
     end
     local count = #entries
@@ -2166,14 +2165,9 @@ function M.worktrees(ctx)
     local plan = worktree_layout(worktrees)
     local entries = {}
     for _, item in ipairs(worktrees) do
-      local ordinal = item.branch ~= '' and item.branch or vim.fs.basename(item.path)
-      if item.detached and item.short_head ~= '' then
-        ordinal = ordinal .. ' ' .. item.short_head
-      end
       entries[#entries + 1] = {
         display = worktree_display(item, plan),
         value = item,
-        ordinal = ordinal,
       }
     end
     local count = #entries

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -261,7 +261,6 @@ function M.open_index()
       entries[#entries + 1] = {
         display = file_display(item),
         value = item,
-        ordinal = item.path .. ' ' .. (item.old_path or ''),
       }
     end
     if #entries == 0 then

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -261,7 +261,7 @@ function M.open_index()
       entries[#entries + 1] = {
         display = file_display(item),
         value = item,
-        ordinal = item.status .. ' ' .. item.path .. ' ' .. (item.old_path or ''),
+        ordinal = item.path .. ' ' .. (item.old_path or ''),
       }
     end
     if #entries == 0 then

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -16,17 +16,6 @@ local section_order = {
   'releases',
 }
 
-local section_search_terms = {
-  prs = { 'pull', 'requests', 'reviews' },
-  issues = { 'bugs', 'tickets' },
-  ci = { 'checks', 'runs', 'actions' },
-  branches = { 'refs' },
-  commits = { 'history', 'log' },
-  worktrees = { 'trees' },
-  browse = { 'web' },
-  releases = { 'tags' },
-}
-
 local function prompt(ctx)
   if ctx.branch ~= '' then
     return ('Forge (%s)> '):format(ctx.branch)
@@ -239,10 +228,6 @@ local function open_root(ctx)
         entries[#entries + 1] = {
           display = { { label } },
           value = route,
-          ordinal = table.concat(
-            vim.tbl_flatten({ label, section, section_search_terms[section] or {} }),
-            ' '
-          ),
         }
       end
     end

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -16,6 +16,17 @@ local section_order = {
   'releases',
 }
 
+local section_search_terms = {
+  prs = { 'pull', 'requests', 'reviews' },
+  issues = { 'bugs', 'tickets' },
+  ci = { 'checks', 'runs', 'actions' },
+  branches = { 'refs' },
+  commits = { 'history', 'log' },
+  worktrees = { 'trees' },
+  browse = { 'web' },
+  releases = { 'tags' },
+}
+
 local function prompt(ctx)
   if ctx.branch ~= '' then
     return ('Forge (%s)> '):format(ctx.branch)
@@ -228,7 +239,10 @@ local function open_root(ctx)
         entries[#entries + 1] = {
           display = { { label } },
           value = route,
-          ordinal = label,
+          ordinal = table.concat(
+            vim.tbl_flatten({ label, section, section_search_terms[section] or {} }),
+            ' '
+          ),
         }
       end
     end

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -46,6 +46,7 @@ describe('fzf picker', function()
     close_calls = 0
     ctx_clears = 0
     package.loaded['forge'] = nil
+    package.loaded['forge.picker'] = nil
     package.loaded['forge.picker.fzf'] = nil
     vim.g.forge = nil
   end)
@@ -148,6 +149,99 @@ describe('fzf picker', function()
       '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:switch]|[FzfLuaHeaderBind:^S] [FzfLuaHeaderText:delete]|[FzfLuaHeaderBind:^X] [FzfLuaHeaderText:browse]',
       captured.opts.fzf_opts['--header']
     )
+  end)
+
+  it('uses deliberate hidden search keys for root menu routes', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Forge> ',
+      entries = {
+        {
+          display = { { 'CI' } },
+          value = 'ci.current_branch',
+        },
+      },
+      actions = {},
+      picker_name = '_menu',
+    })
+
+    assert.is_not_nil(captured)
+    assert.same({ '1\tCI ci checks runs actions\tCI' }, captured.lines)
+  end)
+
+  it('uses branch names as the hidden search key for branch rows', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Branches> ',
+      entries = {
+        {
+          display = {
+            { '* ', 'ForgePass' },
+            { 'main', 'ForgeBranchCurrent' },
+            { ' [origin/main]', 'Directory' },
+          },
+          value = {
+            name = 'main',
+            upstream = 'origin/main',
+            subject = 'Main branch',
+          },
+        },
+      },
+      actions = {},
+      picker_name = 'branch',
+    })
+
+    assert.is_not_nil(captured)
+    assert.same(1, #captured.lines)
+    assert.truthy(captured.lines[1]:find('1\tmain\t%* ', 1))
+    assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3mmain\27%[0m', 1))
+    assert.truthy(captured.lines[1]:find(' %[origin/main%]$', 1))
+  end)
+
+  it('uses branch-or-tail search keys for worktree rows', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Worktrees> ',
+      entries = {
+        {
+          display = {
+            { '* ', 'ForgePass' },
+            { '/repo-feature', 'Directory' },
+            { ' feature', 'ForgeBranch' },
+            { ' abc1234', 'ForgeCommitHash' },
+          },
+          value = {
+            path = '/repo-feature',
+            branch = 'feature',
+            detached = false,
+            short_head = 'abc1234',
+          },
+        },
+        {
+          display = {
+            { '  ', 'ForgeDim' },
+            { '/repo-bisect', 'Directory' },
+            { ' detached', 'ForgeDim' },
+            { ' def5678', 'ForgeCommitHash' },
+          },
+          value = {
+            path = '/repo-bisect',
+            branch = '',
+            detached = true,
+            short_head = 'def5678',
+          },
+        },
+      },
+      actions = {},
+      picker_name = 'worktree',
+    })
+
+    assert.is_not_nil(captured)
+    assert.same(2, #captured.lines)
+    assert.truthy(captured.lines[1]:find('1\tfeature\t%* /repo%-feature', 1))
+    assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m feature\27%[0m', 1))
+    assert.truthy(captured.lines[1]:find(' abc1234$', 1))
+    assert.equals('2\trepo-bisect def5678\t  /repo-bisect detached def5678', captured.lines[2])
   end)
 
   it('treats placeholder rows as no selection', function()

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -62,6 +62,7 @@ describe('fzf picker', function()
             { 'alice  1h', 'ForgeDim' },
           },
           value = '42',
+          ordinal = '42 fix api drift alice',
         },
       },
       actions = {},
@@ -69,8 +70,10 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.same({ '1\t#42 fix api drift alice  1h' }, captured.lines)
+    assert.same({ '1\t42 fix api drift alice\t#42 fix api drift alice  1h' }, captured.lines)
     assert.equals('PRs> ', captured.opts.prompt)
+    assert.equals('3..', captured.opts.fzf_opts['--with-nth'])
+    assert.equals('2', captured.opts.fzf_opts['--nth'])
   end)
 
   it('renders headers with <cr> and ^X style key labels without to text', function()
@@ -171,7 +174,7 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    captured.opts.actions.default({ '1\tNo open PRs' })
+    captured.opts.actions.default({ '1\tNo open PRs\tNo open PRs' })
     assert.is_nil(selected)
   end)
 
@@ -202,7 +205,7 @@ describe('fzf picker', function()
     assert.same('table', type(captured.opts.actions['ctrl-x']))
     assert.is_true(captured.opts.actions['ctrl-x'].reload)
     assert.is_nil(captured.opts.actions['ctrl-x'].noclose)
-    captured.opts.actions['ctrl-x'].fn({ '1\t#42' })
+    captured.opts.actions['ctrl-x'].fn({ '1\t42\t#42' })
     assert.equals('42', selected.value)
   end)
 
@@ -233,7 +236,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.same('table', type(captured.opts.actions.default))
-    captured.opts.actions.default.fn({ '1\tLoad more...' })
+    captured.opts.actions.default.fn({ '1\tLoad more\tLoad more...' })
 
     vim.wait(100, function()
       return selected ~= false
@@ -286,10 +289,10 @@ describe('fzf picker', function()
       lines[#lines + 1] = line
     end)
 
-    assert.same({ '1\t#1', '2\t#2' }, lines)
+    assert.same({ '1\t#1\t#1', '2\t#2\t#2' }, lines)
     assert.is_true(done)
 
-    captured.opts.actions.default({ '2\t#2' })
+    captured.opts.actions.default({ '2\t2\t#2' })
     assert.equals('2', selected.value)
   end)
 
@@ -312,7 +315,7 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.same({ '2\t#2' }, captured.lines)
+    assert.same({ '2\t#2\t#2' }, captured.lines)
   end)
 
   it('skips streamed rows whose rendered display is blank', function()
@@ -345,7 +348,7 @@ describe('fzf picker', function()
       end
     end)
 
-    assert.same({ '2\t#2' }, lines)
+    assert.same({ '2\t#2\t#2' }, lines)
   end)
 
   it('strips branch background ANSI so the selected row highlight can win', function()

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -133,11 +133,15 @@ describe('git sections', function()
     end
 
     package.preload['forge.picker'] = function()
-      return {
+      local picker = dofile(vim.fn.getcwd() .. '/lua/forge/picker/init.lua')
+      return vim.tbl_extend('force', picker, {
+        backend = function()
+          return 'fzf-lua'
+        end,
         pick = function(opts)
           captured.picker = opts
         end,
-      }
+      })
     end
 
     package.preload['forge.term'] = function()
@@ -248,9 +252,12 @@ describe('git sections', function()
     assert.equals('', vim.trim(captured.picker.entries[3].display[3][1]))
     assert.equals('Topic branch', vim.trim(captured.picker.entries[3].display[4][1]))
     assert.equals('ForgeDim', captured.picker.entries[3].display[4][2])
-    assert.equals('main', captured.picker.entries[1].ordinal)
-    assert.equals('feature', captured.picker.entries[2].ordinal)
-    assert.equals('topic', captured.picker.entries[3].ordinal)
+    assert.equals('main', require('forge.picker').search_key('branch', captured.picker.entries[1]))
+    assert.equals(
+      'feature',
+      require('forge.picker').search_key('branch', captured.picker.entries[2])
+    )
+    assert.equals('topic', require('forge.picker').search_key('branch', captured.picker.entries[3]))
 
     local worktree_entry = captured.picker.entries[2]
     captured.picker.actions[1].fn(worktree_entry)
@@ -362,8 +369,14 @@ describe('git sections', function()
     assert.same({ '  ', 'ForgeDim' }, captured.picker.entries[2].display[1])
     assert.same({ '/repo-feature', 'Directory' }, captured.picker.entries[2].display[2])
     assert.equals('feature', vim.trim(captured.picker.entries[2].display[3][1]))
-    assert.equals('main', captured.picker.entries[1].ordinal)
-    assert.equals('feature', captured.picker.entries[2].ordinal)
+    assert.equals(
+      'main',
+      require('forge.picker').search_key('worktree', captured.picker.entries[1])
+    )
+    assert.equals(
+      'feature',
+      require('forge.picker').search_key('worktree', captured.picker.entries[2])
+    )
     assert.equals('ForgeBranch', captured.picker.entries[2].display[3][2])
     assert.same({ ' def5678', 'ForgeCommitHash' }, captured.picker.entries[2].display[4])
 

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -244,6 +244,9 @@ describe('git sections', function()
     assert.equals('', vim.trim(captured.picker.entries[3].display[3][1]))
     assert.equals('Topic branch', vim.trim(captured.picker.entries[3].display[4][1]))
     assert.equals('ForgeDim', captured.picker.entries[3].display[4][2])
+    assert.equals('main', captured.picker.entries[1].ordinal)
+    assert.equals('feature', captured.picker.entries[2].ordinal)
+    assert.equals('topic', captured.picker.entries[3].ordinal)
 
     local worktree_entry = captured.picker.entries[2]
     captured.picker.actions[1].fn(worktree_entry)
@@ -338,6 +341,8 @@ describe('git sections', function()
     assert.same({ '  ', 'ForgeDim' }, captured.picker.entries[2].display[1])
     assert.same({ '/repo-feature', 'Directory' }, captured.picker.entries[2].display[2])
     assert.equals('feature', vim.trim(captured.picker.entries[2].display[3][1]))
+    assert.equals('main', captured.picker.entries[1].ordinal)
+    assert.equals('feature', captured.picker.entries[2].ordinal)
     assert.equals('ForgeBranch', captured.picker.entries[2].display[3][2])
     assert.same({ ' def5678', 'ForgeCommitHash' }, captured.picker.entries[2].display[4])
 

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -115,11 +115,15 @@ describe('routes', function()
     end
 
     package.preload['forge.picker'] = function()
-      return {
+      local picker = dofile(vim.fn.getcwd() .. '/lua/forge/picker/init.lua')
+      return vim.tbl_extend('force', picker, {
+        backend = function()
+          return 'fzf-lua'
+        end,
         pick = function(opts)
           captured.root = opts
         end,
-      }
+      })
     end
 
     package.preload['forge.pickers'] = function()
@@ -193,9 +197,18 @@ describe('routes', function()
       { 'PRs', 'Issues', 'CI', 'Branches', 'Commits', 'Worktrees', 'Browse', 'Releases' },
       labels
     )
-    assert.equals('PRs prs pull requests reviews', captured.root.entries[1].ordinal)
-    assert.equals('CI ci checks runs actions', captured.root.entries[3].ordinal)
-    assert.equals('Branches branches refs', captured.root.entries[4].ordinal)
+    assert.equals(
+      'PRs prs pull requests reviews',
+      require('forge.picker').search_key('_menu', captured.root.entries[1])
+    )
+    assert.equals(
+      'CI ci checks runs actions',
+      require('forge.picker').search_key('_menu', captured.root.entries[3])
+    )
+    assert.equals(
+      'Branches branches refs',
+      require('forge.picker').search_key('_menu', captured.root.entries[4])
+    )
     assert.is_nil(captured.root.entries[1].display[2])
     assert.is_nil(captured.root.entries[4].display[2])
 

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -193,6 +193,9 @@ describe('routes', function()
       { 'PRs', 'Issues', 'CI', 'Branches', 'Commits', 'Worktrees', 'Browse', 'Releases' },
       labels
     )
+    assert.equals('PRs prs pull requests reviews', captured.root.entries[1].ordinal)
+    assert.equals('CI ci checks runs actions', captured.root.entries[3].ordinal)
+    assert.equals('Branches branches refs', captured.root.entries[4].ordinal)
     assert.is_nil(captured.root.entries[1].display[2])
     assert.is_nil(captured.root.entries[4].display[2])
 


### PR DESCRIPTION
## Summary
- make the fzf picker search over a hidden ordinal field instead of the fully rendered row text
- tighten branch, worktree, review-file, and root-menu search keys so visible context stops polluting matches
- keep the rendered rows unchanged while making search behavior reflect the thing users are actually trying to identify

This fixes cases like searching `main` in the branch picker and getting drowned out by repeated `[origin/main]` matches from other rows.

#### Test plan
- [x] `bash -lc 'cd /home/barrett/dev/forge.nvim-picker-search-keys && nix develop /home/barrett/dev/forge.nvim#ci --command busted'`
- [x] `bash -lc 'cd /home/barrett/dev/forge.nvim-picker-search-keys && nix develop /home/barrett/dev/forge.nvim#ci --command selene --display-style quiet lua spec/fzf_picker_spec.lua spec/git_sections_spec.lua spec/routes_spec.lua'`
- [x] `bash -lc 'cd /home/barrett/dev/forge.nvim-picker-search-keys && nix develop /home/barrett/dev/forge.nvim#ci --command lua-language-server --check lua --configpath=/home/barrett/dev/forge.nvim/.luarc.json --checklevel=Warning'`
- [x] `bash -lc 'cd /home/barrett/dev/forge.nvim-picker-search-keys && nix develop /home/barrett/dev/forge.nvim#ci --command stylua --check lua spec/fzf_picker_spec.lua spec/git_sections_spec.lua spec/routes_spec.lua'`