### PR TITLE
feat(target): define Forge target default policy

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -8,6 +8,7 @@ CONTENTS                                                 *forge.nvim-contents*
     `debug`...............................................|forge-config-debug|
     `split`...............................................|forge-config-split|
     `ci`.....................................................|forge-config-ci|
+    `targets`.........................................|forge-config-targets|
     `sources`...........................................|forge-config-sources|
     `contexts`.........................................|forge-config-contexts|
     `sections`.........................................|forge-config-sections|
@@ -19,6 +20,7 @@ CONTENTS                                                 *forge.nvim-contents*
     `display.limits`.............................|forge-config-display-limits|
     COMMANDS..........................................................|:Forge|
     `:Forge`..................................................|:Forge-no-args|
+    TARGET DEFAULTS AND OVERRIDES......................|forge-target-defaults|
     `:Forge pr` [{flags}]..........................................|:Forge-pr|
     `:Forge pr create` [{flags}]............................|:Forge-pr-create|
     `:Forge pr checkout` {num}............................|:Forge-pr-checkout|
@@ -119,6 +121,37 @@ Top-level keys: ~
 
   `ci.split`        `string?`  (default `nil`, inherits from `split`)
     Split direction for CI views. Overrides the global `split`.
+
+`targets`                                             *forge-config-targets*
+  `targets.aliases`      `table<string, string>`  (default `{}`)
+    Symbolic target aliases used by the normalized `:Forge` command
+    modifiers (`repo=`, repo-bearing `rev=`, `target=`, `head=`, and
+    `base=`). Repo addresses resolve in this order: configured alias, git
+    remote name, explicit hosted repo path.
+
+  `targets.default_repo` `string?`  (default `nil`)
+    Preferred collaboration repo for commands that omit an explicit repo
+    target. Values can be aliases, git remotes, `owner/repo`, or
+    `host/owner/repo`. When unset, forge.nvim falls back to `upstream`,
+    then `origin`.
+
+  `targets.ci.repo`      `string`  (default `"current"`)
+    Default repo policy for `:Forge ci` when no explicit repo is given.
+    One of `"current"` or `"collaboration"`.
+
+  Example: >lua
+      vim.g.forge = {
+        targets = {
+          default_repo = 'upstream',
+          aliases = {
+            work = 'github.com/barrettruth/forge.nvim',
+          },
+          ci = {
+            repo = 'collaboration',
+          },
+        },
+      }
+<
 
 `sources`                                               *forge-config-sources*
   `table<string, { hosts: string[] }>`  (default `{}`)
@@ -290,14 +323,34 @@ COMMANDS                                                              *:Forge*
 `:Forge`                                                      *:Forge-no-args*
     Open the root workflow surface (|forge-picker|).
 
+TARGET DEFAULTS AND OVERRIDES                            *forge-target-defaults*
+    Supported verbs accept explicit target modifiers such as `repo=...`,
+    `rev=...`, `target=...`, `head=...`, and `base=...`. Explicit target
+    modifiers override default policy.
+
+    Default policy:
+    - collaboration repo = `targets.default_repo`, else `upstream`, else
+      `origin`
+    - `:Forge pr`, `:Forge issue`, and `:Forge release` default to the
+      collaboration repo
+    - `:Forge ci` defaults to the current branch and uses `targets.ci.repo`
+      for its repo policy
+    - `:Forge pr create` defaults `head=` to the current branch push
+      context and `base=` to the collaboration repo default branch
+    - `:Forge browse` defaults to the current file/line selection on the
+      current branch in the current repo
+
 `:Forge pr` [{flags}]                                              *:Forge-pr*
-    Open the PR list picker. Defaults to open PRs.
+    Open the PR list picker for the collaboration repo. Defaults to open
+    PRs.
     `--state=open`     Show open PRs (default).
     `--state=closed`   Show closed PRs.
     `--state=all`      Show all PRs.
 
 `:Forge pr create` [{flags}]                                *:Forge-pr-create*
     Create a new PR.
+    Default targets: `head=` is the current branch push context and
+    `base=` is the collaboration repo default branch.
     (no flags)         Open the compose buffer (|forge-compose|).
     `--draft`          Open compose buffer with draft pre-set.
     `--fill`           Create instantly from commits (skip compose).
@@ -327,10 +380,11 @@ COMMANDS                                                              *:Forge*
     reopen, draft toggle).
 
 `:Forge issue` [{flags}]                                        *:Forge-issue*
-    Open the issue list picker. Defaults to all issues.
-    `--state=open`     Show open issues.
+    Open the issue list picker for the collaboration repo. Defaults to
+    open issues.
+    `--state=open`     Show open issues (default).
     `--state=closed`   Show closed issues.
-    `--state=all`      Show all issues (default).
+    `--state=all`      Show all issues.
 
 `:Forge issue browse` {num}                              *:Forge-issue-browse*
     Open issue `{num}` in the browser.
@@ -347,7 +401,8 @@ COMMANDS                                                              *:Forge*
     `--web`            Open the forge's web create-issue page.
 
 `:Forge ci` [{flags}]                                              *:Forge-ci*
-    Open the CI runs picker. Defaults to current branch.
+    Open the CI runs picker. Defaults to the current branch in the repo
+    selected by `targets.ci.repo`.
     `--all`            Show runs for all branches.
 
 `:Forge branches`                                        *:Forge-branches*
@@ -361,7 +416,8 @@ COMMANDS                                                              *:Forge*
     Open the worktree picker (|forge-picker-worktree|).
 
 `:Forge release`                                              *:Forge-release*
-    Open the release list picker (|forge-picker-release|).
+    Open the release list picker for the collaboration repo
+    (|forge-picker-release|).
 
 `:Forge release browse` {tag}                          *:Forge-release-browse*
     Open release `{tag}` in the browser.
