### PR TITLE
fix(worktree): use spare width for full path display

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -353,16 +353,19 @@ local function worktree_layout(worktrees)
   end
 
   local paths = {}
+  local full_paths = {}
   local labels = {}
   local shas = {}
   for _, item in ipairs(worktrees) do
     paths[#paths + 1] = vim.fn.pathshorten(home_path(item.path))
+    full_paths[#full_paths + 1] = home_path(item.path)
     labels[#labels + 1] = worktree_label(item)
     shas[#shas + 1] = item.short_head
   end
   local path_opts = #paths <= 3 and { typical_quantile = 1, max_quantile = 1 }
     or { typical_quantile = 0.7, max_quantile = 0.85 }
-  local path_pref, path_max = elastic_width(path_limit, paths, 12, path_opts)
+  local path_pref = elastic_width(path_limit, paths, 12, path_opts)
+  local path_max = math.max(path_pref, layout.max_width(full_paths))
   local label_pref, label_max = elastic_width(label_limit, labels, 8)
   return layout.plan({
     width = layout.picker_width(),

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -508,6 +508,71 @@ describe('git sections', function()
     )
   end)
 
+  it('expands worktree paths beyond the default name width when space is available', function()
+    local home = vim.env.HOME or '/home/barrett'
+    local current_path = home .. '/dev/forge.nvim'
+    local yaml_path = home .. '/dev/forge.nvim-yaml-template-failure'
+    local nested_path = home .. '/dev/forge.nvim/.claude/worktrees/agent-a43cb846'
+
+    vim.api.nvim_win_get_width = function()
+      return 120
+    end
+
+    local current_system = vim.system
+    vim.system = function(cmd, opts, cb)
+      local key = table.concat(cmd, ' ')
+      if key == 'git worktree list --porcelain' then
+        local result = {
+          code = 0,
+          stdout = table.concat({
+            'worktree ' .. current_path,
+            'HEAD 73eb02012345',
+            'branch refs/heads/main',
+            '',
+            'worktree ' .. (home .. '/dev/forge.nvim-issue-117'),
+            'HEAD 1c6fe7612345',
+            'branch refs/heads/fix/yaml-parser-requirement',
+            '',
+            'worktree ' .. (home .. '/dev/forge.nvim-picker-search-keys'),
+            'HEAD a2fef9a12345',
+            'branch refs/heads/fix/picker-search-keys',
+            '',
+            'worktree ' .. yaml_path,
+            'HEAD e566fa912345',
+            'branch refs/heads/fix/yaml-template-parser-failure',
+            '',
+            'worktree ' .. nested_path,
+            'HEAD 9be38e312345',
+            'branch refs/heads/worktree-agent-a43cb846',
+            '',
+          }, '\n'),
+          stderr = '',
+        }
+        captured.last_system = key
+        captured.systems[#captured.systems + 1] = key
+        if cb then
+          cb(result)
+        end
+        return {
+          wait = function()
+            return result
+          end,
+        }
+      end
+      return current_system(cmd, opts, cb)
+    end
+
+    require('forge.pickers').worktrees({ root = current_path })
+    vim.wait(100, function()
+      return captured.picker ~= nil
+    end)
+
+    assert.equals(
+      vim.fn.fnamemodify(yaml_path, ':~'),
+      vim.trim(captured.picker.entries[4].display[2][1])
+    )
+  end)
+
   it('warns for worktree-backed branch deletion and deletes ordinary branches', function()
     local ctx = {
       id = 'current',


### PR DESCRIPTION
## Problem

The worktree picker sized its path column from shortened paths only, so long but meaningful worktree paths could stay truncated even when the picker still had plenty of unused width.

## Solution

Keep using shortened paths to choose the preferred worktree path width, but allow the column to grow up to the full home-relative path width when space is available. Add a regression test that covers a wide picker with a longer worktree path.