### PR TITLE
fix(picker): preserve back across nested flows

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -234,6 +234,7 @@ M.filter_runs = format_mod.filter_runs
 ---@field draft boolean?
 ---@field instant boolean?
 ---@field web boolean?
+---@field back fun()?
 
 ---@param opts forge.CreatePROpts?
 function M.create_pr(opts)
@@ -336,6 +337,7 @@ function M.create_pr(opts)
                   },
                 },
                 picker_name = '_menu',
+                back = opts.back,
               })
             end
           end
@@ -394,6 +396,7 @@ end
 ---@field web boolean?
 ---@field blank boolean?
 ---@field template string?
+---@field back fun()?
 
 ---@param opts forge.CreateIssueOpts?
 function M.create_issue(opts)
@@ -482,6 +485,7 @@ function M.create_issue(opts)
       },
     },
     picker_name = '_menu',
+    back = opts.back,
   })
 end
 

--- a/lua/forge/picker/session.lua
+++ b/lua/forge/picker/session.lua
@@ -151,6 +151,7 @@ function M.pick_json(opts)
       entries = {},
       actions = opts.actions,
       picker_name = opts.picker_name,
+      back = opts.back,
       stream = function(emit)
         request(emit)
       end,

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -587,7 +587,8 @@ end
 ---@return table<string, function>
 local function pr_action_fns(f, num)
   local kind = f.labels.pr_one
-  local function review_pr()
+  local function review_pr(opts)
+    opts = opts or {}
     local review = require('forge.review')
     local repo_root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
 
@@ -620,6 +621,7 @@ local function pr_action_fns(f, num)
             current_file = nil,
             materialization = co_result.code == 0 and 'checkout' or 'current',
             repo_root = repo_root,
+            back = opts.back,
           })
           review.open_index()
           log.debug(('review ready for %s #%s against %s'):format(kind, num, base))
@@ -984,6 +986,7 @@ function M.checks(f, num, filter, cached_checks, opts)
       loading_prompt = checks_prompt,
       actions = actions,
       picker_name = 'ci',
+      back = opts.back,
       cmd = function()
         return f:checks_json_cmd(num)
       end,
@@ -1233,6 +1236,7 @@ function M.ci(f, branch, filter, opts)
       loading_prompt = ci_prompt,
       actions = actions,
       picker_name = 'ci',
+      back = opts.back,
       cmd = function()
         return f:list_runs_json_cmd(branch)
       end,
@@ -1361,7 +1365,7 @@ function M.pr(state, f, opts)
       label = 'review',
       fn = function(entry)
         if entry and not entry.load_more then
-          pr_action_fns(f, entry.value).review()
+          pr_action_fns(f, entry.value).review({ back = opts.back })
         end
       end,
     },
@@ -1419,7 +1423,7 @@ function M.pr(state, f, opts)
       name = 'create',
       label = 'create',
       fn = function()
-        forge_mod.create_pr()
+        forge_mod.create_pr({ back = opts.back })
       end,
     },
     {
@@ -1470,6 +1474,7 @@ function M.pr(state, f, opts)
     end,
     actions = actions,
     picker_name = 'pr',
+    back = opts.back,
     cmd = function()
       return f:list_pr_json_cmd(state, fetch_limit)
     end,
@@ -1611,7 +1616,7 @@ function M.issue(state, f, opts)
       name = 'create',
       label = 'create',
       fn = function()
-        forge_mod.create_issue()
+        forge_mod.create_issue({ back = opts.back })
       end,
     },
     {
@@ -1653,6 +1658,7 @@ function M.issue(state, f, opts)
     end,
     actions = actions,
     picker_name = 'issue',
+    back = opts.back,
     cmd = function()
       return f:list_issue_json_cmd(state, fetch_limit)
     end,
@@ -1862,6 +1868,7 @@ function M.release(state, f, opts)
     loading_prompt = release_prompt,
     actions = actions,
     picker_name = 'release',
+    back = opts.back,
     cmd = function()
       return f:list_releases_json_cmd()
     end,
@@ -1933,7 +1940,7 @@ function M.branches(ctx, opts)
         label = 'review',
         fn = function(entry)
           if entry then
-            require('forge.review').start_branch(ctx, entry.value.name)
+            require('forge.review').start_branch(ctx, entry.value.name, { back = opts.back })
           end
         end,
       },
@@ -2111,7 +2118,7 @@ function M.commits(ctx, branch, opts)
         label = 'review',
         fn = function(entry)
           if entry and not entry.load_more then
-            require('forge.review').start_commit(ctx, entry.value.sha)
+            require('forge.review').start_commit(ctx, entry.value.sha, { back = opts.back })
           end
         end,
       },

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -285,6 +285,7 @@ function M.open_index()
         },
       },
       picker_name = '_menu',
+      back = session.back,
     })
   end
 
@@ -426,7 +427,8 @@ function M.files()
   M.open_index()
 end
 