@@ -370,7 +426,9 @@ COMMANDS                                                              *:Forge*
     Delete release `{tag}` (with confirmation prompt).
 
 `:Forge browse` [{flags}]                                      *:Forge-browse*
-    Open the current file location on the forge.
+    Open a browser target on the forge. Without explicit target modifiers,
+    this defaults to the current file location on the current branch in
+    the current repo.
     `--root`           Open the repository root page.
     `--commit`         Open the current HEAD commit.
     (no flags)         Open the current file and line(s) on the current

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -393,15 +393,117 @@ end
 local function target_parse_opts()
   local ok, forge = pcall(require, 'forge')
   if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
-    return { resolve_repo = true }
+    return {
+      resolve_repo = true,
+      ci_repo = 'current',
+    }
   end
   local cfg = forge.config()
   local targets = type(cfg) == 'table' and cfg.targets or nil
   local aliases = type(targets) == 'table' and targets.aliases or nil
+  local default_repo = type(targets) == 'table' and targets.default_repo or nil
+  local ci = type(targets) == 'table' and targets.ci or nil
+  local ci_repo = type(ci) == 'table' and ci.repo or nil
   return {
     resolve_repo = true,
     aliases = type(aliases) == 'table' and aliases or {},
+    default_repo = type(default_repo) == 'string' and default_repo or nil,
+    ci_repo = ci_repo == 'collaboration' and 'collaboration' or 'current',
   }
+end
+
+local function repo_target(value)
+  if type(value) ~= 'table' then
+    return nil
+  end
+  if value.kind == 'repo' then
+    return value
+  end
+  if value.kind == 'rev' then
+    return value.repo
+  end
+  if value.kind == 'location' and type(value.rev) == 'table' then
+    return value.rev.repo
+  end
+  return value.repo
+end
+
+local function default_policy(command, parse_opts)
+  local policy = {}
+  if
+    not command.parsed_modifiers.repo
+    and (
+      (command.family == 'pr' and (command.name == 'list' or command.name == 'create'))
+      or (command.name == 'list' and (command.family == 'issue' or command.family == 'release'))
+    )
+  then
+    policy.repo = 'collaboration'
+  end
+  if command.family == 'pr' and command.name == 'create' then
+    if not command.parsed_modifiers.head then
+      policy.head = 'current_push_context'
+    end
+    if not command.parsed_modifiers.base then
+      policy.base = 'collaboration_default_branch'
+    end
+  elseif command.family == 'ci' and command.name == 'list' then
+    if
+      not repo_target(command.parsed_modifiers.target)
+      and not repo_target(command.parsed_modifiers.rev)
+      and not command.parsed_modifiers.repo
+    then
+      policy.repo = parse_opts.ci_repo
+    end
+    if
+      command.modifiers.all ~= true
+      and not command.parsed_modifiers.target
+      and not command.parsed_modifiers.rev
+      and command.subjects[1] == nil
+    then
+      policy.rev = 'current_branch'
+    end
+  elseif command.family == 'browse' and command.name == 'open' then
+    if
+      not repo_target(command.parsed_modifiers.target)
+      and not repo_target(command.parsed_modifiers.rev)
+      and not command.parsed_modifiers.repo
+    then
+      policy.repo = 'current'
+    end
+    if not command.parsed_modifiers.target and not command.parsed_modifiers.rev then
+      policy.rev = 'current_branch'
+    end
+    if not command.parsed_modifiers.target then
+      policy.target = 'contextual'
+    end
+  end
+  return next(policy) and policy or {}
+end
+
+local function default_targets(command, parse_opts)
+  local target = require('forge.target')
+  local policy = default_policy(command, parse_opts)
+  local defaults = {}
+  local repo = nil
+  if policy.repo == 'collaboration' then
+    repo = target.collaboration_repo(parse_opts)
+  elseif policy.repo == 'current' then
+    repo = target.current_repo(parse_opts)
+  end
+  if repo then
+    defaults.repo = repo
+  end
+  if policy.rev == 'current_branch' then
+    defaults.rev = target.branch_rev(target.current_branch(), repo)
+  end
+  if policy.head == 'current_push_context' then
+    defaults.head = target.push_rev(parse_opts)
+  end
+  if policy.base == 'collaboration_default_branch' then
+    defaults.base =
+      target.default_branch_rev(defaults.repo or target.collaboration_repo(parse_opts))
+  end
+  return policy, defaults
 end
 
 local function require_git_or_warn()
@@ -423,9 +525,44 @@ local function require_forge_or_warn()
   return f, forge_mod
 end
 
-local function resolve_scope_modifier(command)
-  local _ = command
-  return nil
+local function resolve_scope_modifier(command, forge_name)
+  local target = require('forge.target')
+  local repo = repo_target(command.parsed_modifiers.target)
+    or repo_target(command.parsed_modifiers.rev)
+    or repo_target(command.parsed_modifiers.base)
+    or repo_target(command.parsed_modifiers.head)
+    or repo_target(command.parsed_modifiers.repo)
+    or repo_target(command.default_targets.target)
+    or repo_target(command.default_targets.rev)
+    or repo_target(command.default_targets.base)
+    or repo_target(command.default_targets.head)
+    or repo_target(command.default_targets.repo)
+  return target.repo_scope(repo, forge_name)
+end
+
+local function effective_rev(command)
+  return command.parsed_modifiers.target and command.parsed_modifiers.target.rev
+    or command.parsed_modifiers.rev
+    or command.default_targets.rev
+end
+
+local function location_arg(location)
+  if
+    type(location) ~= 'table'
+    or location.kind ~= 'location'
+    or not location.path
+    or location.path == ''
+  then
+    return nil
+  end
+  local range = location.range
+  if not range then
+    return location.path
+  end
+  if range.start_line == range.end_line then
+    return ('%s:%d'):format(location.path, range.start_line)
+  end
+  return ('%s:%d-%d'):format(location.path, range.start_line, range.end_line)
 end
 
 local function dispatch_pr(command)
