### PR TITLE
feat(target): parse Forge repo and revision addresses

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -18,6 +18,14 @@ local modifiers = {
   commit = { kind = 'flag', legacy = true },
 }
 
+local target_modifier_parsers = {
+  repo = 'resolve_repo',
+  rev = 'parse_rev',
+  target = 'parse_location',
+  head = 'parse_rev',
+  base = 'parse_rev',
+}
+
 local families = {
   {
     name = 'pr',
@@ -379,6 +387,20 @@ local function error_result(msg, opts)
   return nil, {
     code = opts.code,
     message = msg,
+  }
+end
+
+local function target_parse_opts()
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
+    return { resolve_repo = true }
+  end
+  local cfg = forge.config()
+  local targets = type(cfg) == 'table' and cfg.targets or nil
+  local aliases = type(targets) == 'table' and targets.aliases or nil
+  return {
+    resolve_repo = true,
+    aliases = type(aliases) == 'table' and aliases or {},
   }
 end
 
@@ -906,6 +928,20 @@ function M.parse(args, opts)
     local values = verb_values or allowed_values
     if type(value) == 'string' and values and not set_contains(values, value) then
       return error_result(('invalid value for %s: %s'):format(name, value))
+    end
+  end
+
+  command.parsed_modifiers = {}
+  local target = require('forge.target')
+  local parse_opts = target_parse_opts()
+  for name, value in pairs(command.modifiers) do
+    local parser_name = target_modifier_parsers[name]
+    if parser_name and type(value) == 'string' then
+      local parsed, err = target[parser_name](value, parse_opts)
+      if not parsed then
+        return error_result(err)
+      end
+      command.parsed_modifiers[name] = parsed
     end
   end
 

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -1,0 +1,268 @@
+local M = {}
+
+local function trim(text)
+  if type(text) ~= 'string' then
+    return nil
+  end
+  local value = vim.trim(text)
+  if value == '' then
+    return nil
+  end
+  return value
+end
+
+local function normalize_url(url)
+  local value = trim(url)
+  if not value then
+    return nil
+  end
+  local normalized = tostring(value)
+  normalized = normalized:gsub('%.git$', '')
+  normalized = normalized:gsub('^ssh://git@', 'https://')
+  normalized = normalized:gsub('^git@([^:]+):', 'https://%1/')
+  normalized = normalized:gsub('/+$', '')
+  normalized = normalized:gsub('#.*$', '')
+  normalized = normalized:gsub('%?.*$', '')
+  return normalized
+end
+
+local function split_url(url)
+  local normalized = normalize_url(url)
+  if not normalized then
+    return nil
+  end
+  local host, path = normalized:match('^https?://([^/]+)/(.+)$')
+  if not host or not path then
+    return nil
+  end
+  path = path:match('^(.-)/%-/') or path
+  path = path:gsub('/+$', '')
+  if path == '' then
+    return nil
+  end
+  return host, path
+end
+
+local function alias_map(opts)
+  return type(opts) == 'table' and type(opts.aliases) == 'table' and opts.aliases or {}
+end
+
+local function remote_url(name)
+  local result = vim.system({ 'git', 'remote', 'get-url', name }, { text = true }):wait()
+  if result.code ~= 0 then
+    return nil
+  end
+  return trim(result.stdout)
+end
+
+local function parse_range(fragment)
+  if fragment == nil then
+    return nil
+  end
+  local line = fragment:match('^L(%d+)$')
+  if line then
+    local value = tonumber(line)
+    return {
+      start_line = value,
+      end_line = value,
+    }
+  end
+  local start_line, end_line = fragment:match('^L(%d+)%-L(%d+)$')
+  if start_line and end_line then
+    return {
+      start_line = tonumber(start_line),
+      end_line = tonumber(end_line),
+    }
+  end
+  return nil, 'invalid range: ' .. fragment
+end
+
+function M.parse_repo(text)
+  local value = trim(text)
+  if not value then
+    return nil, 'empty repo address'
+  end
+  if value:find('@', 1, true) or value:find(':', 1, true) or value:find('#', 1, true) then
+    return nil, 'invalid repo address: ' .. value
+  end
+
+  local hosted = value
+  if value:match('^[^/]+%.[^/]+/.+$') then
+    hosted = 'https://' .. value
+  end
+  local host, slug = split_url(hosted)
+  if host and slug then
+    return {
+      kind = 'repo',
+      form = 'hosted',
+      text = value,
+      host = host,
+      slug = slug,
+    }
+  end
+
+  if value:match('^[^/%s]+/[^%s]+$') then
+    return {
+      kind = 'repo',
+      form = 'path',
+      text = value,
+      slug = value,
+    }
+  end
+
+  if value:match('^[%w_.%-]+$') then
+    return {
+      kind = 'repo',
+      form = 'symbolic',
+      text = value,
+      name = value,
+    }
+  end
+
+  return nil, 'invalid repo address: ' .. value
+end
+
+function M.resolve_repo(text, opts)
+  local value = trim(text)
+  if not value then
+    return nil, 'empty repo address'
+  end
+
+  local aliases = alias_map(opts)
+  local alias_target = aliases[value]
+  if type(alias_target) == 'string' and alias_target ~= '' then
+    local remote = alias_target:match('^remote:(.+)$')
+    if remote then
+      local resolved, err = M.resolve_repo(remote, {
+        aliases = {},
+      })
+      if not resolved then
+        return nil, err
+      end
+      resolved.via = 'alias'
+      resolved.alias = value
+      return resolved
+    end
+    local resolved, err = M.parse_repo(alias_target)
+    if not resolved then
+      return nil, err
+    end
+    resolved.via = 'alias'
+    resolved.alias = value
+    return resolved
+  end
+
+  local remote = remote_url(value)
+  if remote then
+    local host, slug = split_url(remote)
+    if not host or not slug then
+      return nil, 'invalid remote address: ' .. value
+    end
+    return {
+      kind = 'repo',
+      form = 'hosted',
+      text = value,
+      host = host,
+      slug = slug,
+      via = 'remote',
+      remote = value,
+    }
+  end
+
+  local parsed, err = M.parse_repo(value)
+  if not parsed then
+    return nil, err
+  end
+  if parsed.form == 'symbolic' then
+    return nil, 'unresolved repo address: ' .. value
+  end
+  parsed.via = 'explicit'
+  return parsed
+end
+
+function M.parse_rev(text, opts)
+  local value = trim(text)
+  if not value then
+    return nil, 'empty revision address'
+  end
+  if value:find(':', 1, true) or value:find('#', 1, true) then
+    return nil, 'invalid revision address: ' .. value
+  end
+
+  local repo_text
+  local rev
+  if value:sub(1, 1) == '@' then
+    rev = value:sub(2)
+  else
+    repo_text, rev = value:match('^(.-)@(.+)$')
+  end
+
+  if not rev or rev == '' then
+    return nil, 'invalid revision address: ' .. value
+  end
+
+  local parsed = {
+    kind = 'rev',
+    text = value,
+    rev = rev,
+  }
+
+  if repo_text and repo_text ~= '' then
+    local repo
+    local err
+    if opts and opts.resolve_repo then
+      repo, err = M.resolve_repo(repo_text, opts)
+    else
+      repo, err = M.parse_repo(repo_text)
+    end
+    if not repo then
+      return nil, err
+    end
+    parsed.repo = repo
+  end
+
+  return parsed
+end
+
+function M.parse_location(text, opts)
+  local value = trim(text)
+  if not value then
+    return nil, 'empty location address'
+  end
+
+  local body = value
+  local fragment = nil
+  local hash = value:find('#', 1, true)
+  if hash then
+    body = value:sub(1, hash - 1)
+    fragment = value:sub(hash + 1)
+  end
+
+  local prefix, path = body:match('^(.-):(.+)$')
+  if not prefix or not path or path == '' then
+    return nil, 'invalid location address: ' .. value
+  end
+
+  local rev, err = M.parse_rev(prefix, opts)
+  if not rev then
+    return nil, err
+  end
+
+  local range = nil
+  if fragment then
+    range, err = parse_range(fragment)
+    if not range then
+      return nil, err
+    end
+  end
+
+  return {
+    kind = 'location',
+    text = value,
+    rev = rev,
+    path = path,
+    range = range,
+  }
+end
+
+return M

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -60,6 +60,25 @@ describe('command schema', function()
     assert.same({ 'feature' }, ci.subjects)
   end)
 
+  it('attaches parsed target-bearing modifiers to normalized commands', function()
+    local create = assert(cmd.parse({
+      'pr',
+      'create',
+      'base=@main',
+      'head=github.com/barrettruth/forge.nvim@topic',
+    }))
+    local browse = assert(cmd.parse({
+      'browse',
+      'target=github.com/barrettruth/forge.nvim@main:README.md#L10-L20',
+    }))
+
+    assert.equals('main', create.parsed_modifiers.base.rev)
+    assert.equals('topic', create.parsed_modifiers.head.rev)
+    assert.equals('barrettruth/forge.nvim', create.parsed_modifiers.head.repo.slug)
+    assert.equals('README.md', browse.parsed_modifiers.target.path)
+    assert.same({ start_line = 10, end_line = 20 }, browse.parsed_modifiers.target.range)
+  end)
+
   it('tracks the intended bang matrix', function()
     assert.is_true(cmd.supports_bang('pr', 'close'))
     assert.is_true(cmd.supports_bang('issue', 'close'))

--- a/spec/target_spec.lua
+++ b/spec/target_spec.lua
@@ -1,0 +1,121 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('target parsing', function()
+  local old_system
+
+  before_each(function()
+    old_system = vim.system
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    package.loaded['forge.target'] = nil
+  end)
+
+  it('parses symbolic, path, and hosted repo addresses', function()
+    local target = require('forge.target')
+    local symbolic = assert(target.parse_repo('upstream'))
+    local path = assert(target.parse_repo('barrettruth/forge.nvim'))
+    local hosted = assert(target.parse_repo('github.com/barrettruth/forge.nvim'))
+
+    assert.equals('symbolic', symbolic.form)
+    assert.equals('upstream', symbolic.name)
+    assert.equals('path', path.form)
+    assert.equals('barrettruth/forge.nvim', path.slug)
+    assert.equals('hosted', hosted.form)
+    assert.equals('github.com', hosted.host)
+    assert.equals('barrettruth/forge.nvim', hosted.slug)
+  end)
+
+  it('parses revision addresses with optional repo prefixes', function()
+    local target = require('forge.target')
+    local short = assert(target.parse_rev('@main'))
+    local scoped = assert(target.parse_rev('upstream@topic'))
+
+    assert.equals('main', short.rev)
+    assert.is_nil(short.repo)
+    assert.equals('topic', scoped.rev)
+    assert.equals('symbolic', scoped.repo.form)
+    assert.equals('upstream', scoped.repo.name)
+  end)
+
+  it('parses location addresses with line ranges', function()
+    local target = require('forge.target')
+    local location = assert(target.parse_location('upstream@main:lua/forge/init.lua#L10-L40'))
+
+    assert.equals('main', location.rev.rev)
+    assert.equals('upstream', location.rev.repo.name)
+    assert.equals('lua/forge/init.lua', location.path)
+    assert.same({ start_line = 10, end_line = 40 }, location.range)
+  end)
+
+  it('resolves aliases before remotes', function()
+    vim.system = function(cmd)
+      if table.concat(cmd, ' ') == 'git remote get-url upstream' then
+        return {
+          wait = function()
+            return {
+              code = 0,
+              stdout = 'git@github.com:barrettruth/forge.nvim.git\n',
+            }
+          end,
+        }
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '' }
+        end,
+      }
+    end
+
+    local target = require('forge.target')
+    local resolved = assert(target.resolve_repo('upstream', {
+      aliases = {
+        upstream = 'github.com/example/override',
+      },
+    }))
+
+    assert.equals('alias', resolved.via)
+    assert.equals('github.com', resolved.host)
+    assert.equals('example/override', resolved.slug)
+  end)
+
+  it('resolves remotes when no alias matches', function()
+    vim.system = function(cmd)
+      if table.concat(cmd, ' ') == 'git remote get-url origin' then
+        return {
+          wait = function()
+            return {
+              code = 0,
+              stdout = 'git@gitlab.com:group/subgroup/project.git\n',
+            }
+          end,
+        }
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '' }
+        end,
+      }
+    end
+
+    local target = require('forge.target')
+    local resolved = assert(target.resolve_repo('origin'))
+
+    assert.equals('remote', resolved.via)
+    assert.equals('gitlab.com', resolved.host)
+    assert.equals('group/subgroup/project', resolved.slug)
+    assert.equals('origin', resolved.remote)
+  end)
+
+  it('rejects unresolved symbolic and malformed addresses', function()
+    local target = require('forge.target')
+    local _, unresolved = target.resolve_repo('missing')
+    local _, invalid_rev = target.parse_rev('main')
+    local _, invalid_location = target.parse_location('README.md#L10')
+
+    assert.equals('unresolved repo address: missing', unresolved)
+    assert.equals('invalid revision address: main', invalid_rev)
+    assert.equals('invalid location address: README.md#L10', invalid_location)
+  end)
+end)


### PR DESCRIPTION
## Problem

The normalized `:Forge` command layer still treats target-bearing modifiers like `repo=`, `rev=`, `target=`, `head=`, and `base=` as raw strings. That makes it impossible to carry explicit repo/revision/location intent through the command object cleanly.

## Solution

Add a dedicated `forge.target` module that parses repo, revision, and location addresses, including alias-first repo resolution order. Thread those parsed target objects into `forge.cmd.parse()` so normalized commands now expose typed target data under `parsed_modifiers`.