### PR TITLE
fix(picker): restore root fzf filtering

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -57,15 +57,12 @@ local function render(segments)
   return table.concat(parts)
 end
 
-local function render_line(index, picker_name, entry)
-  local picker_mod = require('forge.picker')
+local function render_line(index, entry)
   local text = render(entry.display)
   if vim.trim(text) == '' then
     return nil
   end
-  local search_key = picker_mod.search_key(picker_name, entry)
-  search_key = search_key:gsub('[\r\n\t]', ' ')
-  return ('%d\t%s\t%s'):format(index, search_key, text)
+  return ('%s\t%d'):format(text, index)
 end
 
 ---@param actions forge.PickerActionDef[]
@@ -113,7 +110,7 @@ function M.pick(opts)
       local next_index = 0
       for i, entry in ipairs(entries) do
         next_index = i
-        local line = render_line(i, opts.picker_name, entry)
+        local line = render_line(i, entry)
         if line then
           fzf_cb(line)
         end
@@ -125,7 +122,7 @@ function M.pick(opts)
         end
         next_index = next_index + 1
         entries[next_index] = entry
-        local line = render_line(next_index, opts.picker_name, entry)
+        local line = render_line(next_index, entry)
         if line then
           fzf_cb(line)
         end
@@ -134,7 +131,7 @@ function M.pick(opts)
   else
     lines = {}
     for i, entry in ipairs(entries) do
-      local line = render_line(i, opts.picker_name, entry)
+      local line = render_line(i, entry)
       if line then
         lines[#lines + 1] = line
       end
@@ -183,8 +180,8 @@ function M.pick(opts)
       ['--ansi'] = '',
       ['--header'] = render_header(opts.actions, bindings),
       ['--no-multi'] = '',
-      ['--with-nth'] = '3..',
-      ['--nth'] = '2',
+      ['--with-nth'] = '1',
+      ['--accept-nth'] = '2',
       ['--delimiter'] = '\t',
     },
     actions = fzf_actions,

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -65,6 +65,12 @@ local function render_line(index, entry)
   return ('%s\t%d'):format(text, index)
 end
 
+---@param selected string
+---@return integer?
+local function selected_index(selected)
+  return tonumber(selected:match('^(%d+)$') or selected:match('^(%d+)%f[\t]') or selected:match('\t(%d+)$'))
+end
+
 ---@param actions forge.PickerActionDef[]
 ---@param bindings table<string, string|false>
 ---@return string?
@@ -147,7 +153,7 @@ function M.pick(opts)
           def.fn(nil)
           return
         end
-        local idx = tonumber(selected[1]:match('^(%d+)'))
+        local idx = selected_index(selected[1])
         local entry = picker_mod.selected(idx and entries[idx] or nil)
         if picker_mod.closes(def, entry) and not picker_mod.closes(def) then
           local utils = require('fzf-lua.utils')

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -331,6 +331,33 @@ describe('fzf picker', function()
     assert.equals('42', selected.value)
   end)
 