@@ -438,12 +575,13 @@ local function dispatch_pr(command)
   end
   local pickers = require('forge.pickers')
   local num = command.subjects[1]
+  local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
     local state = command.modifiers.state
     if state then
-      forge_mod.open('prs.' .. state)
+      forge_mod.open('prs.' .. state, { scope = scope })
     else
-      forge_mod.open('prs')
+      forge_mod.open('prs', { scope = scope })
     end
     return
   end
@@ -452,7 +590,7 @@ local function dispatch_pr(command)
       draft = command.modifiers.draft == true,
       instant = command.modifiers.fill == true,
       web = command.modifiers.web == true,
-      scope = resolve_scope_modifier(command),
+      scope = scope,
     })
     return
   end
@@ -461,42 +599,42 @@ local function dispatch_pr(command)
     return
   end
   if command.name == 'checkout' then
-    pickers.pr_actions(f, num).checkout()
+    pickers.pr_actions(f, { num = num, scope = scope }).checkout()
     return
   end
   if command.name == 'review' then
-    pickers.pr_actions(f, num).review()
+    pickers.pr_actions(f, { num = num, scope = scope }).review()
     return
   end
   if command.name == 'worktree' then
-    pickers.pr_actions(f, num).worktree()
+    pickers.pr_actions(f, { num = num, scope = scope }).worktree()
     return
   end
   if command.name == 'ci' then
     if f.capabilities.per_pr_checks then
-      pickers.checks(f, num)
+      pickers.checks(f, num, nil, nil, { scope = scope })
     else
       require('forge.logger').debug(
         ('per-%s checks unavailable on %s, showing repo CI'):format(f.labels.pr_one, f.name)
       )
-      pickers.ci(f)
+      pickers.ci(f, nil, nil, { scope = scope })
     end
     return
   end
   if command.name == 'browse' then
-    f:view_web(f.kinds.pr, num)
+    f:view_web(f.kinds.pr, num, scope)
     return
   end
   if command.name == 'manage' then
-    pickers.pr_manage(f, num)
+    pickers.pr_manage(f, { num = num, scope = scope })
     return
   end
   if command.name == 'close' then
-    pickers.pr_close(f, num)
+    pickers.pr_close(f, num, scope)
     return
   end
   if command.name == 'reopen' then
-    pickers.pr_reopen(f, num)
+    pickers.pr_reopen(f, num, scope)
     return
   end
   warn(('unsupported pr action: %s'):format(command.name))
@@ -512,12 +650,13 @@ local function dispatch_issue(command)
   end
   local pickers = require('forge.pickers')
   local num = command.subjects[1]
+  local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
     local state = command.modifiers.state
     if state then
-      forge_mod.open('issues.' .. state)
+      forge_mod.open('issues.' .. state, { scope = scope })
     else
-      forge_mod.open('issues')
+      forge_mod.open('issues', { scope = scope })
     end
     return
   end
@@ -527,20 +666,20 @@ local function dispatch_issue(command)
       web = command.modifiers.web == true,
       blank = command.modifiers.blank == true,
       template = template ~= true and template or nil,
-      scope = resolve_scope_modifier(command),
+      scope = scope,
     })
     return
   end
   if command.name == 'browse' then
-    f:view_web(f.kinds.issue, num)
+    f:view_web(f.kinds.issue, num, scope)
     return
   end
   if command.name == 'close' then
-    pickers.issue_close(f, num)
+    pickers.issue_close(f, num, scope)
     return
   end
   if command.name == 'reopen' then
-    pickers.issue_reopen(f, num)
+    pickers.issue_reopen(f, num, scope)
     return
   end
   warn(('unsupported issue action: %s'):format(command.name))
@@ -554,18 +693,20 @@ local function dispatch_ci(command)
   if not f then
     return
   end
+  local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
     local branch = nil
     if command.modifiers.all ~= true then
-      branch = command.modifiers.rev or command.subjects[1]
-      if branch == nil or branch == '' then
-        branch = vim.trim(vim.fn.system('git branch --show-current'))
-        if branch == '' then
-          branch = nil
-        end
-      end
+      local rev = command.parsed_modifiers.target and command.parsed_modifiers.target.rev
+        or command.parsed_modifiers.rev
+        or command.subjects[1] and { rev = command.subjects[1] }
+        or command.default_targets.rev
+      branch = rev and rev.rev or nil
     end
-    forge_mod.open(command.modifiers.all and 'ci.all' or 'ci.current_branch', { branch = branch })
+    forge_mod.open(command.modifiers.all and 'ci.all' or 'ci.current_branch', {
+      branch = branch,
+      scope = scope,
+    })
     return
   end
   warn(('unsupported ci action: %s'):format(command.name))
@@ -580,23 +721,24 @@ local function dispatch_release(command)
     return
   end
   local tag = command.subjects[1]
+  local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
     local state = command.modifiers.state
     if state then
-      forge_mod.open('releases.' .. state)
+      forge_mod.open('releases.' .. state, { scope = scope })
     else
-      forge_mod.open('releases')
+      forge_mod.open('releases', { scope = scope })
     end
     return
   end
   if command.name == 'browse' then
-    f:browse_release(tag)
+    f:browse_release(tag, scope)
     return
   end
   if command.name == 'delete' then
     local function do_delete()
       require('forge.logger').info('deleting release ' .. tag .. '...')
