### PR TITLE
tweak(worktree): prioritize branch labels in picker rows

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -366,35 +366,36 @@ local function worktree_layout(worktrees)
     or { typical_quantile = 0.7, max_quantile = 0.85 }
   local path_pref = elastic_width(path_limit, paths, 12, path_opts)
   local path_max = math.max(path_pref, layout.max_width(full_paths))
-  local label_pref, label_max = elastic_width(label_limit, labels, 8)
+  local label_pref = elastic_width(label_limit, labels, 8)
+  local label_max = math.max(label_pref, layout.max_width(labels))
   return layout.plan({
     width = layout.picker_width(),
     columns = {
       { key = 'marker', fixed = 2 },
       {
-        key = 'path',
-        gap = '',
-        min = 12,
-        preferred = path_pref,
-        max = path_max,
-        shrink = 3,
-        grow = 1,
-        overflow = 'head',
-        pack_on = 'compact',
-      },
-      {
         key = 'label',
-        gap = ' ',
+        gap = '',
         min = 8,
         preferred = label_pref,
         max = label_max,
         optional = true,
         drop = 2,
-        shrink = 2,
-        grow = 2,
+        shrink = 3,
+        grow = 1,
         overflow = 'tail',
         pack_on = 'compact',
         hide_if_empty = true,
+      },
+      {
+        key = 'path',
+        gap = ' ',
+        min = 12,
+        preferred = path_pref,
+        max = path_max,
+        shrink = 3,
+        grow = 2,
+        overflow = 'head',
+        pack_on = 'compact',
       },
       {
         key = 'sha',
@@ -412,16 +413,16 @@ local function worktree_display(item, plan)
   local label = worktree_label(item)
   return layout.render(plan, {
     marker = { item.current and '* ' or '  ', item.current and 'ForgePass' or 'ForgeDim' },
-    path = {
-      render = function(width)
-        return { display_path(item.path, width), 'Directory' }
-      end,
-    },
     label = {
       label,
       item.current and item.branch ~= '' and 'ForgeBranchCurrent'
         or item.branch ~= '' and 'ForgeBranch'
         or 'ForgeDim',
+    },
+    path = {
+      render = function(width)
+        return { display_path(item.path, width), 'Directory' }
+      end,
     },
     sha = { item.short_head, 'ForgeCommitHash' },
   })

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -356,7 +356,7 @@ describe('git sections', function()
       },
     }
 
-    local old_system = vim.system
+    local current_system = vim.system
     vim.system = function(cmd, _, cb)
       local key = table.concat(cmd, ' ')
       captured.last_system = key
@@ -450,7 +450,7 @@ describe('git sections', function()
     vim.wait(100, function()
       return captured.picker and captured.picker.prompt == 'Commits on main (4)> '
     end)
-    vim.system = old_system
+    vim.system = current_system
 
     assert.equals(
       'git log --max-count=5 --format=%H%x1f%h%x1f%s%x1f%an%x1f%ct%x1e origin/main',

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -473,14 +473,14 @@ describe('git sections', function()
     assert.equals('add', captured.picker.actions[2].name)
     assert.equals('delete', captured.picker.actions[3].name)
     assert.same({ '* ', 'ForgePass' }, captured.picker.entries[1].display[1])
-    assert.same({ '/repo        ', 'Directory' }, captured.picker.entries[1].display[2])
-    assert.equals('main', vim.trim(captured.picker.entries[1].display[3][1]))
-    assert.equals('ForgeBranchCurrent', captured.picker.entries[1].display[3][2])
+    assert.equals('main', vim.trim(captured.picker.entries[1].display[2][1]))
+    assert.equals('ForgeBranchCurrent', captured.picker.entries[1].display[2][2])
+    assert.equals('/repo', vim.trim(captured.picker.entries[1].display[3][1]))
+    assert.equals('Directory', captured.picker.entries[1].display[3][2])
     assert.same({ ' abc1234', 'ForgeCommitHash' }, captured.picker.entries[1].display[4])
 
     assert.same({ '  ', 'ForgeDim' }, captured.picker.entries[2].display[1])
-    assert.same({ '/repo-feature', 'Directory' }, captured.picker.entries[2].display[2])
-    assert.equals('feature', vim.trim(captured.picker.entries[2].display[3][1]))
+    assert.equals('feature', vim.trim(captured.picker.entries[2].display[2][1]))
     assert.equals(
       'main',
       require('forge.picker').search_key('worktree', captured.picker.entries[1])
@@ -489,7 +489,9 @@ describe('git sections', function()
       'feature',
       require('forge.picker').search_key('worktree', captured.picker.entries[2])
     )
-    assert.equals('ForgeBranch', captured.picker.entries[2].display[3][2])
+    assert.equals('ForgeBranch', captured.picker.entries[2].display[2][2])
+    assert.equals('/repo-feature', vim.trim(captured.picker.entries[2].display[3][1]))
+    assert.equals('Directory', captured.picker.entries[2].display[3][2])
     assert.same({ ' def5678', 'ForgeCommitHash' }, captured.picker.entries[2].display[4])
 
     local entry = captured.picker.entries[2]
@@ -564,8 +566,68 @@ describe('git sections', function()
     end)
 
     assert.equals(
-      ' feature/some-long-worktree-branch-name',
-      captured.picker.entries[1].display[3][1]
+      'feature/some-long-worktree-branch-name',
+      vim.trim(captured.picker.entries[1].display[2][1])
+    )
+  end)
+
+  it('expands outlier worktree branch labels when the picker has spare width', function()
+    vim.api.nvim_win_get_width = function()
+      return 120
+    end
+
+    local current_system = vim.system
+    vim.system = function(cmd, opts, cb)
+      local key = table.concat(cmd, ' ')
+      if key == 'git worktree list --porcelain' then
+        local result = {
+          code = 0,
+          stdout = table.concat({
+            'worktree /repo',
+            'HEAD abc123456789',
+            'branch refs/heads/main',
+            '',
+            'worktree /repo-issue-117',
+            'HEAD 1c6fe7612345',
+            'branch refs/heads/fix/yaml-parser-requirement',
+            '',
+            'worktree /repo-issue-74',
+            'HEAD a73818212345',
+            'branch refs/heads/fix/github-ci-refresh-ux',
+            '',
+            'worktree /repo-issue-75',
+            'HEAD 3a4198412345',
+            'branch refs/heads/fix/commit-picker-yank-state',
+            '',
+            'worktree /repo-issues-119-113',
+            'HEAD 861293612345',
+            'branch refs/heads/fix/commit-picker-upstream-load-more',
+            '',
+          }, '\n'),
+          stderr = '',
+        }
+        captured.last_system = key
+        captured.systems[#captured.systems + 1] = key
+        if cb then
+          cb(result)
+        end
+        return {
+          wait = function()
+            return result
+          end,
+        }
+      end
+      return current_system(cmd, opts, cb)
+    end
+
+    require('forge.pickers').worktrees({ root = '/repo' })
+    vim.wait(100, function()
+      return captured.picker ~= nil
+    end)
+
+    assert.equals(
+      'fix/commit-picker-upstream-load-more',
+      vim.trim(captured.picker.entries[5].display[2][1])
     )
   end)
 
@@ -612,11 +674,11 @@ describe('git sections', function()
 
     assert.equals(
       vim.fn.fnamemodify(current_path, ':~'),
-      vim.trim(captured.picker.entries[1].display[2][1])
+      vim.trim(captured.picker.entries[1].display[3][1])
     )
     assert.equals(
       vim.fn.pathshorten(vim.fn.fnamemodify(nested_path, ':~')),
-      vim.trim(captured.picker.entries[2].display[2][1])
+      vim.trim(captured.picker.entries[2].display[3][1])
     )
   end)
 
@@ -681,7 +743,7 @@ describe('git sections', function()
 
     assert.equals(
       vim.fn.fnamemodify(yaml_path, ':~'),
-      vim.trim(captured.picker.entries[4].display[2][1])
+      vim.trim(captured.picker.entries[4].display[3][1])
     )
   end)
 


### PR DESCRIPTION
## Problem

The worktree picker still treated paths as the primary display field, which meant long branch names could stay truncated even in wide pickers and the row order did not match how people usually identify worktrees.

## Solution

Move branch labels ahead of paths in worktree rows and allow branch labels to grow to their full width when the picker has spare space. Keep paths as secondary context and add regression coverage for the reordered rows and wide-picker branch expansion.