-function M.start_branch(ctx, branch)
+function M.start_branch(ctx, branch, opts)
+  opts = opts or {}
   branch = branch or ctx.branch
   if not branch or branch == '' then
     log.warn('missing branch')
@@ -451,6 +453,7 @@ function M.start_branch(ctx, branch)
     current_file = nil,
     materialization = 'current',
     repo_root = ctx.root,
+    back = opts.back,
   }
 
   if ctx.branch ~= branch then
@@ -467,7 +470,8 @@ function M.start_branch(ctx, branch)
   M.open_index()
 end
 
-function M.start_commit(ctx, sha)
+function M.start_commit(ctx, sha, opts)
+  opts = opts or {}
   sha = sha or ctx.head
   if not sha or sha == '' then
     log.warn('missing commit')
@@ -498,6 +502,7 @@ function M.start_commit(ctx, sha)
     materialization = 'worktree',
     repo_root = ctx.root,
     worktree_path = worktree,
+    back = opts.back,
   })
   M.open_index()
 end

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -1,8 +1,9 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
-describe('create_issue', function()
+describe('create_pr', function()
   local captured
   local old_system
+  local old_fn_system
   local old_executable
   local old_preload
 
@@ -11,7 +12,8 @@ describe('create_issue', function()
       errors = {},
     }
 
-    old_system = vim.fn.system
+    old_system = vim.system
+    old_fn_system = vim.fn.system
     old_executable = vim.fn.executable
     old_preload = {
       ['forge.action'] = package.preload['forge.action'],
@@ -33,6 +35,43 @@ describe('create_issue', function()
       return 0
     end
 
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/repo.git\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return 'feature\n'
+      end
+      return ''
+    end
+
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      if key == 'pr-for-branch feature' then
+        result.stdout = '\n'
+      elseif key == 'default-branch' then
+        result.stdout = 'main\n'
+      elseif key == 'git diff --quiet origin/main..HEAD' then
+        result.code = 1
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
     package.preload['forge.action'] = function()
       return {
         register = function() end,
@@ -48,7 +87,7 @@ describe('create_issue', function()
 
     package.preload['forge.compose'] = function()
       return {
-        open_issue = function(_, result)
+        open_pr = function(_, _, _, _, result)
           captured.opened = result
         end,
       }
@@ -81,8 +120,15 @@ describe('create_issue', function()
     package.preload['forge.github'] = function()
       return {
         cli = 'gh',
-        issue_template_paths = function()
-          return { '.github/ISSUE_TEMPLATE/' }
+        labels = { pr_one = 'PR' },
+        pr_for_branch_cmd = function(_, branch)
+          return { 'pr-for-branch', branch }
+        end,
+        default_branch_cmd = function()
+          return { 'default-branch' }
+        end,
+        template_paths = function()
+          return { '.github/PULL_REQUEST_TEMPLATE/' }
         end,
       }
     end
@@ -108,6 +154,29 @@ describe('create_issue', function()
       }
     end
 
+    package.preload['forge.template'] = function()
+      return {
+        discover = function()
+          return nil,
+            {
+              {
+                name = 'pull_request.md',
+                display = 'Pull Request',
+                is_yaml = false,
+                dir = '/repo/.github/PULL_REQUEST_TEMPLATE',
+              },
+            },
+            nil
+        end,
+        load = function()
+          return { body = 'template' }
+        end,
+        fill_from_commits = function()
+          return 'title', 'body'
+        end,
+      }
+    end
+
     package.loaded['forge'] = nil
     package.loaded['forge.action'] = nil
     package.loaded['forge.client'] = nil
@@ -122,7 +191,8 @@ describe('create_issue', function()
   end)
 
   after_each(function()
-    vim.fn.system = old_system
+    vim.system = old_system
+    vim.fn.system = old_fn_system
     vim.fn.executable = old_executable
 
     package.preload['forge.action'] = old_preload['forge.action']
@@ -149,93 +219,18 @@ describe('create_issue', function()
     package.loaded['forge.template'] = nil
   end)
 
-  it('aborts issue creation when a single yaml template cannot be loaded', function()
-    package.preload['forge.template'] = function()
-      return {
-        discover = function()
-          return nil,
-            nil,
-            'tree-sitter yaml parser not found; install it to use YAML issue form templates'
-        end,
-        load = function() end,
-      }
-    end
-
-    require('forge').create_issue()
-
-    assert.is_nil(captured.opened)
-    assert.is_nil(captured.picker)
-    assert.same(
-      { 'tree-sitter yaml parser not found; install it to use YAML issue form templates' },
-      captured.errors
-    )
-  end)
-
-  it(
-    'logs an error instead of opening a blank issue when a selected yaml template fails to load',
-    function()
-      package.preload['forge.template'] = function()
-        return {
-          discover = function()
-            return nil,
-              {
-                {
-                  name = 'bug_report.yaml',
-                  display = 'Bug Report',
-                  is_yaml = true,
-                  dir = '/repo/.github/ISSUE_TEMPLATE',
-                },
-              },
-              nil
-          end,
-          load = function()
-            return nil,
-              'tree-sitter yaml parser not found; install it to use YAML issue form templates'
-          end,
-        }
-      end
-
-      require('forge').create_issue()
-
-      assert.is_not_nil(captured.picker)
-      captured.picker.actions[1].fn(captured.picker.entries[1])
-
-      assert.is_nil(captured.opened)
-      assert.same(
-        { 'tree-sitter yaml parser not found; install it to use YAML issue form templates' },
-        captured.errors
-      )
-    end
-  )
-
-  it('preserves back on the issue template picker', function()
+  it('preserves back on the PR template picker', function()
     local back_calls = 0
 
-    package.preload['forge.template'] = function()
-      return {
-        discover = function()
-          return nil,
-            {
-              {
-                name = 'bug_report.md',
-                display = 'Bug Report',
-                is_yaml = false,
-                dir = '/repo/.github/ISSUE_TEMPLATE',
-              },
-            },
-            nil
-        end,
-        load = function()
-          return { body = 'template' }
-        end,
-      }
-    end
-
-    require('forge').create_issue({
+    require('forge').create_pr({
       back = function()
         back_calls = back_calls + 1
       end,
     })
+
+    vim.wait(100, function()
+      return captured.picker ~= nil
+    end)
 
     assert.is_not_nil(captured.picker)
     assert.is_function(captured.picker.back)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -3,7 +3,9 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 local captured
 local cache
 local issue_create_calls
+local issue_create_opts
 local pr_create_calls
+local pr_create_opts
 local default_system
 
 local function fake_forge()
@@ -124,7 +126,9 @@ describe('pickers', function()
   before_each(function()
     captured = nil
     issue_create_calls = 0
+    issue_create_opts = nil
     pr_create_calls = 0
+    pr_create_opts = nil
     default_system = vim.system
     vim.system = function(_, _, cb)
       if cb then
@@ -268,11 +272,13 @@ describe('pickers', function()
         repo_info = function(f)
           return f:repo_info()
         end,
-        create_issue = function()
+        create_issue = function(...)
           issue_create_calls = issue_create_calls + 1
+          issue_create_opts = select(1, ...)
         end,
-        create_pr = function()
+        create_pr = function(...)
           pr_create_calls = pr_create_calls + 1
+          pr_create_opts = select(1, ...)
         end,
         edit_pr = function() end,
       }
@@ -441,6 +447,48 @@ describe('pickers', function()
     assert.equals('42', streamed[1].value)
     assert.equals('#42', streamed[1].display[1][1])
     assert.same(42, cache['pr:open'][1].number)
+  end)
+
+  it('keeps back available on uncached streaming PR opens', function()
+    cache['pr:open'] = nil
+    local back_calls = 0
+
+    local old_system = vim.system
+    vim.system = function()
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge(), {
+      back = function()
+        back_calls = back_calls + 1
+      end,
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_function(captured.back)
+
+    captured.back()
+
+    assert.equals(1, back_calls)
+    vim.system = old_system
+  end)
+
+  it('passes back through create actions from nested pickers', function()
+    local pickers = require('forge.pickers')
+    local back = function() end
+
+    pickers.pr('open', fake_forge(), { back = back })
+    action_by_name('create').fn()
+    assert.same(back, pr_create_opts.back)
+
+    pickers.issue('open', fake_issue_forge(), { back = back })
+    action_by_name('create').fn()
+    assert.same(back, issue_create_opts.back)
   end)
 
   it('ignores stale PR responses after a refresh starts a newer fetch', function()

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -242,6 +242,36 @@ describe('review index', function()
     assert.equals('origin/main', captured.gdiff)
   end)
 
+  it('preserves back callbacks on the review files picker', function()
+    local back_calls = 0
+
+    review.start_session({
+      subject = {
+        kind = 'pr',
+        id = '42',
+        label = 'PR #42',
+        base_ref = 'origin/main',
+        head_ref = 'pr-42',
+      },
+      repo_root = '/repo',
+      back = function()
+        back_calls = back_calls + 1
+      end,
+    })
+
+    review.open_index()
+
+    vim.wait(100, function()
+      return captured.picker ~= nil
+    end)
+
+    assert.is_function(captured.picker.back)
+
+    captured.picker.back()
+
+    assert.equals(1, back_calls)
+  end)
+
   it('toggles the active file between patch and context modes', function()
     review.start_session({
       subject = {


### PR DESCRIPTION
## Problem

The initial Back support only covered some nested picker paths. Back could disappear on uncached streaming opens and was missing from other picker-to-picker flows like template selection and review file indexes.

## Solution

Pass Back through the streaming `pick_json` path and the remaining nested picker flows, including PR and issue template menus and the review files picker. Add regression coverage for uncached opens, create-template flows, and review index navigation so nested pickers keep Back consistently.