-      vim.system(f:delete_release_cmd(tag), { text = true }, function(result)
+      vim.system(f:delete_release_cmd(tag, scope), { text = true }, function(result)
         vim.schedule(function()
           if result.code == 0 then
             require('forge.logger').info('deleted release ' .. tag)
@@ -629,12 +771,29 @@ local function dispatch_browse(command)
   if not f then
     return
   end
+  local scope = resolve_scope_modifier(command, f.name)
   if command.modifiers.commit then
-    forge_mod.open('browse.commit')
+    forge_mod.open('browse.commit', { scope = scope })
   elseif command.modifiers.root then
-    forge_mod.open('browse.branch')
+    forge_mod.open('browse.branch', {
+      scope = scope,
+      branch = effective_rev(command) and effective_rev(command).rev or nil,
+    })
   else
-    forge_mod.open('browse.contextual')
+    local location = command.parsed_modifiers.target
+    if location then
+      local loc = location_arg(location)
+      if loc then
+        f:browse(loc, location.rev.rev, scope)
+        return
+      end
+    end
+    local rev = effective_rev(command)
+    if rev and rev.rev then
+      f:browse(require('forge').file_loc(), rev.rev, scope)
+      return
+    end
+    forge_mod.open('browse.contextual', { scope = scope })
   end
 end
 
@@ -944,6 +1103,8 @@ function M.parse(args, opts)
       command.parsed_modifiers[name] = parsed
     end
   end
+
+  command.default_policy, command.default_targets = default_targets(command, parse_opts)
 
   return command
 end

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -114,6 +114,12 @@ local DEFAULTS = {
   debug = false,
   split = 'horizontal',
   ci = { lines = 1000, refresh = 5 },
+  targets = {
+    aliases = {},
+    ci = {
+      repo = 'current',
+    },
+  },
   sources = {},
   contexts = {
     current = true,
@@ -314,10 +320,22 @@ function M.config()
   vim.validate('forge.ci', cfg.ci, 'table')
   vim.validate('forge.ci.lines', cfg.ci.lines, 'number')
   vim.validate('forge.ci.refresh', cfg.ci.refresh, 'number')
+  vim.validate('forge.targets', cfg.targets, 'table')
   if cfg.ci.split ~= nil then
     vim.validate('forge.ci.split', cfg.ci.split, function(v)
       return v == 'horizontal' or v == 'vertical'
     end, "'horizontal' or 'vertical'")
+  end
+  vim.validate('forge.targets.aliases', cfg.targets.aliases, 'table')
+  if cfg.targets.default_repo ~= nil then
+    vim.validate('forge.targets.default_repo', cfg.targets.default_repo, 'string')
+  end
+  local target_ci = cfg.targets.ci or {}
+  vim.validate('forge.targets.ci', target_ci, 'table')
+  if target_ci.repo ~= nil then
+    vim.validate('forge.targets.ci.repo', target_ci.repo, function(v)
+      return v == 'current' or v == 'collaboration'
+    end, "'current' or 'collaboration'")
   end
 
   vim.validate('forge.display.icons', cfg.display.icons, 'table')
@@ -440,6 +458,10 @@ function M.config()
     if source.hosts ~= nil then
       vim.validate('forge.sources.' .. name .. '.hosts', source.hosts, 'table')
     end
+  end
+
+  for name, target in pairs(cfg.targets.aliases) do
+    vim.validate('forge.targets.aliases.' .. name, target, 'string')
   end
 
   for name, enabled in pairs(cfg.contexts) do

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -42,43 +42,43 @@ local function route_handlers()
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.pr('all', ctx.forge, { back = opts.back })
+      pickers.pr('all', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['prs.open'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.pr('open', ctx.forge, { back = opts.back })
+      pickers.pr('open', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['prs.closed'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.pr('closed', ctx.forge, { back = opts.back })
+      pickers.pr('closed', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['issues.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.issue('all', ctx.forge, { back = opts.back })
+      pickers.issue('all', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['issues.open'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.issue('open', ctx.forge, { back = opts.back })
+      pickers.issue('open', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['issues.closed'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.issue('closed', ctx.forge, { back = opts.back })
+      pickers.issue('closed', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['ci.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.ci(ctx.forge, nil, nil, { back = opts.back })
+      pickers.ci(ctx.forge, nil, nil, { back = opts.back, scope = opts.scope })
     end,
     ['ci.current_branch'] = function(ctx, opts)
       if not ctx.forge then
@@ -88,7 +88,7 @@ local function route_handlers()
       if branch == nil or branch == '' then
         branch = ctx.branch ~= '' and ctx.branch or nil
       end
-      pickers.ci(ctx.forge, branch, nil, { back = opts.back })
+      pickers.ci(ctx.forge, branch, nil, { back = opts.back, scope = opts.scope })
     end,
     ['branches.local'] = function(ctx, opts)
       pickers.branches(ctx, { back = opts.back })
@@ -112,9 +112,9 @@ local function route_handlers()
         return false, err
       end
       if ctx.has_file and ctx.loc then
-        ctx.forge:browse(ctx.loc, branch)
+        ctx.forge:browse(ctx.loc, branch, opts.scope)
       else
-        ctx.forge:browse_branch(branch)
+        ctx.forge:browse_branch(branch, opts.scope)
       end
     end,
     ['browse.branch'] = function(ctx, opts)
@@ -125,7 +125,7 @@ local function route_handlers()
       if not branch then
         return false, err
       end
-      ctx.forge:browse_branch(branch)
+      ctx.forge:browse_branch(branch, opts.scope)
     end,
     ['browse.commit'] = function(ctx, opts)
       if not ctx.forge then
@@ -138,25 +138,25 @@ local function route_handlers()
       if sha == '' then
         return false, 'detached HEAD'
       end
-      ctx.forge:browse_commit(sha)
+      ctx.forge:browse_commit(sha, opts.scope)
     end,
     ['releases.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.release('all', ctx.forge, { back = opts.back })
+      pickers.release('all', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['releases.draft'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.release('draft', ctx.forge, { back = opts.back })
+      pickers.release('draft', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['releases.prerelease'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
-      pickers.release('prerelease', ctx.forge, { back = opts.back })
+      pickers.release('prerelease', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
   }
 end

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+local default_hosts = {
+  github = 'github.com',
+  gitlab = 'gitlab.com',
+  codeberg = 'codeberg.org',
+}
+
 local function trim(text)
   if type(text) ~= 'string' then
     return nil
@@ -47,12 +53,50 @@ local function alias_map(opts)
   return type(opts) == 'table' and type(opts.aliases) == 'table' and opts.aliases or {}
 end
 
-local function remote_url(name)
-  local result = vim.system({ 'git', 'remote', 'get-url', name }, { text = true }):wait()
+local function shell_text(cmd)
+  local result = vim.system(cmd, { text = true }):wait()
   if result.code ~= 0 then
     return nil
   end
   return trim(result.stdout)
+end
+
+local function remote_url(name)
+  return shell_text({ 'git', 'remote', 'get-url', name })
+end
+
+local function preferred_remote_name()
+  if remote_url('origin') then
+    return 'origin'
+  end
+  local remotes = shell_text({ 'git', 'remote' })
+  if not remotes then
+    return nil
+  end
+  return vim.split(remotes, '\n', { plain = true, trimempty = true })[1]
+end
+
+local function push_remote_name(branch)
+  local value = trim(branch)
+  if not value then
+    return preferred_remote_name()
+  end
+  local branch_remote = shell_text({ 'git', 'config', 'branch.' .. value .. '.pushRemote' })
+  if branch_remote then
+    return branch_remote
+  end
+  local push_default = shell_text({ 'git', 'config', 'remote.pushDefault' })
+  if push_default then
+    return push_default
+  end
+  local upstream = shell_text({ 'git', 'rev-parse', '--abbrev-ref', value .. '@{upstream}' })
+  if upstream then
+    local remote = upstream:match('^([^/]+)/')
+    if remote then
+      return remote
+    end
+  end
+  return preferred_remote_name()
 end
 
 local function parse_range(fragment)
@@ -180,6 +224,92 @@ function M.resolve_repo(text, opts)
   return parsed
 end
 
+function M.current_branch()
+  return shell_text({ 'git', 'branch', '--show-current' })
+end
+
+function M.current_repo(opts)
+  local remote = preferred_remote_name()
+  if not remote then
+    return nil
+  end
+  return M.resolve_repo(remote, opts)
+end
+
+function M.push_repo(opts)
+  local branch = M.current_branch()
+  local remote = push_remote_name(branch)
+  if not remote then
+    return nil
+  end
+  return M.resolve_repo(remote, opts)
+end
+
+function M.collaboration_repo(opts)
+  local configured = type(opts) == 'table' and trim(opts.default_repo) or nil
+  if configured then
+    local resolved = M.resolve_repo(configured, opts)
+    if resolved then
+      return resolved
+    end
+  end
+  for _, remote in ipairs({ 'upstream', 'origin' }) do
+    local resolved = M.resolve_repo(remote, opts)
+    if resolved then
+      return resolved
+    end
+  end
+  return nil
+end
+
+function M.branch_rev(branch, repo)
+  local value = trim(branch)
+  if not value then
+    return nil
+  end
+  local rev = {
+    kind = 'rev',
+    text = '@' .. value,
+    rev = value,
+  }
+  if repo then
+    rev.repo = repo
+  end
+  return rev
+end
+
+function M.default_branch_rev(repo)
+  if not repo then
+    return nil
+  end
+  return {
+    kind = 'rev',
+    text = '',
+    repo = repo,
+    default_branch = true,
+  }
+end
+
+function M.current_rev(opts)
+  return M.branch_rev(M.current_branch(), M.current_repo(opts))
+end
+
+function M.ci_rev(opts)
+  local repo = type(opts) == 'table'
+      and opts.ci_repo == 'collaboration'
+      and M.collaboration_repo(opts)
+    or M.current_repo(opts)
+  return M.branch_rev(M.current_branch(), repo)
+end
+
+function M.push_rev(opts)
+  return M.branch_rev(M.current_branch(), M.push_repo(opts))
+end
+
+function M.collaboration_default_branch(opts)
+  return M.default_branch_rev(M.collaboration_repo(opts))
+end
+
 function M.parse_rev(text, opts)
   local value = trim(text)
   if not value then
@@ -263,6 +393,26 @@ function M.parse_location(text, opts)
     path = path,
     range = range,
   }
+end
+
+function M.repo_scope(repo, forge_name)
+  if type(repo) ~= 'table' then
+    return nil
+  end
+  local host = repo.host
+  local slug = repo.slug
+  if repo.form == 'path' then
+    local current = nil
+    local ok, forge = pcall(require, 'forge')
+    if ok and type(forge) == 'table' and type(forge.current_scope) == 'function' then
+      current = forge.current_scope(forge_name)
+    end
+    host = current and current.host or default_hosts[forge_name]
+  end
+  if not host or not slug then
+    return nil
+  end
+  return require('forge.scope').from_url(forge_name, ('https://%s/%s'):format(host, slug))
 end
 
 return M

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -2,6 +2,69 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 describe('command schema', function()
   local cmd = require('forge.cmd')
+  local old_system
+  local old_preload
+
+  before_each(function()
+    old_system = vim.system
+    old_preload = package.preload['forge']
+
+    vim.system = function(cmdline)
+      local key = table.concat(cmdline, ' ')
+      local result = {
+        code = 1,
+        stdout = '',
+      }
+      if key == 'git remote get-url origin' then
+        result = { code = 0, stdout = 'git@github.com:owner/current.git\n' }
+      elseif key == 'git remote get-url upstream' then
+        result = { code = 0, stdout = 'git@github.com:owner/upstream.git\n' }
+      elseif key == 'git remote' then
+        result = { code = 0, stdout = 'origin\nupstream\n' }
+      elseif key == 'git branch --show-current' then
+        result = { code = 0, stdout = 'feature\n' }
+      elseif key == 'git config branch.feature.pushRemote' then
+        result = { code = 0, stdout = 'origin\n' }
+      elseif key == 'git config remote.pushDefault' then
+        result = { code = 1, stdout = '' }
+      elseif key == 'git rev-parse --abbrev-ref feature@{upstream}' then
+        result = { code = 0, stdout = 'origin/feature\n' }
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            targets = {
+              default_repo = 'collab',
+              aliases = {
+                collab = 'remote:upstream',
+              },
+              ci = {
+                repo = 'collaboration',
+              },
+            },
+          }
+        end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.target'] = nil
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    package.preload['forge'] = old_preload
+    package.loaded['forge'] = nil
+    package.loaded['forge.target'] = nil
+  end)
 
   it('lists canonical and local command families in order', function()
     assert.same({
@@ -77,6 +140,37 @@ describe('command schema', function()
     assert.equals('barrettruth/forge.nvim', create.parsed_modifiers.head.repo.slug)
     assert.equals('README.md', browse.parsed_modifiers.target.path)
     assert.same({ start_line = 10, end_line = 20 }, browse.parsed_modifiers.target.range)
+  end)
+
+  it('attaches default target policy for omitted addresses', function()
+    local pr = assert(cmd.parse({ 'pr' }))
+    local create = assert(cmd.parse({ 'pr', 'create' }))
+    local ci = assert(cmd.parse({ 'ci' }))
+    local browse = assert(cmd.parse({ 'browse' }))
+
+    assert.same({ repo = 'collaboration' }, pr.default_policy)
+    assert.equals('owner/upstream', pr.default_targets.repo.slug)
+
+    assert.same({
+      repo = 'collaboration',
+      head = 'current_push_context',
+      base = 'collaboration_default_branch',
+    }, create.default_policy)
+    assert.equals('feature', create.default_targets.head.rev)
+    assert.equals('owner/current', create.default_targets.head.repo.slug)
+    assert.is_true(create.default_targets.base.default_branch)
+    assert.equals('owner/upstream', create.default_targets.base.repo.slug)
+
+    assert.same({ repo = 'collaboration', rev = 'current_branch' }, ci.default_policy)
+    assert.equals('feature', ci.default_targets.rev.rev)
+    assert.equals('owner/upstream', ci.default_targets.rev.repo.slug)
+
+    assert.same(
+      { repo = 'current', rev = 'current_branch', target = 'contextual' },
+      browse.default_policy
+    )
+    assert.equals('feature', browse.default_targets.rev.rev)
+    assert.equals('owner/current', browse.default_targets.rev.repo.slug)
   end)
 
   it('tracks the intended bang matrix', function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -4,16 +4,19 @@ describe(':Forge command', function()
   local captured
   local old_preload
   local old_systemlist
+  local old_system
 
   before_each(function()
     captured = {
       opens = {},
       pr_action_num = nil,
+      pr_action_scope = nil,
       reviews = {},
       review_actions = {},
       warnings = {},
       closed_prs = {},
       closed_issues = {},
+      browse_calls = {},
     }
     old_preload = {
       ['forge'] = package.preload['forge'],
@@ -22,6 +25,37 @@ describe(':Forge command', function()
       ['forge.review'] = package.preload['forge.review'],
     }
     old_systemlist = vim.fn.systemlist
+    old_system = vim.system
+
+    vim.system = function(cmd, _, cb)
+      local key = table.concat(cmd, ' ')
+      local result = {
+        code = 1,
+        stdout = '',
+        stderr = '',
+      }
+      if key == 'git remote get-url origin' then
+        result = { code = 0, stdout = 'git@github.com:owner/current.git\n', stderr = '' }
+      elseif key == 'git remote get-url upstream' then
+        result = { code = 0, stdout = 'git@github.com:owner/upstream.git\n', stderr = '' }
+      elseif key == 'git remote' then
+        result = { code = 0, stdout = 'origin\nupstream\n', stderr = '' }
+      elseif key == 'git branch --show-current' then
+        result = { code = 0, stdout = 'main\n', stderr = '' }
+      elseif key == 'git config branch.main.pushRemote' then
+        result = { code = 1, stdout = '', stderr = '' }
+      elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
+        result = { code = 0, stdout = 'origin/main\n', stderr = '' }
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
 
     package.preload['forge.logger'] = function()
       return {
@@ -38,6 +72,7 @@ describe(':Forge command', function()
       return {
         detect = function()
           return {
+            name = 'github',
             capabilities = {
               per_pr_checks = true,
             },
@@ -48,6 +83,26 @@ describe(':Forge command', function()
               pr = 'pr',
               issue = 'issue',
             },
+            view_web = function(_, kind, num, scope)
+              captured.view_web = {
+                kind = kind,
+                num = num,
+                scope = scope,
+              }
+            end,
+            browse = function(_, loc, branch, scope)
+              table.insert(captured.browse_calls, {
+                loc = loc,
+                branch = branch,
+                scope = scope,
+              })
+            end,
+            browse_release = function(_, tag, scope)
+              captured.release_browse = {
+                tag = tag,
+                scope = scope,
+              }
+            end,
           }
         end,
         current_context = function()
@@ -69,6 +124,9 @@ describe(':Forge command', function()
         clear_cache = function()
           captured.cleared = true
         end,
+        file_loc = function()
+          return 'lua/forge/init.lua:10'
+        end,
         open = function(route, opts)
           table.insert(captured.opens, { route = route, opts = opts })
         end,
@@ -80,11 +138,13 @@ describe(':Forge command', function()
 
     package.preload['forge.pickers'] = function()
       return {
-        pr_actions = function(_, num)
-          captured.pr_action_num = num
+        pr_actions = function(_, pr)
+          local ref = type(pr) == 'table' and pr or { num = pr }
+          captured.pr_action_num = ref.num
+          captured.pr_action_scope = ref.scope
           return {
             review = function()
-              table.insert(captured.reviews, num)
+              table.insert(captured.reviews, ref.num)
             end,
             checkout = function() end,
             worktree = function() end,
@@ -157,6 +217,7 @@ describe(':Forge command', function()
   end)
 
   after_each(function()
+    vim.system = old_system
     vim.fn.systemlist = old_systemlist
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
@@ -176,6 +237,7 @@ describe(':Forge command', function()
     vim.cmd('Forge pr review 42')
 
     assert.equals('42', captured.pr_action_num)
+    assert.is_nil(captured.pr_action_scope)
     assert.same({ '42' }, captured.reviews)
   end)
 
@@ -183,6 +245,7 @@ describe(':Forge command', function()
     vim.cmd('Forge pr diff 7')
 
     assert.equals('7', captured.pr_action_num)
+    assert.is_nil(captured.pr_action_scope)
     assert.same({ '7' }, captured.reviews)
   end)
 
@@ -219,14 +282,30 @@ describe(':Forge command', function()
     assert.is_nil(captured.opens[3].opts)
   end)
 
-  it('dispatches browse subcommands through the route aliases', function()
+  it('uses explicit browse defaults for omitted targets', function()
     vim.cmd('Forge browse')
+
+    assert.same({
+      loc = 'lua/forge/init.lua:10',
+      branch = 'main',
+      scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'current',
+        slug = 'owner/current',
+        repo_arg = 'owner/current',
+        web_url = 'https://github.com/owner/current',
+      },
+    }, captured.browse_calls[1])
+  end)
+
+  it('dispatches browse subcommands through the route aliases', function()
     vim.cmd('Forge browse --root')
     vim.cmd('Forge browse --commit')
 
-    assert.equals('browse.contextual', captured.opens[1].route)
-    assert.equals('browse.branch', captured.opens[2].route)
-    assert.equals('browse.commit', captured.opens[3].route)
+    assert.equals('browse.branch', captured.opens[1].route)
+    assert.equals('browse.commit', captured.opens[2].route)
   end)
 
   it('dispatches normalized create and clear commands through the command layer', function()
@@ -234,9 +313,33 @@ describe(':Forge command', function()
     vim.cmd('Forge issue create --blank --template=bug')
     vim.cmd('Forge clear')
 
-    assert.same({ draft = true, instant = true, web = true, scope = nil }, captured.create_pr)
+    assert.same({
+      draft = true,
+      instant = true,
+      web = true,
+      scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'upstream',
+        slug = 'owner/upstream',
+        repo_arg = 'owner/upstream',
+        web_url = 'https://github.com/owner/upstream',
+      },
+    }, captured.create_pr)
     assert.same({ web = false, blank = true, template = 'bug', scope = nil }, captured.create_issue)
     assert.is_true(captured.cleared)
+  end)
+
+  it('applies collaboration and ci default scopes to list commands', function()
+    vim.cmd('Forge pr')
+    vim.cmd('Forge ci')
+
+    assert.equals('prs', captured.opens[1].route)
+    assert.equals('owner/upstream', captured.opens[1].opts.scope.slug)
+    assert.equals('ci.current_branch', captured.opens[2].route)
+    assert.equals('owner/current', captured.opens[2].opts.scope.slug)
+    assert.equals('main', captured.opens[2].opts.branch)
   end)
 
   it('rejects unsupported bang with E477 and no side effects', function()

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -28,6 +28,8 @@ describe('config', function()
     local cfg = forge.config()
     assert.equals(1000, cfg.ci.lines)
     assert.equals('horizontal', cfg.split)
+    assert.same({}, cfg.targets.aliases)
+    assert.equals('current', cfg.targets.ci.repo)
     assert.equals(45, cfg.display.widths.title)
     assert.equals(100, cfg.display.limits.pulls)
     assert.equals(100, cfg.display.limits.commits)
@@ -607,6 +609,45 @@ describe('config validation', function()
     assert.has_error(function()
       forge.config()
     end)
+  end)
+
+  it('rejects non-table targets', function()
+    vim.g.forge = { targets = 'bad' }
+    assert.has_error(function()
+      forge.config()
+    end)
+  end)
+
+  it('rejects invalid target alias values', function()
+    vim.g.forge = { targets = { aliases = { upstream = false } } }
+    assert.has_error(function()
+      forge.config()
+    end)
+  end)
+
+  it('rejects invalid ci repo policy', function()
+    vim.g.forge = { targets = { ci = { repo = 'fork' } } }
+    assert.has_error(function()
+      forge.config()
+    end)
+  end)
+
+  it('accepts target alias and collaboration defaults', function()
+    vim.g.forge = {
+      targets = {
+        default_repo = 'upstream',
+        aliases = {
+          work = 'github.com/owner/repo',
+        },
+        ci = {
+          repo = 'collaboration',
+        },
+      },
+    }
+    local cfg = forge.config()
+    assert.equals('upstream', cfg.targets.default_repo)
+    assert.equals('github.com/owner/repo', cfg.targets.aliases.work)
+    assert.equals('collaboration', cfg.targets.ci.repo)
   end)
 
   it('accepts false for individual key binding', function()

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -13,17 +13,24 @@ local function fake_forge()
       issue = 'Issues',
       ci = 'CI',
     },
-    browse = function(_, loc, branch)
+    browse = function(_, loc, branch, scope)
       captured.browse = {
         loc = loc,
         branch = branch,
+        scope = scope,
       }
     end,
-    browse_branch = function(_, branch)
-      captured.browse_branch = branch
+    browse_branch = function(_, branch, scope)
+      captured.browse_branch = {
+        branch = branch,
+        scope = scope,
+      }
     end,
-    browse_commit = function(_, sha)
-      captured.browse_commit = sha
+    browse_commit = function(_, sha, scope)
+      captured.browse_commit = {
+        sha = sha,
+        scope = scope,
+      }
     end,
   }
 end
@@ -131,14 +138,17 @@ describe('routes', function()
         pr = function(state, _, opts)
           captured.pr = state
           captured.pr_back = opts and opts.back or nil
+          captured.pr_scope = opts and opts.scope or nil
         end,
         issue = function(state, _, opts)
           captured.issue = state
           captured.issue_back = opts and opts.back or nil
+          captured.issue_scope = opts and opts.scope or nil
         end,
         ci = function(_, branch, _, opts)
           captured.ci = branch
           captured.ci_back = opts and opts.back or nil
+          captured.ci_scope = opts and opts.scope or nil
         end,
         branches = function(ctx, opts)
           captured.branches = ctx.id
@@ -155,6 +165,7 @@ describe('routes', function()
         release = function(state, _, opts)
           captured.release = state
           captured.release_back = opts and opts.back or nil
+          captured.release_scope = opts and opts.scope or nil
         end,
       }
     end
@@ -187,6 +198,24 @@ describe('routes', function()
     require('forge.routes').open('prs')
 
     assert.equals('closed', captured.pr)
+  end)
+
+  it('passes scoped route options through picker handlers', function()
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      owner = 'owner',
+      repo = 'repo',
+      slug = 'owner/repo',
+      repo_arg = 'owner/repo',
+      web_url = 'https://github.com/owner/repo',
+    }
+
+    require('forge.routes').open('prs', { scope = scope })
+    require('forge.routes').open('ci.current_branch', { scope = scope })
+
+    assert.same(scope, captured.pr_scope)
+    assert.same(scope, captured.ci_scope)
   end)
 
   it('opens the configured root sections through the picker client', function()
@@ -240,13 +269,13 @@ describe('routes', function()
   it('uses branch browsing for contextual browse without a file buffer', function()
     require('forge.routes').open('browse.contextual')
 
-    assert.equals('main', captured.browse_branch)
+    assert.same({ branch = 'main', scope = nil }, captured.browse_branch)
     assert.is_nil(captured.browse)
   end)
 
   it('uses the current commit for commit browsing', function()
     require('forge.routes').open('browse.commit')
 
-    assert.equals('abc123', captured.browse_commit)
+    assert.same({ sha = 'abc123', scope = nil }, captured.browse_commit)
   end)
 end)

--- a/spec/target_spec.lua
+++ b/spec/target_spec.lua
@@ -108,6 +108,100 @@ describe('target parsing', function()
     assert.equals('origin', resolved.remote)
   end)
 
+  it('prefers configured collaboration repos before upstream and origin', function()
+    vim.system = function(cmd)
+      local key = table.concat(cmd, ' ')
+      if key == 'git remote get-url upstream' then
+        return {
+          wait = function()
+            return {
+              code = 0,
+              stdout = 'git@github.com:owner/upstream.git\n',
+            }
+          end,
+        }
+      end
+      if key == 'git remote get-url origin' then
+        return {
+          wait = function()
+            return {
+              code = 0,
+              stdout = 'git@github.com:owner/current.git\n',
+            }
+          end,
+        }
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '' }
+        end,
+      }
+    end
+
+    local target = require('forge.target')
+    local configured = assert(target.collaboration_repo({
+      default_repo = 'work',
+      aliases = {
+        work = 'github.com/owner/shared',
+      },
+    }))
+    local fallback = assert(target.collaboration_repo({}))
+
+    assert.equals('owner/shared', configured.slug)
+    assert.equals('owner/upstream', fallback.slug)
+  end)
+
+  it('resolves current push context through branch push remotes', function()
+    vim.system = function(cmd)
+      local key = table.concat(cmd, ' ')
+      if key == 'git branch --show-current' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'feature\n' }
+          end,
+        }
+      end
+      if key == 'git config branch.feature.pushRemote' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'fork\n' }
+          end,
+        }
+      end
+      if key == 'git remote get-url fork' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'git@github.com:owner/fork.git\n' }
+          end,
+        }
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '' }
+        end,
+      }
+    end
+
+    local target = require('forge.target')
+    local rev = assert(target.push_rev({}))
+
+    assert.equals('feature', rev.rev)
+    assert.equals('owner/fork', rev.repo.slug)
+  end)
+
+  it('converts resolved repo targets into forge scopes', function()
+    local target = require('forge.target')
+    local scope = assert(target.repo_scope({
+      kind = 'repo',
+      form = 'hosted',
+      host = 'github.com',
+      slug = 'owner/repo',
+    }, 'github'))
+
+    assert.equals('github', scope.kind)
+    assert.equals('owner/repo', scope.slug)
+  end)
+
   it('rejects unresolved symbolic and malformed addresses', function()
     local target = require('forge.target')
     local _, unresolved = target.resolve_repo('missing')


### PR DESCRIPTION
## Problem

The new `:Forge` command language could parse explicit repo and revision addresses, but it still had no canonical policy for omitted targets. That left alias order, collaboration repo defaults, CI repo defaults, and browse/create fallback behavior implicit.

## Solution

Add a dedicated target policy layer with configurable aliases and default repo settings, thread normalized default policy metadata through `forge.cmd`, and pass resolved scope defaults into list/create/browse dispatch. This also documents the alias resolution order and default-vs-explicit override model in the help file.