### PR TITLE
fix(ci): leave completed log folds open

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -551,7 +551,7 @@ On GitHub, `<cr>` on a run opens a summary buffer showing all jobs with
 status, durations, and annotations. Press `<cr>` on a job line to open its
 full log. On GitLab and Codeberg, in-progress jobs open a live-tailing
 terminal (`glab ci trace`, `tea actions runs logs --follow`); completed
-jobs render in a buffer with highlighting and folds.
+jobs render in a buffer with highlighting and folds left open by default.
 
 In-progress views auto-refresh at the `ci.refresh` interval.
 

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -583,7 +583,7 @@ local function render(buf, parsed)
       for _, r in ipairs(ranges) do
         vim.cmd(r[1] .. ',' .. r[2] .. 'fold')
       end
-      vim.wo[0].foldlevel = 1
+      vim.wo[0].foldlevel = 99
     end)
   end
 end

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -576,3 +576,47 @@ describe('buffer reuse refreshes', function()
     assert.same({ '✓ new job (ID 2)' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
   end)
 end)
+
+describe('log folds', function()
+  local original_system
+
+  before_each(function()
+    original_system = vim.system
+  end)
+
+  after_each(function()
+    vim.system = original_system
+  end)
+
+  it('leaves completed log folds open by default', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = table.concat({
+          'build\tSetup\t2024-01-01T00:00:00Z hello',
+          'build\tSetup\t2024-01-01T00:00:01Z ##[group]Install',
+          'build\tSetup\t2024-01-01T00:00:02Z done',
+          'build\tSetup\t2024-01-01T00:00:03Z ##[endgroup]',
+        }, '\n'),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    log_mod.open({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      title = 'ci',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'build'
+    end)
+
+    assert.equals(99, vim.wo[0].foldlevel)
+    assert.equals(-1, vim.fn.foldclosed(1))
+    assert.equals(-1, vim.fn.foldclosed(2))
+    assert.equals(-1, vim.fn.foldclosed(3))
+  end)
+end)


### PR DESCRIPTION
## Problem

Completed CI log buffers were creating folds and then collapsing them immediately, which makes step output harder to read on first open.

## Solution

Keep the existing fold structure, but leave completed log buffers open by default. Add a regression spec for the default fold state and update the vimdoc wording to match.
