### PR TITLE
feat(picker): support returning to parent pickers

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -182,6 +182,7 @@ Top-level keys: ~
 
   Defaults: >lua
       keys = {
+        back = '<c-b>',
         pr = {
           review = '<c-d>',
           worktree = '<c-w>',
@@ -233,6 +234,10 @@ Top-level keys: ~
         },
       }
 <
+
+  `keys.back`
+    Return to the parent picker when available. This action is active only on
+    nested pickers and is not shown in header hints.
 
   `keys.pr.review` is the canonical PR review binding. `keys.pr.diff` is
   still accepted as a legacy alias.

--- a/lua/forge/action.lua
+++ b/lua/forge/action.lua
@@ -14,7 +14,10 @@ actions.open = {
       context = context.id
     end
 
-    require('forge.routes').open(entry.value, { context = context })
+    require('forge.routes').open(entry.value, {
+      context = context,
+      back = opts.back,
+    })
   end,
 }
 

--- a/lua/forge/client.lua
+++ b/lua/forge/client.lua
@@ -8,6 +8,7 @@ clients.picker = function(opts)
     entries = opts.entries,
     actions = opts.actions,
     picker_name = '_menu',
+    back = opts.back,
   })
 end
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -20,6 +20,7 @@ local M = {}
 ---@field hosts string[]
 
 ---@class forge.KeysConfig
+---@field back string|false?
 ---@field pr forge.PRPickerKeys?
 ---@field issue forge.IssuePickerKeys?
 ---@field ci forge.CIPickerKeys?
@@ -221,6 +222,7 @@ local DEFAULTS = {
     worktrees = 'worktrees.list',
   },
   keys = {
+    back = '<c-b>',
     pr = {
       review = '<c-d>',
       diff = '<c-d>',
@@ -425,6 +427,7 @@ function M.config()
   end
   if type(cfg.keys) == 'table' then
     local keys = cfg.keys --[[@as forge.KeysConfig]]
+    vim.validate('forge.keys.back', keys.back, key_or_false, 'string or false')
     if keys.pr ~= nil then
       vim.validate('forge.keys.pr', keys.pr, 'table')
       for _, k in ipairs({

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -111,6 +111,16 @@ function M.pick(opts)
   local bindings = keys[opts.picker_name] or {}
   local entries = opts.entries or {}
   local stream = rawget(opts, 'stream')
+  local actions = vim.deepcopy(opts.actions or {})
+
+  if opts.back and keys.back then
+    actions[#actions + 1] = {
+      name = 'back',
+      fn = function()
+        opts.back()
+      end,
+    }
+  end
 
   local lines
   if stream then
@@ -147,8 +157,10 @@ function M.pick(opts)
   end
 
   local fzf_actions = {}
-  for _, def in ipairs(opts.actions) do
-    local key = def.name == 'default' and '<cr>' or bindings[def.name]
+  for _, def in ipairs(actions) do
+    local key = def.name == 'default' and '<cr>'
+      or def.name == 'back' and keys.back
+      or bindings[def.name]
     if key then
       local action_fn = function(selected)
         if not selected[1] then
@@ -186,7 +198,7 @@ function M.pick(opts)
     prompt = opts.prompt or '',
     fzf_opts = {
       ['--ansi'] = '',
-      ['--header'] = render_header(opts.actions, bindings),
+      ['--header'] = render_header(actions, bindings),
       ['--no-multi'] = '',
       ['--with-nth'] = '1',
       ['--accept-nth'] = '2',

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -19,6 +19,7 @@ local M = {}
 ---@field entries forge.PickerEntry[]
 ---@field actions forge.PickerActionDef[]
 ---@field picker_name string
+---@field back fun()?
 
 M.backends = {
   ['fzf-lua'] = 'forge.picker.fzf',

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -666,12 +666,13 @@ local function pr_action_fns(f, num)
     end,
     review = review_pr,
     diff = review_pr,
-    ci = function()
+    ci = function(opts)
+      opts = opts or {}
       if f.capabilities.per_pr_checks then
-        M.checks(f, num)
+        M.checks(f, num, nil, nil, opts)
       else
         log.debug(('per-%s checks unavailable on %s, showing repo CI'):format(kind, f.name))
-        M.ci(f)
+        M.ci(f, nil, nil, opts)
       end
     end,
     manage = function()
@@ -685,7 +686,7 @@ end
 
 ---@param f forge.Forge
 ---@param num string
-local function pr_manage_picker(f, num, parent_refresh)
+local function pr_manage_picker(f, num, parent)
   local forge_mod = require('forge')
   local kind = f.labels.pr_one
   log.info('loading more for ' .. kind .. ' #' .. num .. '...')
@@ -700,7 +701,7 @@ local function pr_manage_picker(f, num, parent_refresh)
   local entries = {}
   local action_map = {}
   local function reopen_self()
-    pr_manage_picker(f, num, parent_refresh)
+    pr_manage_picker(f, num, parent)
   end
 
   local function add(label, fn)
@@ -740,7 +741,7 @@ local function pr_manage_picker(f, num, parent_refresh)
           f:merge_cmd(num, method),
           'merged (' .. method .. ')',
           'merge failed',
-          parent_refresh or reopen_self,
+          parent and parent.refresh or reopen_self,
           reopen_self
         )
       end)
@@ -756,7 +757,7 @@ local function pr_manage_picker(f, num, parent_refresh)
         f:close_cmd(num),
         'closed',
         'close failed',
-        parent_refresh or reopen_self,
+        parent and parent.refresh or reopen_self,
         reopen_self
       )
     end)
@@ -769,7 +770,7 @@ local function pr_manage_picker(f, num, parent_refresh)
         f:reopen_cmd(num),
         'reopened',
         'reopen failed',
-        parent_refresh or reopen_self,
+        parent and parent.refresh or reopen_self,
         reopen_self
       )
     end)
