### PR TITLE
refactor(ops): share Forge command and picker actions

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -1138,6 +1138,12 @@ PUBLIC API: `require('forge')` ~
     over defaults. If `vim.g.forge.keys` is `false`, `cfg.keys` is
     `false`.
 
+SHARED OPERATIONS: `require('forge.ops')` ~
+    Picker actions and `:Forge` command dispatch share semantic forge
+    operations through `forge.ops`. Future command/picker capability work
+    should add semantic behavior there before wiring it into picker-only
+    or command-only entrypoints.
+
                                                             *forge.register()*
 `register(name, source)`
     Registers a custom `forge.Forge` source under `name`.

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local ops = require('forge.ops')
+
 local modifiers = {
   state = { kind = 'value' },
   repo = { kind = 'value', target = 'repo' },
@@ -546,47 +548,22 @@ local function effective_rev(command)
     or command.default_targets.rev
 end
 
-local function location_arg(location)
-  if
-    type(location) ~= 'table'
-    or location.kind ~= 'location'
-    or not location.path
-    or location.path == ''
-  then
-    return nil
-  end
-  local range = location.range
-  if not range then
-    return location.path
-  end
-  if range.start_line == range.end_line then
-    return ('%s:%d'):format(location.path, range.start_line)
-  end
-  return ('%s:%d-%d'):format(location.path, range.start_line, range.end_line)
-end
-
 local function dispatch_pr(command)
   if not require_git_or_warn() then
     return
   end
-  local f, forge_mod = require_forge_or_warn()
+  local f = require_forge_or_warn()
   if not f then
     return
   end
-  local pickers = require('forge.pickers')
   local num = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
-    local state = command.modifiers.state
-    if state then
-      forge_mod.open('prs.' .. state, { scope = scope })
-    else
-      forge_mod.open('prs', { scope = scope })
-    end
+    ops.pr_list(command.modifiers.state, { scope = scope })
     return
   end
   if command.name == 'create' then
-    forge_mod.create_pr({
+    ops.pr_create({
       draft = command.modifiers.draft == true,
       instant = command.modifiers.fill == true,
       web = command.modifiers.web == true,
@@ -595,46 +572,39 @@ local function dispatch_pr(command)
     return
   end
   if command.name == 'edit' then
-    forge_mod.edit_pr(num)
+    ops.pr_edit({ num = num, scope = scope })
     return
   end
   if command.name == 'checkout' then
-    pickers.pr_actions(f, { num = num, scope = scope }).checkout()
+    ops.pr_checkout(f, { num = num, scope = scope })
     return
   end
   if command.name == 'review' then
-    pickers.pr_actions(f, { num = num, scope = scope }).review()
+    ops.pr_review(f, { num = num, scope = scope })
     return
   end
   if command.name == 'worktree' then
-    pickers.pr_actions(f, { num = num, scope = scope }).worktree()
+    ops.pr_worktree(f, { num = num, scope = scope })
     return
   end
   if command.name == 'ci' then
-    if f.capabilities.per_pr_checks then
-      pickers.checks(f, num, nil, nil, { scope = scope })
-    else
-      require('forge.logger').debug(
-        ('per-%s checks unavailable on %s, showing repo CI'):format(f.labels.pr_one, f.name)
-      )
-      pickers.ci(f, nil, nil, { scope = scope })
-    end
+    ops.pr_ci(f, { num = num, scope = scope })
     return
   end
   if command.name == 'browse' then
-    f:view_web(f.kinds.pr, num, scope)
+    ops.pr_browse(f, { num = num, scope = scope })
     return
   end
   if command.name == 'manage' then
-    pickers.pr_manage(f, { num = num, scope = scope })
+    ops.pr_manage(f, { num = num, scope = scope })
     return
   end
   if command.name == 'close' then
-    pickers.pr_close(f, num, scope)
+    ops.pr_close(f, { num = num, scope = scope })
     return
   end
   if command.name == 'reopen' then
-    pickers.pr_reopen(f, num, scope)
+    ops.pr_reopen(f, { num = num, scope = scope })
     return
   end
   warn(('unsupported pr action: %s'):format(command.name))
@@ -644,25 +614,19 @@ local function dispatch_issue(command)
   if not require_git_or_warn() then
     return
   end
-  local f, forge_mod = require_forge_or_warn()
+  local f = require_forge_or_warn()
   if not f then
     return
   end
-  local pickers = require('forge.pickers')
   local num = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
-    local state = command.modifiers.state
-    if state then
-      forge_mod.open('issues.' .. state, { scope = scope })
-    else
-      forge_mod.open('issues', { scope = scope })
-    end
+    ops.issue_list(command.modifiers.state, { scope = scope })
     return
   end
   if command.name == 'create' then
     local template = command.modifiers.template
-    forge_mod.create_issue({
+    ops.issue_create({
       web = command.modifiers.web == true,
       blank = command.modifiers.blank == true,
       template = template ~= true and template or nil,
@@ -671,15 +635,15 @@ local function dispatch_issue(command)
     return
   end
   if command.name == 'browse' then
-    f:view_web(f.kinds.issue, num, scope)
+    ops.issue_browse(f, { num = num, scope = scope })
     return
   end
   if command.name == 'close' then
-    pickers.issue_close(f, num, scope)
+    ops.issue_close(f, { num = num, scope = scope })
     return
   end
   if command.name == 'reopen' then
-    pickers.issue_reopen(f, num, scope)
+    ops.issue_reopen(f, { num = num, scope = scope })
     return
   end
   warn(('unsupported issue action: %s'):format(command.name))
@@ -689,7 +653,7 @@ local function dispatch_ci(command)
   if not require_git_or_warn() then
     return
   end
-  local f, forge_mod = require_forge_or_warn()
+  local f = require_forge_or_warn()
   if not f then
     return
   end
@@ -703,10 +667,7 @@ local function dispatch_ci(command)
         or command.default_targets.rev
       branch = rev and rev.rev or nil
     end
-    forge_mod.open(command.modifiers.all and 'ci.all' or 'ci.current_branch', {
-      branch = branch,
-      scope = scope,
-    })
+    ops.ci_list(command.modifiers.all and nil or branch, { scope = scope })
     return
   end
   warn(('unsupported ci action: %s'):format(command.name))
@@ -716,49 +677,22 @@ local function dispatch_release(command)
   if not require_git_or_warn() then
     return
   end
-  local f, forge_mod = require_forge_or_warn()
+  local f = require_forge_or_warn()
   if not f then
     return
   end
   local tag = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'list' then
-    local state = command.modifiers.state
-    if state then
-      forge_mod.open('releases.' .. state, { scope = scope })
-    else
-      forge_mod.open('releases', { scope = scope })
-    end
+    ops.release_list(command.modifiers.state, { scope = scope })
     return
   end
   if command.name == 'browse' then
-    f:browse_release(tag, scope)
+    ops.release_browse(f, { tag = tag, scope = scope })
     return
   end
   if command.name == 'delete' then
-    local function do_delete()
-      require('forge.logger').info('deleting release ' .. tag .. '...')
-      vim.system(f:delete_release_cmd(tag, scope), { text = true }, function(result)
-        vim.schedule(function()
-          if result.code == 0 then
-            require('forge.logger').info('deleted release ' .. tag)
-          else
-            require('forge.logger').error('delete failed')
-          end
-        end)
-      end)
-    end
-    if command.bang then
-      do_delete()
-      return
-    end
-    vim.ui.select({ 'Yes', 'No' }, {
-      prompt = 'Delete release ' .. tag .. '? ',
-    }, function(choice)
-      if choice == 'Yes' then
-        do_delete()
-      end
-    end)
+    ops.release_delete(f, { tag = tag, scope = scope }, { confirm = not command.bang })
     return
   end
 end
@@ -767,33 +701,27 @@ local function dispatch_browse(command)
   if not require_git_or_warn() then
     return
   end
-  local f, forge_mod = require_forge_or_warn()
+  local f = require_forge_or_warn()
   if not f then
     return
   end
   local scope = resolve_scope_modifier(command, f.name)
   if command.modifiers.commit then
-    forge_mod.open('browse.commit', { scope = scope })
+    ops.browse_commit({ scope = scope })
   elseif command.modifiers.root then
-    forge_mod.open('browse.branch', {
+    ops.browse_branch(effective_rev(command) and effective_rev(command).rev or nil, {
       scope = scope,
-      branch = effective_rev(command) and effective_rev(command).rev or nil,
     })
   else
     local location = command.parsed_modifiers.target
-    if location then
-      local loc = location_arg(location)
-      if loc then
-        f:browse(loc, location.rev.rev, scope)
-        return
-      end
-    end
-    local rev = effective_rev(command)
-    if rev and rev.rev then
-      f:browse(require('forge').file_loc(), rev.rev, scope)
+    if location and ops.browse_location(f, location, scope) then
       return
     end
-    forge_mod.open('browse.contextual', { scope = scope })
+    local rev = effective_rev(command)
+    if rev and rev.rev and ops.browse_file(f, require('forge').file_loc(), rev.rev, scope) then
+      return
+    end
+    ops.browse_contextual({ scope = scope })
   end
 end
 

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -1,0 +1,382 @@
+local M = {}
+
+local log = require('forge.logger')
+
+local function trim(text)
+  if type(text) ~= 'string' then
+    return ''
+  end
+  return vim.trim(text)
+end
+
+local function cmd_error(result, fallback)
+  local msg = result.stderr or ''
+  if vim.trim(msg) == '' then
+    msg = result.stdout or ''
+  end
+  msg = vim.trim(msg)
+  if msg == '' then
+    msg = fallback
+  end
+  return msg
+end
+
+local function run_forge_cmd(kind, id, label, cmd, success_msg, fail_msg, opts)
+  opts = opts or {}
+  log.info(label .. ' ' .. kind .. ' #' .. id .. '...')
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        log.info(('%s %s #%s'):format(success_msg, kind, id))
+        if opts.on_success then
+          opts.on_success()
+        end
+      else
+        log.error(cmd_error(result, fail_msg))
+        if opts.on_failure then
+          opts.on_failure()
+        end
+      end
+    end)
+  end)
+end
+
+local function normalize_pr_ref(pr)
+  if type(pr) == 'table' then
+    return pr
+  end
+  return { num = pr }
+end
+
+local function normalize_issue_ref(issue, scope)
+  if type(issue) == 'table' then
+    return issue
+  end
+  return { num = issue, scope = scope }
+end
+
+local function normalize_release_ref(release, scope)
+  if type(release) == 'table' then
+    return release
+  end
+  return { tag = release, scope = scope }
+end
+
+local function location_arg(location)
+  if
+    type(location) ~= 'table'
+    or location.kind ~= 'location'
+    or not location.path
+    or location.path == ''
+  then
+    return nil
+  end
+  local range = location.range
+  if not range then
+    return location.path
+  end
+  if range.start_line == range.end_line then
+    return ('%s:%d'):format(location.path, range.start_line)
+  end
+  return ('%s:%d-%d'):format(location.path, range.start_line, range.end_line)
+end
+
+function M.pr_list(state, opts)
+  require('forge').open(state and ('prs.' .. state) or 'prs', opts)
+end
+
+function M.pr_create(opts)
+  require('forge').create_pr(opts)
+end
+
+function M.pr_edit(pr)
+  pr = normalize_pr_ref(pr)
+  require('forge').edit_pr(pr.num, pr.scope)
+end
+
+function M.pr_checkout(f, pr)
+  pr = normalize_pr_ref(pr)
+  local kind = f.labels.pr_one
+  log.info(('checking out %s #%s...'):format(kind, pr.num))
+  vim.system(f:checkout_cmd(pr.num, pr.scope), { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        log.info(('checked out %s #%s'):format(kind, pr.num))
+      else
+        log.error(cmd_error(result, 'checkout failed'))
+      end
+    end)
+  end)
+end
+
+function M.pr_browse(f, pr)
+  pr = normalize_pr_ref(pr)
+  f:view_web(f.kinds.pr, pr.num, pr.scope)
+end
+
+function M.pr_worktree(f, pr)
+  pr = normalize_pr_ref(pr)
+  local kind = f.labels.pr_one
+  local fetch_cmd = f:fetch_pr(pr.num, pr.scope)
+  local branch = fetch_cmd[#fetch_cmd]:match(':(.+)$')
+  if not branch then
+    return
+  end
+  local root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
+  local wt_path = vim.fs.normalize(root .. '/../' .. branch)
+  log.info(('fetching %s #%s into worktree...'):format(kind, pr.num))
+  vim.system(fetch_cmd, { text = true }, function()
+    vim.system({ 'git', 'worktree', 'add', wt_path, branch }, { text = true }, function(result)
+      vim.schedule(function()
+        if result.code == 0 then
+          log.info(('worktree at %s'):format(wt_path))
+        else
+          log.error(cmd_error(result, 'worktree failed'))
+        end
+      end)
+    end)
+  end)
+end
+
+function M.pr_review(f, pr, opts)
+  pr = normalize_pr_ref(pr)
+  opts = opts or {}
+  local review = require('forge.review')
+  local kind = f.labels.pr_one
+  local repo_root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
+
+  log.info(('reviewing %s #%s...'):format(kind, pr.num))
+  vim.system(f:checkout_cmd(pr.num, pr.scope), { text = true }, function(co_result)
+    if co_result.code ~= 0 then
+      vim.schedule(function()
+        log.debug('checkout skipped, proceeding with review')
+      end)
+    end
+
+    vim.system(f:pr_base_cmd(pr.num, pr.scope), { text = true }, function(base_result)
+      vim.schedule(function()
+        local base = trim(base_result.stdout)
+        if base == '' or base_result.code ~= 0 then
+          base = 'main'
+        end
+        local range = require('forge').remote_ref(pr.scope, base) or ('origin/' .. base)
+        local head = vim.trim(vim.fn.system('git branch --show-current'))
+        review.start_session({
+          subject = {
+            kind = 'pr',
+            id = pr.num,
+            label = ('%s #%s'):format(kind, pr.num),
+            base_ref = range,
+            head_ref = head,
+          },
+          mode = 'patch',
+          files = {},
+          current_file = nil,
+          materialization = co_result.code == 0 and 'checkout' or 'current',
+          repo_root = repo_root,
+          back = opts.back,
+        })
+        review.open_index()
+        log.debug(('review ready for %s #%s against %s'):format(kind, pr.num, base))
+      end)
+    end)
+  end)
+end
+
+function M.pr_ci(f, pr, opts)
+  pr = normalize_pr_ref(pr)
+  opts = vim.tbl_extend('force', opts or {}, { scope = pr.scope })
+  local pickers = require('forge.pickers')
+  if f.capabilities.per_pr_checks then
+    pickers.checks(f, pr.num, nil, nil, opts)
+  else
+    log.debug(('per-%s checks unavailable on %s, showing repo CI'):format(f.labels.pr_one, f.name))
+    pickers.ci(f, nil, nil, opts)
+  end
+end
+
+function M.pr_manage(f, pr, parent)
+  require('forge.pickers').pr_manage(f, normalize_pr_ref(pr), parent)
+end
+
+function M.pr_close(f, pr, opts)
+  pr = normalize_pr_ref(pr)
+  run_forge_cmd(
+    f.labels.pr_one,
+    pr.num,
+    'closing',
+    f:close_cmd(pr.num, pr.scope),
+    'closed',
+    'close failed',
+    opts
+  )
+end
+
+function M.pr_reopen(f, pr, opts)
+  pr = normalize_pr_ref(pr)
+  run_forge_cmd(
+    f.labels.pr_one,
+    pr.num,
+    'reopening',
+    f:reopen_cmd(pr.num, pr.scope),
+    'reopened',
+    'reopen failed',
+    opts
+  )
+end
+
+function M.pr_approve(f, pr, opts)
+  pr = normalize_pr_ref(pr)
+  run_forge_cmd(
+    f.labels.pr_one,
+    pr.num,
+    'approving',
+    f:approve_cmd(pr.num, pr.scope),
+    'approved',
+    'approve failed',
+    opts
+  )
+end
+
+function M.pr_merge(f, pr, method, opts)
+  pr = normalize_pr_ref(pr)
+  run_forge_cmd(
+    f.labels.pr_one,
+    pr.num,
+    'merging (' .. method .. ')',
+    f:merge_cmd(pr.num, method, pr.scope),
+    'merged (' .. method .. ')',
+    'merge failed',
+    opts
+  )
+end
+
+function M.pr_toggle_draft(f, pr, is_draft, opts)
+  pr = normalize_pr_ref(pr)
+  local cmd = f:draft_toggle_cmd(pr.num, is_draft, pr.scope)
+  if not cmd then
+    return
+  end
+  run_forge_cmd(
+    f.labels.pr_one,
+    pr.num,
+    'toggling draft',
+    cmd,
+    is_draft and 'marked as ready' or 'marked as draft',
+    'draft toggle failed',
+    opts
+  )
+end
+
+function M.issue_list(state, opts)
+  require('forge').open(state and ('issues.' .. state) or 'issues', opts)
+end
+
+function M.issue_create(opts)
+  require('forge').create_issue(opts)
+end
+
+function M.issue_browse(f, issue)
+  issue = normalize_issue_ref(issue)
+  f:view_web(f.kinds.issue, issue.num, issue.scope)
+end
+
+function M.issue_close(f, issue, opts)
+  issue = normalize_issue_ref(issue)
+  run_forge_cmd(
+    'issue',
+    issue.num,
+    'closing',
+    f:close_issue_cmd(issue.num, issue.scope),
+    'closed',
+    'close failed',
+    opts
+  )
+end
+
+function M.issue_reopen(f, issue, opts)
+  issue = normalize_issue_ref(issue)
+  run_forge_cmd(
+    'issue',
+    issue.num,
+    'reopening',
+    f:reopen_issue_cmd(issue.num, issue.scope),
+    'reopened',
+    'reopen failed',
+    opts
+  )
+end
+
+function M.ci_list(branch, opts)
+  opts = vim.tbl_extend('force', opts or {}, { branch = branch })
+  require('forge').open(branch == nil and 'ci.all' or 'ci.current_branch', opts)
+end
+
+function M.release_list(state, opts)
+  require('forge').open(state and ('releases.' .. state) or 'releases', opts)
+end
+
+function M.release_browse(f, release)
+  release = normalize_release_ref(release)
+  f:browse_release(release.tag, release.scope)
+end
+
+function M.release_delete(f, release, opts)
+  release = normalize_release_ref(release)
+  opts = opts or {}
+  local function do_delete()
+    run_forge_cmd(
+      'release',
+      release.tag,
+      'deleting',
+      f:delete_release_cmd(release.tag, release.scope),
+      'deleted',
+      'delete failed',
+      opts
+    )
+  end
+  if opts.confirm == false then
+    do_delete()
+    return
+  end
+  vim.ui.select({ 'Yes', 'No' }, {
+    prompt = 'Delete release ' .. release.tag .. '? ',
+  }, function(choice)
+    if choice == 'Yes' then
+      do_delete()
+    elseif opts.on_cancel then
+      opts.on_cancel()
+    end
+  end)
+end
+
+function M.browse_commit(opts)
+  require('forge').open('browse.commit', opts)
+end
+
+function M.browse_branch(branch, opts)
+  require('forge').open('browse.branch', vim.tbl_extend('force', opts or {}, { branch = branch }))
+end
+
+function M.browse_contextual(opts)
+  require('forge').open('browse.contextual', opts)
+end
+
+function M.browse_location(f, location, scope)
+  local loc = location_arg(location)
+  if not loc then
+    return false
+  end
+  f:browse(loc, location.rev.rev, scope)
+  return true
+end
+
+function M.browse_file(f, file_loc, branch, scope)
+  if trim(file_loc) == '' or trim(branch) == '' then
+    return false
+  end
+  f:browse(file_loc, branch, scope)
+  return true
+end
+
+return M

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -3,12 +3,10 @@ local M = {}
 local format = require('forge.format')
 local layout = require('forge.layout')
 local log = require('forge.logger')
+local ops = require('forge.ops')
 local picker = require('forge.picker')
 local picker_session = require('forge.picker.session')
 
----@param result { code: integer, stdout: string?, stderr: string? }
----@param fallback string
----@return string
 local function cmd_error(result, fallback)
   local msg = result.stderr or ''
   if vim.trim(msg) == '' then
@@ -19,31 +17,6 @@ local function cmd_error(result, fallback)
     msg = fallback
   end
   return msg
-end
-
----@param kind string
----@param num string
----@param label string
----@param cmd string[]
----@param success_msg string
----@param fail_msg string
-local function run_forge_cmd(kind, num, label, cmd, success_msg, fail_msg, on_success, on_failure)
-  log.info(label .. ' ' .. kind .. ' #' .. num .. '...')
-  vim.system(cmd, { text = true }, function(result)
-    vim.schedule(function()
-      if result.code == 0 then
-        log.info(('%s %s #%s'):format(success_msg, kind, num))
-        if on_success then
-          on_success()
-        end
-      else
-        log.error(cmd_error(result, fail_msg))
-        if on_failure then
-          on_failure()
-        end
-      end
-    end)
-  end)
 end
 
 local next_ci_filter = {
@@ -562,26 +535,16 @@ end
 ---@param is_open boolean
 local function issue_toggle_state(f, num, is_open, on_success, ref)
   if is_open then
-    run_forge_cmd(
-      'issue',
-      num,
-      'closing',
-      f:close_issue_cmd(num, ref),
-      'closed',
-      'close failed',
-      on_success,
-      on_success
+    ops.issue_close(
+      f,
+      { num = num, scope = ref },
+      { on_success = on_success, on_failure = on_success }
     )
   else
-    run_forge_cmd(
-      'issue',
-      num,
-      'reopening',
-      f:reopen_issue_cmd(num, ref),
-      'reopened',
-      'reopen failed',
-      on_success,
-      on_success
+    ops.issue_reopen(
+      f,
+      { num = num, scope = ref },
+      { on_success = on_success, on_failure = on_success }
     )
   end
 end
@@ -590,28 +553,17 @@ end
 ---@param num string
 ---@param is_open boolean
 local function pr_toggle_state(f, num, is_open, on_success, ref)
-  local kind = f.labels.pr_one
   if is_open then
-    run_forge_cmd(
-      kind,
-      num,
-      'closing',
-      f:close_cmd(num, ref),
-      'closed',
-      'close failed',
-      on_success,
-      on_success
+    ops.pr_close(
+      f,
+      { num = num, scope = ref },
+      { on_success = on_success, on_failure = on_success }
     )
   else
-    run_forge_cmd(
-      kind,
-      num,
-      'reopening',
-      f:reopen_cmd(num, ref),
-      'reopened',
-      'reopen failed',
-      on_success,
-      on_success
+    ops.pr_reopen(
+      f,
+      { num = num, scope = ref },
+      { on_success = on_success, on_failure = on_success }
     )
   end
 end
@@ -629,106 +581,30 @@ end
 ---@param pr forge.PRRef
 ---@return table<string, function>
 local function pr_action_fns(f, pr)
-  local num = pr.num
-  local ref = pr.scope
-  local kind = f.labels.pr_one
-  local function review_pr(opts)
-    opts = opts or {}
-    local review = require('forge.review')
-    local repo_root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
-
-    log.info(('reviewing %s #%s...'):format(kind, num))
-    vim.system(f:checkout_cmd(num, ref), { text = true }, function(co_result)
-      if co_result.code ~= 0 then
-        vim.schedule(function()
-          log.debug('checkout skipped, proceeding with review')
-        end)
-      end
-
-      vim.system(f:pr_base_cmd(num, ref), { text = true }, function(base_result)
-        vim.schedule(function()
-          local base = vim.trim(base_result.stdout or '')
-          if base == '' or base_result.code ~= 0 then
-            base = 'main'
-          end
-          local range = require('forge').remote_ref(ref, base) or ('origin/' .. base)
-          local head = vim.trim(vim.fn.system('git branch --show-current'))
-          review.start_session({
-            subject = {
-              kind = 'pr',
-              id = num,
-              label = ('%s #%s'):format(kind, num),
-              base_ref = range,
-              head_ref = head,
-            },
-            mode = 'patch',
-            files = {},
-            current_file = nil,
-            materialization = co_result.code == 0 and 'checkout' or 'current',
-            repo_root = repo_root,
-            back = opts.back,
-          })
-          review.open_index()
-          log.debug(('review ready for %s #%s against %s'):format(kind, num, base))
-        end)
-      end)
-    end)
-  end
   return {
     checkout = function()
-      log.info(('checking out %s #%s...'):format(kind, num))
-      vim.system(f:checkout_cmd(num, ref), { text = true }, function(result)
-        vim.schedule(function()
-          if result.code == 0 then
-            log.info(('checked out %s #%s'):format(kind, num))
-          else
-            log.error(cmd_error(result, 'checkout failed'))
-          end
-        end)
-      end)
+      ops.pr_checkout(f, pr)
     end,
     browse = function()
-      f:view_web(f.kinds.pr, num, ref)
+      ops.pr_browse(f, pr)
     end,
     worktree = function()
-      local fetch_cmd = f:fetch_pr(num, ref)
-      local branch = fetch_cmd[#fetch_cmd]:match(':(.+)$')
-      if not branch then
-        return
-      end
-      local root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
-      local wt_path = vim.fs.normalize(root .. '/../' .. branch)
-      log.info(('fetching %s #%s into worktree...'):format(kind, num))
-      vim.system(fetch_cmd, { text = true }, function()
-        vim.system({ 'git', 'worktree', 'add', wt_path, branch }, { text = true }, function(result)
-          vim.schedule(function()
-            if result.code == 0 then
-              log.info(('worktree at %s'):format(wt_path))
-            else
-              log.error(cmd_error(result, 'worktree failed'))
-            end
-          end)
-        end)
-      end)
+      ops.pr_worktree(f, pr)
     end,
-    review = review_pr,
-    diff = review_pr,
+    review = function(opts)
+      ops.pr_review(f, pr, opts)
+    end,
+    diff = function(opts)
+      ops.pr_review(f, pr, opts)
+    end,
     ci = function(opts)
-      opts = opts or {}
-      if f.capabilities.per_pr_checks then
-        opts.scope = ref
-        M.checks(f, num, nil, nil, opts)
-      else
-        log.debug(('per-%s checks unavailable on %s, showing repo CI'):format(kind, f.name))
-        opts.scope = ref
-        M.ci(f, nil, nil, opts)
-      end
+      ops.pr_ci(f, pr, opts)
     end,
-    manage = function()
-      M.pr_manage(f, { num = num, scope = ref })
+    manage = function(parent)
+      ops.pr_manage(f, pr, parent)
     end,
     edit = function()
-      require('forge').edit_pr(num, ref)
+      ops.pr_edit(pr)
     end,
   }
 end
@@ -764,84 +640,48 @@ local function pr_manage_picker(f, pr, parent)
   end
 
   add('Edit', function()
-    require('forge').edit_pr(num, ref)
+    ops.pr_edit(pr)
   end)
 
   if can_write and is_open then
     add('Approve', function()
-      run_forge_cmd(
-        kind,
-        num,
-        'approving',
-        f:approve_cmd(num, ref),
-        'approved',
-        'approve failed',
-        reopen_self,
-        reopen_self
-      )
+      ops.pr_approve(f, pr, { on_success = reopen_self, on_failure = reopen_self })
     end)
   end
 
   if can_write and is_open then
     for _, method in ipairs(info.merge_methods) do
       add('Merge (' .. method .. ')', function()
-        run_forge_cmd(
-          kind,
-          num,
-          'merging (' .. method .. ')',
-          f:merge_cmd(num, method, ref),
-          'merged (' .. method .. ')',
-          'merge failed',
-          parent and parent.refresh or reopen_self,
-          reopen_self
-        )
+        ops.pr_merge(f, pr, method, {
+          on_success = parent and parent.refresh or reopen_self,
+          on_failure = reopen_self,
+        })
       end)
     end
   end
 
   if is_open then
     add('Close', function()
-      run_forge_cmd(
-        kind,
-        num,
-        'closing',
-        f:close_cmd(num, ref),
-        'closed',
-        'close failed',
-        parent and parent.refresh or reopen_self,
-        reopen_self
-      )
+      ops.pr_close(f, pr, {
+        on_success = parent and parent.refresh or reopen_self,
+        on_failure = reopen_self,
+      })
     end)
   else
     add('Reopen', function()
-      run_forge_cmd(
-        kind,
-        num,
-        'reopening',
-        f:reopen_cmd(num, ref),
-        'reopened',
-        'reopen failed',
-        parent and parent.refresh or reopen_self,
-        reopen_self
-      )
+      ops.pr_reopen(f, pr, {
+        on_success = parent and parent.refresh or reopen_self,
+        on_failure = reopen_self,
+      })
     end)
   end
 
-  local draft_cmd = f:draft_toggle_cmd(num, pr_state.is_draft, ref)
-  if draft_cmd then
-    local draft_label = pr_state.is_draft and 'Mark as ready' or 'Mark as draft'
-    local draft_done = pr_state.is_draft and 'marked as ready' or 'marked as draft'
-    add(draft_label, function()
-      run_forge_cmd(
-        kind,
-        num,
-        'toggling draft',
-        draft_cmd,
-        draft_done,
-        'draft toggle failed',
-        reopen_self,
-        reopen_self
-      )
+  if f:draft_toggle_cmd(num, pr_state.is_draft, ref) then
+    add(pr_state.is_draft and 'Mark as ready' or 'Mark as draft', function()
+      ops.pr_toggle_draft(f, pr, pr_state.is_draft, {
+        on_success = reopen_self,
+        on_failure = reopen_self,
+      })
     end)
   end
 
@@ -1355,7 +1195,6 @@ end
 ---@param opts? forge.PickerLimitOpts
 function M.pr(state, f, opts)
   opts = opts or {}
-  local cli_kind = f.kinds.pr
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
   local prev_state = ({ all = 'closed', open = 'all', closed = 'open' })[state]
   local state_label = ({ all = 'All', open = 'Open', closed = 'Closed' })[state] or state
@@ -1487,7 +1326,7 @@ function M.pr(state, f, opts)
       close = false,
       fn = function(entry)
         if entry and not entry.load_more then
-          f:view_web(cli_kind, entry.value.num, entry.value.scope)
+          ops.pr_browse(f, entry.value)
         end
       end,
     },
@@ -1496,7 +1335,7 @@ function M.pr(state, f, opts)
       label = 'more',
       fn = function(entry)
         if entry and not entry.load_more then
-          pr_manage_picker(f, entry.value, {
+          ops.pr_manage(f, entry.value, {
             refresh = reopen_list,
             back = back_to_list,
           })
@@ -1516,7 +1355,7 @@ function M.pr(state, f, opts)
       name = 'create',
       label = 'create',
       fn = function()
-        forge_mod.create_pr({ back = opts.back, scope = ref })
+        ops.pr_create({ back = opts.back, scope = ref })
       end,
     },
     {
@@ -1614,7 +1453,6 @@ end
 ---@param opts? forge.PickerLimitOpts
 function M.issue(state, f, opts)
   opts = opts or {}
-  local cli_kind = f.kinds.issue
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
   local prev_state = ({ all = 'closed', open = 'all', closed = 'open' })[state]
   local state_label = ({ all = 'All', open = 'Open', closed = 'Closed' })[state] or state
@@ -1698,7 +1536,7 @@ function M.issue(state, f, opts)
         if entry and entry.load_more then
           M.issue(state, f, { limit = entry.next_limit, back = opts.back, scope = ref })
         elseif entry then
-          f:view_web(cli_kind, entry.value.num, entry.value.scope)
+          ops.issue_browse(f, entry.value)
         end
       end,
     },
@@ -1708,7 +1546,7 @@ function M.issue(state, f, opts)
       close = false,
       fn = function(entry)
         if entry and not entry.load_more then
-          f:view_web(cli_kind, entry.value.num, entry.value.scope)
+          ops.issue_browse(f, entry.value)
         end
       end,
     },
@@ -1731,7 +1569,7 @@ function M.issue(state, f, opts)
       name = 'create',
       label = 'create',
       fn = function()
-        forge_mod.create_issue({ back = opts.back, scope = ref })
+        ops.issue_create({ back = opts.back, scope = ref })
       end,
     },
     {
@@ -1811,45 +1649,36 @@ end
 
 ---@param f forge.Forge
 ---@param pr forge.PRRefLike
-function M.pr_manage(f, pr)
-  pr_manage_picker(f, normalize_pr_ref(pr))
+function M.pr_manage(f, pr, parent)
+  pr_manage_picker(f, normalize_pr_ref(pr), parent)
 end
 
 ---@param f forge.Forge
 ---@param num string
 ---@param ref? forge.Scope
 function M.issue_close(f, num, ref)
-  run_forge_cmd('issue', num, 'closing', f:close_issue_cmd(num, ref), 'closed', 'close failed')
+  ops.issue_close(f, { num = num, scope = ref })
 end
 
 ---@param f forge.Forge
 ---@param num string
 ---@param ref? forge.Scope
 function M.issue_reopen(f, num, ref)
-  run_forge_cmd(
-    'issue',
-    num,
-    'reopening',
-    f:reopen_issue_cmd(num, ref),
-    'reopened',
-    'reopen failed'
-  )
+  ops.issue_reopen(f, { num = num, scope = ref })
 end
 
 ---@param f forge.Forge
 ---@param num string
 ---@param ref? forge.Scope
 function M.pr_close(f, num, ref)
-  local kind = f.labels.pr_one
-  run_forge_cmd(kind, num, 'closing', f:close_cmd(num, ref), 'closed', 'close failed')
+  ops.pr_close(f, { num = num, scope = ref })
 end
 
 ---@param f forge.Forge
 ---@param num string
 ---@param ref? forge.Scope
 function M.pr_reopen(f, num, ref)
-  local kind = f.labels.pr_one
-  run_forge_cmd(kind, num, 'reopening', f:reopen_cmd(num, ref), 'reopened', 'reopen failed')
+  ops.pr_reopen(f, { num = num, scope = ref })
 end
 
 ---@param f forge.Forge
@@ -1922,7 +1751,7 @@ function M.release(state, f, opts)
       close = false,
       fn = function(entry)
         if entry then
-          f:browse_release(entry.value.tag, entry.value.scope)
+          ops.release_browse(f, entry.value)
         end
       end,
     },
@@ -1947,25 +1776,13 @@ function M.release(state, f, opts)
         if not entry then
           return
         end
-        local tag = entry.value.tag
-        vim.ui.select({ 'Yes', 'No' }, {
-          prompt = 'Delete release ' .. tag .. '? ',
-        }, function(choice)
-          if choice == 'Yes' then
-            run_forge_cmd(
-              'release',
-              tag,
-              'deleting',
-              f:delete_release_cmd(tag, entry.value.scope),
-              'deleted',
-              'delete failed',
-              reopen_list,
-              reopen_list
-            )
-          else
+        ops.release_delete(f, entry.value, {
+          on_success = reopen_list,
+          on_failure = reopen_list,
+          on_cancel = function()
             M.release(state, f, { back = opts.back, scope = ref })
-          end
-        end)
+          end,
+        })
       end,
     },
     {

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -9,6 +9,7 @@ describe(':Forge command', function()
   before_each(function()
     captured = {
       opens = {},
+      ops_calls = {},
       pr_action_num = nil,
       pr_action_scope = nil,
       reviews = {},
@@ -21,6 +22,7 @@ describe(':Forge command', function()
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.ops'] = package.preload['forge.ops'],
       ['forge.pickers'] = package.preload['forge.pickers'],
       ['forge.review'] = package.preload['forge.review'],
     }
@@ -136,6 +138,120 @@ describe(':Forge command', function()
       }
     end
 
+    package.preload['forge.ops'] = function()
+      return {
+        pr_list = function(state, opts)
+          table.insert(captured.ops_calls, { name = 'pr_list', state = state, opts = opts })
+          require('forge').open(state and ('prs.' .. state) or 'prs', opts)
+        end,
+        pr_create = function(opts)
+          table.insert(captured.ops_calls, { name = 'pr_create', opts = opts })
+          require('forge').create_pr(opts)
+        end,
+        pr_edit = function(pr)
+          table.insert(captured.ops_calls, { name = 'pr_edit', pr = pr })
+          require('forge').edit_pr(pr.num, pr.scope)
+        end,
+        pr_checkout = function(_, pr)
+          table.insert(captured.ops_calls, { name = 'pr_checkout', pr = pr })
+        end,
+        pr_review = function(_, pr, opts)
+          table.insert(captured.ops_calls, { name = 'pr_review', pr = pr, opts = opts })
+        end,
+        pr_worktree = function(_, pr)
+          table.insert(captured.ops_calls, { name = 'pr_worktree', pr = pr })
+        end,
+        pr_ci = function(_, pr, opts)
+          table.insert(captured.ops_calls, { name = 'pr_ci', pr = pr, opts = opts })
+        end,
+        pr_browse = function(f, pr)
+          table.insert(captured.ops_calls, { name = 'pr_browse', pr = pr })
+          f:view_web(f.kinds.pr, pr.num, pr.scope)
+        end,
+        pr_manage = function(_, pr)
+          table.insert(captured.ops_calls, { name = 'pr_manage', pr = pr })
+        end,
+        pr_close = function(_, pr)
+          table.insert(captured.ops_calls, { name = 'pr_close', pr = pr })
+        end,
+        pr_reopen = function(_, pr)
+          table.insert(captured.ops_calls, { name = 'pr_reopen', pr = pr })
+        end,
+        issue_list = function(state, opts)
+          table.insert(captured.ops_calls, { name = 'issue_list', state = state, opts = opts })
+          require('forge').open(state and ('issues.' .. state) or 'issues', opts)
+        end,
+        issue_create = function(opts)
+          table.insert(captured.ops_calls, { name = 'issue_create', opts = opts })
+          require('forge').create_issue(opts)
+        end,
+        issue_browse = function(f, issue)
+          table.insert(captured.ops_calls, { name = 'issue_browse', issue = issue })
+          f:view_web(f.kinds.issue, issue.num, issue.scope)
+        end,
+        issue_close = function(_, issue)
+          table.insert(captured.ops_calls, { name = 'issue_close', issue = issue })
+        end,
+        issue_reopen = function(_, issue)
+          table.insert(captured.ops_calls, { name = 'issue_reopen', issue = issue })
+        end,
+        ci_list = function(branch, opts)
+          table.insert(captured.ops_calls, { name = 'ci_list', branch = branch, opts = opts })
+          require('forge').open(
+            branch == nil and 'ci.all' or 'ci.current_branch',
+            vim.tbl_extend('force', opts or {}, { branch = branch })
+          )
+        end,
+        release_list = function(state, opts)
+          table.insert(captured.ops_calls, { name = 'release_list', state = state, opts = opts })
+          require('forge').open(state and ('releases.' .. state) or 'releases', opts)
+        end,
+        release_browse = function(f, release)
+          table.insert(captured.ops_calls, { name = 'release_browse', release = release })
+          f:browse_release(release.tag, release.scope)
+        end,
+        release_delete = function(_, release, opts)
+          table.insert(
+            captured.ops_calls,
+            { name = 'release_delete', release = release, opts = opts }
+          )
+        end,
+        browse_commit = function(opts)
+          table.insert(captured.ops_calls, { name = 'browse_commit', opts = opts })
+          require('forge').open('browse.commit', opts)
+        end,
+        browse_branch = function(branch, opts)
+          table.insert(captured.ops_calls, { name = 'browse_branch', branch = branch, opts = opts })
+          require('forge').open(
+            'browse.branch',
+            vim.tbl_extend('force', opts or {}, { branch = branch })
+          )
+        end,
+        browse_contextual = function(opts)
+          table.insert(captured.ops_calls, { name = 'browse_contextual', opts = opts })
+          require('forge').open('browse.contextual', opts)
+        end,
+        browse_location = function(f, location, scope)
+          table.insert(
+            captured.ops_calls,
+            { name = 'browse_location', location = location, scope = scope }
+          )
+          f:browse(location.path .. ':10-20', location.rev.rev, scope)
+          return true
+        end,
+        browse_file = function(f, file_loc, branch, scope)
+          table.insert(captured.ops_calls, {
+            name = 'browse_file',
+            file_loc = file_loc,
+            branch = branch,
+            scope = scope,
+          })
+          f:browse(file_loc, branch, scope)
+          return true
+        end,
+      }
+    end
+
     package.preload['forge.pickers'] = function()
       return {
         pr_actions = function(_, pr)
@@ -210,6 +326,7 @@ describe(':Forge command', function()
     package.loaded['forge'] = nil
     package.loaded['forge.cmd'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.pickers'] = nil
     package.loaded['forge.review'] = nil
 
@@ -221,11 +338,13 @@ describe(':Forge command', function()
     vim.fn.systemlist = old_systemlist
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.ops'] = old_preload['forge.ops']
     package.preload['forge.pickers'] = old_preload['forge.pickers']
     package.preload['forge.review'] = old_preload['forge.review']
     package.loaded['forge'] = nil
     package.loaded['forge.cmd'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.pickers'] = nil
     package.loaded['forge.review'] = nil
     if vim.api.nvim_get_commands({ builtin = false }).Forge then
@@ -236,17 +355,21 @@ describe(':Forge command', function()
   it('dispatches :Forge pr review to the PR review action', function()
     vim.cmd('Forge pr review 42')
 
-    assert.equals('42', captured.pr_action_num)
-    assert.is_nil(captured.pr_action_scope)
-    assert.same({ '42' }, captured.reviews)
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '42', scope = nil },
+      opts = nil,
+    }, captured.ops_calls[1])
   end)
 
   it('keeps :Forge pr diff as an alias for the PR review action', function()
     vim.cmd('Forge pr diff 7')
 
-    assert.equals('7', captured.pr_action_num)
-    assert.is_nil(captured.pr_action_scope)
-    assert.same({ '7' }, captured.reviews)
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '7', scope = nil },
+      opts = nil,
+    }, captured.ops_calls[1])
   end)
 
   it('dispatches review navigation subcommands', function()
@@ -347,15 +470,15 @@ describe(':Forge command', function()
 
     assert.is_false(ok)
     assert.matches('E477: No ! allowed', err)
-    assert.is_nil(captured.pr_action_num)
+    assert.is_nil(captured.ops_calls[1])
   end)
 
   it('allows supported bang on close subcommands', function()
     vim.cmd('Forge! pr close 42')
     vim.cmd('Forge! issue close 9')
 
-    assert.same({ '42' }, captured.closed_prs)
-    assert.same({ '9' }, captured.closed_issues)
+    assert.same({ name = 'pr_close', pr = { num = '42', scope = nil } }, captured.ops_calls[1])
+    assert.same({ name = 'issue_close', issue = { num = '9', scope = nil } }, captured.ops_calls[2])
   end)
 
   it('completes git-local subcommands and commit refs', function()

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -1,0 +1,182 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('shared operations', function()
+  local captured
+  local old_system
+  local old_fn_system
+  local old_ui_select
+  local old_preload
+
+  before_each(function()
+    captured = {
+      commands = {},
+      infos = {},
+      errors = {},
+      sessions = {},
+      opened = 0,
+    }
+
+    old_system = vim.system
+    old_fn_system = vim.fn.system
+    old_ui_select = vim.ui.select
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.review'] = package.preload['forge.review'],
+    }
+
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return 'feature\n'
+      end
+      return ''
+    end
+
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      captured.commands[#captured.commands + 1] = key
+      if key == 'pr-base 42' then
+        result.stdout = 'main\n'
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    vim.ui.select = function(_, _, cb)
+      cb('Yes')
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        info = function(msg)
+          captured.infos[#captured.infos + 1] = msg
+        end,
+        error = function(msg)
+          captured.errors[#captured.errors + 1] = msg
+        end,
+        debug = function() end,
+        warn = function() end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        remote_ref = function(_, branch)
+          return 'origin/' .. branch
+        end,
+        open = function() end,
+      }
+    end
+
+    package.preload['forge.review'] = function()
+      return {
+        start_session = function(session)
+          captured.sessions[#captured.sessions + 1] = session
+        end,
+        open_index = function()
+          captured.opened = captured.opened + 1
+        end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
+    package.loaded['forge.review'] = nil
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.fn.system = old_fn_system
+    vim.ui.select = old_ui_select
+
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.review'] = old_preload['forge.review']
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
+    package.loaded['forge.review'] = nil
+  end)
+
+  it('starts PR review sessions through the shared operation', function()
+    local ops = require('forge.ops')
+    ops.pr_review({
+      labels = { pr_one = 'PR' },
+      checkout_cmd = function(_, num)
+        return { 'checkout', num }
+      end,
+      pr_base_cmd = function(_, num)
+        return { 'pr-base', num }
+      end,
+    }, { num = '42' })
+
+    vim.wait(100, function()
+      return captured.opened == 1
+    end)
+
+    assert.same({ 'checkout 42', 'pr-base 42' }, captured.commands)
+    assert.equals('origin/main', captured.sessions[1].subject.base_ref)
+    assert.equals('feature', captured.sessions[1].subject.head_ref)
+    assert.equals('/repo', captured.sessions[1].repo_root)
+    assert.equals(1, captured.opened)
+  end)
+
+  it('runs PR close commands and success callbacks through the shared operation', function()
+    local done = 0
+    local ops = require('forge.ops')
+    ops.pr_close({
+      labels = { pr_one = 'PR' },
+      close_cmd = function(_, num)
+        return { 'close', num }
+      end,
+    }, { num = '42' }, {
+      on_success = function()
+        done = done + 1
+      end,
+    })
+
+    vim.wait(100, function()
+      return done == 1
+    end)
+
+    assert.same({ 'close 42' }, captured.commands)
+    assert.equals(1, done)
+  end)
+
+  it('confirms release deletion before running the shared delete operation', function()
+    local done = 0
+    local ops = require('forge.ops')
+    ops.release_delete({
+      delete_release_cmd = function(_, tag)
+        return { 'delete', tag }
+      end,
+    }, { tag = 'v1.2.3' }, {
+      on_success = function()
+        done = done + 1
+      end,
+    })
+
+    vim.wait(100, function()
+      return done == 1
+    end)
+
+    assert.same({ 'delete v1.2.3' }, captured.commands)
+    assert.equals(1, done)
+  end)
+end)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -4,6 +4,7 @@ local captured
 local cache
 local issue_create_calls
 local issue_create_opts
+local op_calls
 local pr_create_calls
 local pr_create_opts
 local default_system
@@ -127,6 +128,7 @@ describe('pickers', function()
     captured = nil
     issue_create_calls = 0
     issue_create_opts = nil
+    op_calls = {}
     pr_create_calls = 0
     pr_create_opts = nil
     default_system = vim.system
@@ -149,6 +151,7 @@ describe('pickers', function()
       ['fzf-lua.utils'] = package.preload['fzf-lua.utils'],
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.ops'] = package.preload['forge.ops'],
       ['forge.picker'] = package.preload['forge.picker'],
     }
     package.preload['fzf-lua.utils'] = function()
@@ -174,6 +177,92 @@ describe('pickers', function()
         end,
         pick = function(opts)
           captured = opts
+        end,
+      }
+    end
+    package.preload['forge.ops'] = function()
+      return {
+        pr_checkout = function(_, pr)
+          table.insert(op_calls, { name = 'pr_checkout', pr = pr })
+        end,
+        pr_browse = function(_, pr)
+          table.insert(op_calls, { name = 'pr_browse', pr = pr })
+        end,
+        pr_worktree = function(_, pr)
+          table.insert(op_calls, { name = 'pr_worktree', pr = pr })
+        end,
+        pr_review = function(_, pr, opts)
+          table.insert(op_calls, { name = 'pr_review', pr = pr, opts = opts })
+        end,
+        pr_ci = function(_, pr, opts)
+          table.insert(op_calls, { name = 'pr_ci', pr = pr, opts = opts })
+        end,
+        pr_manage = function(_, pr, parent)
+          table.insert(op_calls, { name = 'pr_manage', pr = pr, parent = parent })
+          require('forge.pickers').pr_manage(fake_forge(), pr, parent)
+        end,
+        pr_edit = function(pr)
+          table.insert(op_calls, { name = 'pr_edit', pr = pr })
+        end,
+        pr_create = function(opts)
+          require('forge').create_pr(opts)
+        end,
+        pr_close = function(_, pr, opts)
+          table.insert(op_calls, { name = 'pr_close', pr = pr })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        pr_reopen = function(_, pr, opts)
+          table.insert(op_calls, { name = 'pr_reopen', pr = pr })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        pr_approve = function(_, pr, opts)
+          table.insert(op_calls, { name = 'pr_approve', pr = pr })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        pr_merge = function(_, pr, method, opts)
+          table.insert(op_calls, { name = 'pr_merge', pr = pr, method = method })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        pr_toggle_draft = function(_, pr, is_draft, opts)
+          table.insert(op_calls, { name = 'pr_toggle_draft', pr = pr, is_draft = is_draft })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        issue_browse = function(_, issue)
+          table.insert(op_calls, { name = 'issue_browse', issue = issue })
+        end,
+        issue_create = function(opts)
+          require('forge').create_issue(opts)
+        end,
+        issue_close = function(_, issue, opts)
+          table.insert(op_calls, { name = 'issue_close', issue = issue })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        issue_reopen = function(_, issue, opts)
+          table.insert(op_calls, { name = 'issue_reopen', issue = issue })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
+        end,
+        release_browse = function(_, release)
+          table.insert(op_calls, { name = 'release_browse', release = release })
+        end,
+        release_delete = function(_, release, opts)
+          table.insert(op_calls, { name = 'release_delete', release = release })
+          if opts and opts.on_success then
+            opts.on_success()
+          end
         end,
       }
     end
@@ -286,6 +375,7 @@ describe('pickers', function()
     package.loaded['forge'] = nil
     package.loaded['forge.config'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.picker.session'] = nil
     package.loaded['forge.pickers'] = nil
@@ -297,10 +387,12 @@ describe('pickers', function()
     package.preload['fzf-lua.utils'] = old_preload['fzf-lua.utils']
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.ops'] = old_preload['forge.ops']
     package.preload['forge.picker'] = old_preload['forge.picker']
     package.loaded['forge'] = nil
     package.loaded['forge.config'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.picker.session'] = nil
     package.loaded['forge.pickers'] = nil
@@ -342,6 +434,19 @@ describe('pickers', function()
     assert.is_false(rawget(action_by_name('worktree'), 'close'))
     assert.is_nil(rawget(action_by_name('checkout'), 'close'))
     assert.is_nil(rawget(action_by_name('manage'), 'close'))
+  end)
+
+  it('routes PR review actions through forge.ops', function()
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+
+    action_by_name('review').fn(captured.entries[1])
+
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '42', scope = nil },
+      opts = {},
+    }, op_calls[1])
   end)
 
   it('shows edit inside the more picker', function()


### PR DESCRIPTION
## Problem

Issue #148 remained because picker actions and `:Forge` command dispatch were still expressing the same semantic operations through separate paths, which risked drift as the new CLI grows.

## Solution

Add a dedicated `forge.ops` shared-operations layer, route normalized command dispatch and picker actions through it for overlapping semantic actions, add direct ops tests plus command/picker delegation coverage, and document the shared-ops architecture in the help file.

Closes #148.