+  it('resolves selections when fzf-lua returns the full rendered row', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Forge> ',
+      entries = {
+        {
+          display = { { 'Branches' } },
+          value = 'branches.local',
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(entry)
+            selected = entry
+          end,
+        },
+      },
+      picker_name = '_menu',
+    })
+
+    assert.is_not_nil(captured)
+    captured.opts.actions.enter({ 'Branches\t1' })
+    assert.equals('branches.local', selected.value)
+  end)
+
   it('closes close=false actions when the selected row forces it', function()
     local picker = require('forge.picker.fzf')
     picker.pick({

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -71,10 +71,10 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.same({ '1\t42 fix api drift alice\t#42 fix api drift alice  1h' }, captured.lines)
+    assert.same({ '#42 fix api drift alice  1h\t1' }, captured.lines)
     assert.equals('PRs> ', captured.opts.prompt)
-    assert.equals('3..', captured.opts.fzf_opts['--with-nth'])
-    assert.equals('2', captured.opts.fzf_opts['--nth'])
+    assert.equals('1', captured.opts.fzf_opts['--with-nth'])
+    assert.equals('2', captured.opts.fzf_opts['--accept-nth'])
   end)
 
   it('renders headers with <cr> and ^X style key labels without to text', function()
@@ -179,7 +179,7 @@ describe('fzf picker', function()
     )
   end)
 
-  it('uses deliberate hidden search keys for root menu routes', function()
+  it('renders root menu rows with visible labels and hidden selection ids', function()
     local picker = require('forge.picker.fzf')
     picker.pick({
       prompt = 'Forge> ',
@@ -194,10 +194,10 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.same({ '1\tCI ci checks runs actions\tCI' }, captured.lines)
+    assert.same({ 'CI\t1' }, captured.lines)
   end)
 
-  it('uses branch names as the hidden search key for branch rows', function()
+  it('renders branch rows with visible labels and hidden selection ids', function()
     local picker = require('forge.picker.fzf')
     picker.pick({
       prompt = 'Branches> ',
@@ -221,12 +221,12 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.same(1, #captured.lines)
-    assert.truthy(captured.lines[1]:find('1\tmain\t%* ', 1))
+    assert.truthy(captured.lines[1]:find('^%* ', 1))
     assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3mmain\27%[0m', 1))
-    assert.truthy(captured.lines[1]:find(' %[origin/main%]$', 1))
+    assert.truthy(captured.lines[1]:find(' %[origin/main%]\t1$', 1))
   end)
 
-  it('uses branch-or-tail search keys for worktree rows', function()
+  it('renders worktree rows with visible labels and hidden selection ids', function()
     local picker = require('forge.picker.fzf')
     picker.pick({
       prompt = 'Worktrees> ',
@@ -266,10 +266,10 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.same(2, #captured.lines)
-    assert.truthy(captured.lines[1]:find('1\tfeature\t%* /repo%-feature', 1))
+    assert.truthy(captured.lines[1]:find('^%* /repo%-feature', 1))
     assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m feature\27%[0m', 1))
-    assert.truthy(captured.lines[1]:find(' abc1234$', 1))
-    assert.equals('2\trepo-bisect def5678\t  /repo-bisect detached def5678', captured.lines[2])
+    assert.truthy(captured.lines[1]:find(' abc1234\t1$', 1))
+    assert.equals('  /repo-bisect detached def5678\t2', captured.lines[2])
   end)
 
   it('treats placeholder rows as no selection', function()
@@ -296,7 +296,7 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    captured.opts.actions.enter({ '1\tNo open PRs\tNo open PRs' })
+    captured.opts.actions.enter({ '1' })
     assert.is_nil(selected)
   end)
 
@@ -327,7 +327,7 @@ describe('fzf picker', function()
     assert.same('table', type(captured.opts.actions['ctrl-x']))
     assert.is_true(captured.opts.actions['ctrl-x'].reload)
     assert.is_nil(captured.opts.actions['ctrl-x'].noclose)
-    captured.opts.actions['ctrl-x'].fn({ '1\t42\t#42' })
+    captured.opts.actions['ctrl-x'].fn({ '1' })
     assert.equals('42', selected.value)
   end)
 
@@ -359,7 +359,7 @@ describe('fzf picker', function()
     assert.is_not_nil(captured)
     assert.same('table', type(captured.opts.actions.enter))
     assert.is_true(captured.opts.actions.enter.reload)
-    captured.opts.actions.enter.fn({ '1\tLoad more\tLoad more...' })
+    captured.opts.actions.enter.fn({ '1' })
 
     vim.wait(100, function()
       return selected ~= false
@@ -412,10 +412,10 @@ describe('fzf picker', function()
       lines[#lines + 1] = line
     end)
 
-    assert.same({ '1\t#1\t#1', '2\t#2\t#2' }, lines)
+    assert.same({ '#1\t1', '#2\t2' }, lines)
     assert.is_true(done)
 
-    captured.opts.actions.enter({ '2\t#2\t#2' })
+    captured.opts.actions.enter({ '2' })
     assert.equals('2', selected.value)
   end)
 
@@ -438,7 +438,7 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.same({ '2\t#2\t#2' }, captured.lines)
+    assert.same({ '#2\t2' }, captured.lines)
   end)
 
   it('skips streamed rows whose rendered display is blank', function()
@@ -471,7 +471,7 @@ describe('fzf picker', function()
       end
     end)
 
-    assert.same({ '2\t#2\t#2' }, lines)
+    assert.same({ '#2\t2' }, lines)
   end)
 
   it('strips branch background ANSI so the selected row highlight can win', function()


### PR DESCRIPTION
## Summary
- restore `:Forge` root picker filtering after the hidden search-field refactor broke `fzf` matching
- switch the `fzf` backend back to searching visible row text while using `--accept-nth` to return the internal row index
- update picker backend specs to cover the new `display<TAB>index` line format and selection behavior

#### Test plan
- [x] `nix develop /home/barrett/dev/forge.nvim#ci --command busted /home/barrett/dev/forge.nvim/spec/fzf_picker_spec.lua`
- [x] `nix develop /home/barrett/dev/forge.nvim#ci --command busted /home/barrett/dev/forge.nvim/spec/pickers_spec.lua`
- [x] `nix develop /home/barrett/dev/forge.nvim#ci --command busted /home/barrett/dev/forge.nvim/spec/routes_spec.lua`
- [x] `nix develop /home/barrett/dev/forge.nvim#ci --command selene --display-style quiet /home/barrett/dev/forge.nvim/lua/forge/picker/fzf.lua /home/barrett/dev/forge.nvim/spec/fzf_picker_spec.lua`