@@ -808,6 +809,7 @@ local function pr_manage_picker(f, num, parent_refresh)
       },
     },
     picker_name = '_menu',
+    back = parent and parent.back or nil,
   })
 end
 
@@ -815,7 +817,8 @@ end
 ---@param num string
 ---@param filter string?
 ---@param cached_checks table[]?
-function M.checks(f, num, filter, cached_checks)
+function M.checks(f, num, filter, cached_checks, opts)
+  opts = opts or {}
   filter = filter or 'all'
   local forge_mod = require('forge')
   local current_checks = cached_checks
@@ -915,35 +918,35 @@ function M.checks(f, num, filter, cached_checks)
       name = 'filter',
       label = 'filter',
       fn = function()
-        M.checks(f, num, next_ci_filter[filter] or 'all', current_checks)
+        M.checks(f, num, next_ci_filter[filter] or 'all', current_checks, { back = opts.back })
       end,
     },
     {
       name = 'failed',
       label = 'failed',
       fn = function()
-        M.checks(f, num, 'fail', current_checks)
+        M.checks(f, num, 'fail', current_checks, { back = opts.back })
       end,
     },
     {
       name = 'passed',
       label = 'passed',
       fn = function()
-        M.checks(f, num, 'pass', current_checks)
+        M.checks(f, num, 'pass', current_checks, { back = opts.back })
       end,
     },
     {
       name = 'running',
       label = 'running',
       fn = function()
-        M.checks(f, num, 'pending', current_checks)
+        M.checks(f, num, 'pending', current_checks, { back = opts.back })
       end,
     },
     {
       name = 'all',
       label = 'all',
       fn = function()
-        M.checks(f, num, 'all', current_checks)
+        M.checks(f, num, 'all', current_checks, { back = opts.back })
       end,
     },
     {
@@ -951,7 +954,7 @@ function M.checks(f, num, filter, cached_checks)
       label = 'refresh',
       fn = function()
         log.info(('refreshing checks for %s #%s...'):format(f.labels.pr_one, num))
-        M.checks(f, num, filter)
+        M.checks(f, num, filter, nil, { back = opts.back })
       end,
     },
   }
@@ -965,6 +968,7 @@ function M.checks(f, num, filter, cached_checks)
       entries = entries,
       actions = actions,
       picker_name = 'ci',
+      back = opts.back,
     })
   end
 
@@ -1010,7 +1014,8 @@ end
 ---@param f forge.Forge
 ---@param branch string?
 ---@param filter string?
-function M.ci(f, branch, filter)
+function M.ci(f, branch, filter, opts)
+  opts = opts or {}
   filter = filter or 'all'
   local forge_mod = require('forge')
   local request_key = forge_mod.list_key('ci', branch or 'all')
@@ -1169,35 +1174,35 @@ function M.ci(f, branch, filter)
       name = 'filter',
       label = 'filter',
       fn = function()
-        M.ci(f, branch, next_ci_filter[filter] or 'all')
+        M.ci(f, branch, next_ci_filter[filter] or 'all', { back = opts.back })
       end,
     },
     {
       name = 'failed',
       label = 'failed',
       fn = function()
-        M.ci(f, branch, 'fail')
+        M.ci(f, branch, 'fail', { back = opts.back })
       end,
     },
     {
       name = 'passed',
       label = 'passed',
       fn = function()
-        M.ci(f, branch, 'pass')
+        M.ci(f, branch, 'pass', { back = opts.back })
       end,
     },
     {
       name = 'running',
       label = 'running',
       fn = function()
-        M.ci(f, branch, 'pending')
+        M.ci(f, branch, 'pending', { back = opts.back })
       end,
     },
     {
       name = 'all',
       label = 'all',
       fn = function()
-        M.ci(f, branch, 'all')
+        M.ci(f, branch, 'all', { back = opts.back })
       end,
     },
     {
@@ -1205,7 +1210,7 @@ function M.ci(f, branch, filter)
       label = 'refresh',
       fn = function()
         log.info('refreshing CI runs...')
-        M.ci(f, branch, filter)
+        M.ci(f, branch, filter, { back = opts.back })
       end,
     },
   }
@@ -1218,6 +1223,7 @@ function M.ci(f, branch, filter)
       entries = entries,
       actions = actions,
       picker_name = 'ci',
+      back = opts.back,
     })
   end
 
@@ -1306,7 +1312,11 @@ function M.pr(state, f, opts)
 
   local function reopen_list()
     clear_state_caches(forge_mod, 'pr')
-    M.pr(state, f, { limit = visible_limit })
+    M.pr(state, f, { limit = visible_limit, back = opts.back })
+  end
+
+  local function back_to_list()
+    M.pr(state, f, { limit = visible_limit, back = opts.back })
   end
 
   local function maybe_prefetch_next()
@@ -1328,9 +1338,12 @@ function M.pr(state, f, opts)
       label = 'more',
       fn = function(entry)
         if entry and entry.load_more then
-          M.pr(state, f, { limit = entry.next_limit })
+          M.pr(state, f, { limit = entry.next_limit, back = opts.back })
         elseif entry then
-          pr_manage_picker(f, entry.value, reopen_list)
+          pr_manage_picker(f, entry.value, {
+            refresh = reopen_list,
+            back = back_to_list,
+          })
         end
       end,
     },
@@ -1367,7 +1380,7 @@ function M.pr(state, f, opts)
       label = 'checks',
       fn = function(entry)
         if entry and not entry.load_more then
-          pr_action_fns(f, entry.value).ci()
+          pr_action_fns(f, entry.value).ci({ back = back_to_list })
         end
       end,
     },
@@ -1386,7 +1399,10 @@ function M.pr(state, f, opts)
       label = 'more',
       fn = function(entry)
         if entry and not entry.load_more then
-          pr_manage_picker(f, entry.value, reopen_list)
+          pr_manage_picker(f, entry.value, {
+            refresh = reopen_list,
+            back = back_to_list,
+          })
         end
       end,
     },
@@ -1419,7 +1435,7 @@ function M.pr(state, f, opts)
       name = 'filter',
       label = 'filter',
       fn = function()
-        M.pr(next_state, f, { limit = visible_limit })
+        M.pr(next_state, f, { limit = visible_limit, back = opts.back })
       end,
     },
     {
@@ -1427,7 +1443,7 @@ function M.pr(state, f, opts)
       label = 'refresh',
       fn = function()
         clear_state_caches(forge_mod, 'pr')
-        M.pr(state, f, { limit = visible_limit })
+        M.pr(state, f, { limit = visible_limit, back = opts.back })
       end,
     },
   }
@@ -1440,6 +1456,7 @@ function M.pr(state, f, opts)
       entries = entries,
       actions = actions,
       picker_name = 'pr',
+      back = opts.back,
     })
     maybe_prefetch_next()
   end
@@ -1542,7 +1559,7 @@ function M.issue(state, f, opts)
 
   local function reopen_list()
     clear_state_caches(forge_mod, 'issue')
-    M.issue(state, f, { limit = visible_limit })
+    M.issue(state, f, { limit = visible_limit, back = opts.back })
   end
 
   local function maybe_prefetch_next()
@@ -1565,7 +1582,7 @@ function M.issue(state, f, opts)
       close = false,
       fn = function(entry)
         if entry and entry.load_more then
-          M.issue(state, f, { limit = entry.next_limit })
+          M.issue(state, f, { limit = entry.next_limit, back = opts.back })
         elseif entry then
           f:view_web(cli_kind, entry.value)
         end
@@ -1601,7 +1618,7 @@ function M.issue(state, f, opts)
       name = 'filter',
       label = 'filter',
       fn = function()
-        M.issue(next_state, f, { limit = visible_limit })
+        M.issue(next_state, f, { limit = visible_limit, back = opts.back })
       end,
     },
     {
@@ -1609,7 +1626,7 @@ function M.issue(state, f, opts)
       label = 'refresh',
       fn = function()
         clear_state_caches(forge_mod, 'issue')
-        M.issue(state, f, { limit = visible_limit })
+        M.issue(state, f, { limit = visible_limit, back = opts.back })
       end,
     },
   }
@@ -1622,6 +1639,7 @@ function M.issue(state, f, opts)
       entries = entries,
       actions = actions,
       picker_name = 'issue',
+      back = opts.back,
     })
     maybe_prefetch_next()
   end
@@ -1704,7 +1722,8 @@ end
 
 ---@param state 'all'|'draft'|'prerelease'
 ---@param f forge.Forge
-function M.release(state, f)
+function M.release(state, f, opts)
+  opts = opts or {}
   local forge_mod = require('forge')
   local cache_key = forge_mod.list_key('release', 'list')
   local rel_fields = f.release_fields
@@ -1751,7 +1770,7 @@ function M.release(state, f)
 
   local function reopen_list()
     clear_list_cache(forge_mod, cache_key)
-    M.release(state, f)
+    M.release(state, f, { back = opts.back })
   end
 
   local actions = {
@@ -1802,7 +1821,7 @@ function M.release(state, f)
               reopen_list
             )
           else
-            M.release(state, f)
+            M.release(state, f, { back = opts.back })
           end
         end)
       end,
@@ -1811,7 +1830,7 @@ function M.release(state, f)
       name = 'filter',
       label = 'filter',
       fn = function()
-        M.release(next_state, f)
+        M.release(next_state, f, { back = opts.back })
       end,
     },
     {
@@ -1819,7 +1838,7 @@ function M.release(state, f)
       label = 'refresh',
       fn = function()
         clear_list_cache(forge_mod, cache_key)
-        M.release(state, f)
+        M.release(state, f, { back = opts.back })
       end,
     },
   }
@@ -1832,6 +1851,7 @@ function M.release(state, f)
       entries = entries,
       actions = actions,
       picker_name = 'release',
+      back = opts.back,
     })
   end
 
@@ -1866,7 +1886,8 @@ function M.release(state, f)
 end
 
 ---@param ctx { root: string, branch: string, forge: forge.Forge? }
-function M.branches(ctx)
+function M.branches(ctx, opts)
+  opts = opts or {}
   local forge_mod = require('forge')
   local cache_key = forge_mod.list_key('branch', 'local-refs-v2')
 
@@ -1948,14 +1969,14 @@ function M.branches(ctx)
                 'delete failed',
                 function()
                   forge_mod.clear_list(cache_key)
-                  M.branches(ctx)
+                  M.branches(ctx, { back = opts.back })
                 end,
                 function()
-                  M.branches(ctx)
+                  M.branches(ctx, { back = opts.back })
                 end
               )
             else
-              M.branches(ctx)
+              M.branches(ctx, { back = opts.back })
             end
           end)
         end,
@@ -1977,7 +1998,7 @@ function M.branches(ctx)
         label = 'refresh',
         fn = function()
           forge_mod.clear_list(cache_key)
-          M.branches(ctx)
+          M.branches(ctx, { back = opts.back })
         end,
       },
     }
@@ -2000,6 +2021,7 @@ function M.branches(ctx)
       entries = entries,
       actions = actions,
       picker_name = 'branch',
+      back = opts.back,
     })
   end
 
@@ -2071,7 +2093,7 @@ function M.commits(ctx, branch, opts)
             return
           end
           if entry.load_more then
-            M.commits(ctx, branch, { limit = entry.next_limit })
+            M.commits(ctx, branch, { limit = entry.next_limit, back = opts.back })
             return
           end
           require('forge.term').open({
@@ -2110,7 +2132,7 @@ function M.commits(ctx, branch, opts)
         label = 'refresh',
         fn = function()
           forge_mod.clear_list(cache_key)
-          M.commits(ctx, branch, { limit = visible_limit })
+          M.commits(ctx, branch, { limit = visible_limit, back = opts.back })
         end,
       },
     }
@@ -2133,6 +2155,7 @@ function M.commits(ctx, branch, opts)
       entries = entries,
       actions = actions,
       picker_name = 'commit',
+      back = opts.back,
     })
   end
 
@@ -2195,7 +2218,8 @@ function M.commits(ctx, branch, opts)
 end
 
 ---@param ctx { root: string }
-function M.worktrees(ctx)
+function M.worktrees(ctx, opts)
+  opts = opts or {}
   local forge_mod = require('forge')
   local cache_key = forge_mod.list_key('worktree', 'list')
 
@@ -2212,7 +2236,7 @@ function M.worktrees(ctx)
     entries = with_placeholder(entries, 'No linked worktrees')
 
     local function reopen()
-      M.worktrees(ctx)
+      M.worktrees(ctx, { back = opts.back })
     end
 
     picker.pick({
@@ -2320,11 +2344,12 @@ function M.worktrees(ctx)
           label = 'refresh',
           fn = function()
             forge_mod.clear_list(cache_key)
-            M.worktrees(ctx)
+            M.worktrees(ctx, { back = opts.back })
           end,
         },
       },
       picker_name = 'worktree',
+      back = opts.back,
     })
   end
 

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -38,47 +38,47 @@ local function route_handlers()
   local pickers = require('forge.pickers')
 
   return {
-    ['prs.all'] = function(ctx)
+    ['prs.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.pr('all', ctx.forge)
+      pickers.pr('all', ctx.forge, { back = opts.back })
     end,
-    ['prs.open'] = function(ctx)
+    ['prs.open'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.pr('open', ctx.forge)
+      pickers.pr('open', ctx.forge, { back = opts.back })
     end,
-    ['prs.closed'] = function(ctx)
+    ['prs.closed'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.pr('closed', ctx.forge)
+      pickers.pr('closed', ctx.forge, { back = opts.back })
     end,
-    ['issues.all'] = function(ctx)
+    ['issues.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.issue('all', ctx.forge)
+      pickers.issue('all', ctx.forge, { back = opts.back })
     end,
-    ['issues.open'] = function(ctx)
+    ['issues.open'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.issue('open', ctx.forge)
+      pickers.issue('open', ctx.forge, { back = opts.back })
     end,
-    ['issues.closed'] = function(ctx)
+    ['issues.closed'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.issue('closed', ctx.forge)
+      pickers.issue('closed', ctx.forge, { back = opts.back })
     end,
-    ['ci.all'] = function(ctx)
+    ['ci.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.ci(ctx.forge)
+      pickers.ci(ctx.forge, nil, nil, { back = opts.back })
     end,
     ['ci.current_branch'] = function(ctx, opts)
       if not ctx.forge then
@@ -88,20 +88,20 @@ local function route_handlers()
       if branch == nil or branch == '' then
         branch = ctx.branch ~= '' and ctx.branch or nil
       end
-      pickers.ci(ctx.forge, branch)
+      pickers.ci(ctx.forge, branch, nil, { back = opts.back })
     end,
-    ['branches.local'] = function(ctx)
-      pickers.branches(ctx)
+    ['branches.local'] = function(ctx, opts)
+      pickers.branches(ctx, { back = opts.back })
     end,
     ['commits.current_branch'] = function(ctx, opts)
       local branch, err = branch_for(ctx, opts)
       if not branch then
         return false, err
       end
-      pickers.commits(ctx, branch)
+      pickers.commits(ctx, branch, { back = opts.back })
     end,
-    ['worktrees.list'] = function(ctx)
-      pickers.worktrees(ctx)
+    ['worktrees.list'] = function(ctx, opts)
+      pickers.worktrees(ctx, { back = opts.back })
     end,
     ['browse.contextual'] = function(ctx, opts)
       if not ctx.forge then
@@ -140,23 +140,23 @@ local function route_handlers()
       end
       ctx.forge:browse_commit(sha)
     end,
-    ['releases.all'] = function(ctx)
+    ['releases.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.release('all', ctx.forge)
+      pickers.release('all', ctx.forge, { back = opts.back })
     end,
-    ['releases.draft'] = function(ctx)
+    ['releases.draft'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.release('draft', ctx.forge)
+      pickers.release('draft', ctx.forge, { back = opts.back })
     end,
-    ['releases.prerelease'] = function(ctx)
+    ['releases.prerelease'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.release('prerelease', ctx.forge)
+      pickers.release('prerelease', ctx.forge, { back = opts.back })
     end,
   }
 end
@@ -212,7 +212,8 @@ function M.resolve(name)
   return routes[name] or name
 end
 
-local function open_root(ctx)
+local function open_root(ctx, opts)
+  opts = opts or {}
   local cfg = require('forge').config()
   local sections = rawget(cfg, 'sections') or {}
   local routes = rawget(cfg, 'routes') or {}
@@ -245,6 +246,9 @@ local function open_root(ctx)
   local default_action, action_err = action.bind('open', {
     name = 'default',
     context = ctx.id,
+    back = function()
+      open_root(ctx)
+    end,
   })
   if not default_action then
     log.error(action_err)
@@ -256,6 +260,7 @@ local function open_root(ctx)
     prompt = prompt(ctx),
     entries = entries,
     actions = { default_action },
+    back = opts.back,
   })
   if not ok and client_err then
     log.error(client_err)
@@ -272,7 +277,7 @@ function M.open(name, opts)
   end
 
   if not name or name == '' then
-    open_root(ctx)
+    open_root(ctx, opts)
     return
   end
 

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -126,6 +126,35 @@ describe('fzf picker', function()
     assert.is_nil(captured.opts.fzf_opts['--header'])
   end)
 
+  it('binds a hidden back action without adding a header hint', function()
+    local picker = require('forge.picker.fzf')
+    local back_calls = 0
+    picker.pick({
+      prompt = 'PR #42 More> ',
+      entries = {
+        {
+          display = { { 'Edit' } },
+          value = 'Edit',
+        },
+      },
+      actions = {
+        { name = 'default', label = 'run', fn = function() end },
+      },
+      picker_name = '_menu',
+      back = function()
+        back_calls = back_calls + 1
+      end,
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_nil(captured.opts.fzf_opts['--header'])
+    assert.is_function(captured.opts.actions['ctrl-b'])
+
+    captured.opts.actions['ctrl-b']({})
+
+    assert.equals(1, back_calls)
+  end)
+
   it('renders headers for git-local pickers without the legacy prefix', function()
     local picker = require('forge.picker.fzf')
     picker.pick({

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -36,6 +36,8 @@ describe('config', function()
     assert.is_nil(cfg.keys.pr.manage)
     assert.is_nil(cfg.keys.pr.edit)
     assert.is_nil(cfg.keys.pr.close)
+    assert.equals('<c-b>', cfg.keys.back)
+    assert.equals('<c-b>', cfg.keys.back)
     assert.equals('<c-w>', cfg.keys.ci.watch)
     assert.equals('<c-f>', cfg.keys.ci.filter)
     assert.is_nil(cfg.keys.ci.failed)
@@ -81,12 +83,14 @@ describe('config', function()
   it('deep-merges git section key bindings', function()
     vim.g.forge = {
       keys = {
+        back = false,
         branch = { browse = '<c-b>' },
         commit = { yank = false },
         worktree = { refresh = '<c-f>' },
       },
     }
     local cfg = forge.config()
+    assert.is_false(cfg.keys.back)
     assert.equals('<c-d>', cfg.keys.branch.review)
     assert.equals('<c-s>', cfg.keys.branch.delete)
     assert.equals('<c-b>', cfg.keys.branch.browse)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -352,6 +352,33 @@ describe('pickers', function()
     assert.same({ 'Edit', 'Approve', 'Merge (merge)', 'Close', 'Mark as draft' }, labels)
   end)
 
+  it('passes back callbacks through nested PR menus', function()
+    local pickers = require('forge.pickers')
+    local back_calls = 0
+
+    pickers.pr('open', fake_forge(), {
+      back = function()
+        back_calls = back_calls + 1
+      end,
+    })
+
+    assert.is_not_nil(captured)
+    action_by_name('default').fn(captured.entries[1])
+
+    assert.equals('PR #42 More> ', captured.prompt)
+    assert.equals('_menu', captured.picker_name)
+    assert.is_function(captured.back)
+
+    captured.back()
+
+    assert.equals('Open PRs (1)> ', captured.prompt)
+    assert.is_function(captured.back)
+
+    captured.back()
+
+    assert.equals(1, back_calls)
+  end)
+
   it('shows an explicit empty PR row instead of a blank picker', function()
     cache['pr:open'] = {}
 

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -128,26 +128,33 @@ describe('routes', function()
 
     package.preload['forge.pickers'] = function()
       return {
-        pr = function(state)
+        pr = function(state, _, opts)
           captured.pr = state
+          captured.pr_back = opts and opts.back or nil
         end,
-        issue = function(state)
+        issue = function(state, _, opts)
           captured.issue = state
+          captured.issue_back = opts and opts.back or nil
         end,
-        ci = function(_, branch)
+        ci = function(_, branch, _, opts)
           captured.ci = branch
+          captured.ci_back = opts and opts.back or nil
         end,
-        branches = function(ctx)
+        branches = function(ctx, opts)
           captured.branches = ctx.id
+          captured.branches_back = opts and opts.back or nil
         end,
-        commits = function(_, branch)
+        commits = function(_, branch, opts)
           captured.commits = branch
+          captured.commits_back = opts and opts.back or nil
         end,
-        worktrees = function(ctx)
+        worktrees = function(ctx, opts)
           captured.worktrees = ctx.id
+          captured.worktrees_back = opts and opts.back or nil
         end,
-        release = function(state)
+        release = function(state, _, opts)
           captured.release = state
+          captured.release_back = opts and opts.back or nil
         end,
       }
     end
@@ -215,6 +222,7 @@ describe('routes', function()
     captured.root.actions[1].fn(captured.root.entries[2])
 
     assert.equals('open', captured.issue)
+    assert.is_function(captured.issue_back)
   end)
 
   it('opens branch, commit, and worktree routes through the route aliases', function()


### PR DESCRIPTION
## Problem

Nested forge pickers were forward-only. After drilling into a submenu like PR actions or opening a section from the root picker, there was no picker-native way to return to the previous workflow.

## Solution

Add a configurable Back action for nested pickers, default it to `<c-b>`, keep it out of header hints, and thread parent callbacks through the root and nested picker flows. Document the new key in vimdoc and cover the behavior in picker, route, and config specs.
