### PR TITLE
feat(cmd): add Forge contextual completion (#146)

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -21,6 +21,7 @@ CONTENTS                                                 *forge.nvim-contents*
     COMMANDS..........................................................|:Forge|
     `:Forge`..................................................|:Forge-no-args|
     TARGET DEFAULTS AND OVERRIDES......................|forge-target-defaults|
+    COMMAND COMPLETION................................|forge-command-completion|
     `:Forge pr` [{flags}]..........................................|:Forge-pr|
     `:Forge pr create` [{flags}]............................|:Forge-pr-create|
     `:Forge pr checkout` {num}............................|:Forge-pr-checkout|
@@ -345,6 +346,17 @@ TARGET DEFAULTS AND OVERRIDES                            *forge-target-defaults*
       context and `base=` to the collaboration repo default branch
     - `:Forge browse` defaults to the current file/line selection on the
       current branch in the current repo
+
+COMMAND COMPLETION                                  *forge-command-completion*
+    `:Forge` completion is contextual:
+    - families are suggested after `:Forge `
+    - verbs are suggested after a family such as `:Forge pr `
+    - only valid modifiers are suggested for the resolved subcommand
+    - `repo=` suggests configured aliases, git remotes, and resolved repo
+      addresses
+    - `rev=`, `head=`, and `base=` suggest revision addresses using `@...`
+    - `target=` suggests repo/revision prefixes and leaves path completion
+      after `:` for future work
 
 `:Forge pr` [{flags}]                                              *:Forge-pr*
     Open the PR list picker for the collaboration repo. Defaults to open

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1097,16 +1097,60 @@ function M.run(opts)
   return M.dispatch(command)
 end
 
-local function modifier_completion_items(command, legacy)
-  local items = {}
-  local names = legacy and command.declared_legacy_modifiers or command.declared_modifiers
-  for _, name in ipairs(names or {}) do
-    local spec = modifiers[name]
-    local prefix = legacy and '--' or ''
-    if spec and spec.kind == 'flag' then
-      items[#items + 1] = prefix .. name
+local function completion_state(command, args)
+  local state = {
+    subjects = {},
+    modifiers = {},
+  }
+  for _, token in ipairs(args) do
+    local name, value
+    if token:match('^%-%-') then
+      local body = token:sub(3)
+      local eq = body:find('=', 1, true)
+      if eq then
+        name = body:sub(1, eq - 1)
+        value = body:sub(eq + 1)
+      else
+        name = body
+        value = true
+      end
     else
-      items[#items + 1] = prefix .. name .. '='
+      local eq = token:find('=', 1, true)
+      if eq then
+        name = token:sub(1, eq - 1)
+        value = token:sub(eq + 1)
+      end
+    end
+    if
+      name
+      and (
+        list_contains(command.declared_modifiers or {}, name)
+        or list_contains(command.declared_legacy_modifiers or {}, name)
+      )
+    then
+      if state.modifiers[name] == nil then
+        state.modifiers[name] = value
+      end
+    else
+      state.subjects[#state.subjects + 1] = token
+    end
+  end
+  return state
+end
+
+local function filtered_modifier_completion_items(command, state, legacy)
+  local items = {}
+  local names = legacy and (command.declared_legacy_modifiers or command.legacy_modifiers)
+    or (command.declared_modifiers or command.modifiers)
+  for _, name in ipairs(names or {}) do
+    if state.modifiers[name] == nil then
+      local spec = modifiers[name]
+      local prefix = legacy and '--' or ''
+      if spec and spec.kind == 'flag' then
+        items[#items + 1] = prefix .. name
+      else
+        items[#items + 1] = prefix .. name .. '='
+      end
     end
   end
   return items
@@ -1118,22 +1162,180 @@ local function filter(candidates, arglead)
   end, candidates)
 end
 
-local function completion_values(family_name, verb_name, flag_name)
+local function system_lines(cmd)
+  if type(cmd) == 'table' then
+    local result = vim.system(cmd, { text = true }):wait()
+    if result.code ~= 0 then
+      return {}
+    end
+    local output = vim.trim(result.stdout or '')
+    return output == '' and {} or vim.split(output, '\n', { plain = true, trimempty = true })
+  end
+  local lines = vim.fn.systemlist(cmd)
+  if vim.v.shell_error ~= 0 then
+    return {}
+  end
+  return lines
+end
+
+local function add_completion_candidate(items, seen, value)
+  if type(value) ~= 'string' or value == '' or seen[value] then
+    return
+  end
+  seen[value] = true
+  items[#items + 1] = value
+end
+
+local function repo_completion_values(prefix)
+  local target = require('forge.target')
+  local parse_opts = target_parse_opts()
+  local items = {}
+  local seen = {}
+
+  local alias_names = {}
+  for name in pairs(parse_opts.aliases or {}) do
+    alias_names[#alias_names + 1] = name
+  end
+  table.sort(alias_names)
+  for _, name in ipairs(alias_names) do
+    add_completion_candidate(items, seen, name)
+  end
+
+  for _, remote in ipairs(system_lines({ 'git', 'remote' })) do
+    add_completion_candidate(items, seen, remote)
+    local resolved = target.resolve_repo(remote, parse_opts)
+    if resolved then
+      add_completion_candidate(items, seen, resolved.slug)
+      if resolved.host and resolved.slug then
+        add_completion_candidate(items, seen, resolved.host .. '/' .. resolved.slug)
+      end
+    end
+  end
+
+  for _, repo in ipairs({
+    target.current_repo(parse_opts),
+    target.push_repo(parse_opts),
+    target.collaboration_repo(parse_opts),
+  }) do
+    if repo then
+      add_completion_candidate(items, seen, repo.slug)
+      if repo.host and repo.slug then
+        add_completion_candidate(items, seen, repo.host .. '/' .. repo.slug)
+      end
+    end
+  end
+
+  return filter(items, prefix)
+end
+
+local function ref_completion_values(prefix)
+  local items = {}
+  local seen = {}
+  for _, ref in
+    ipairs(system_lines('git for-each-ref --format=%(refname:short) refs/heads refs/tags'))
+  do
+    add_completion_candidate(items, seen, ref)
+  end
+  for _, sha in
+    ipairs(system_lines({ 'git', 'rev-list', '--max-count=20', '--abbrev-commit', 'HEAD' }))
+  do
+    add_completion_candidate(items, seen, sha)
+  end
+  return filter(items, prefix)
+end
+
+local function rev_address_completion_values(prefix)
+  local items = {}
+  local seen = {}
+  local at = prefix:find('@', 1, true)
+  if at then
+    local repo = prefix:sub(1, at - 1)
+    local rev_prefix = prefix:sub(at + 1)
+    local base = repo ~= '' and (repo .. '@') or '@'
+    for _, ref in ipairs(ref_completion_values(rev_prefix)) do
+      add_completion_candidate(items, seen, base .. ref)
+    end
+    return items
+  end
+
+  for _, repo in ipairs(repo_completion_values(prefix)) do
+    add_completion_candidate(items, seen, repo .. '@')
+  end
+  for _, ref in ipairs(ref_completion_values('')) do
+    add_completion_candidate(items, seen, '@' .. ref)
+  end
+  return filter(items, prefix)
+end
+
+local function target_completion_values(prefix)
+  if prefix:find(':', 1, true) then
+    return {}
+  end
+  local items = {}
+  local seen = {}
+  local at = prefix:find('@', 1, true)
+  if at then
+    for _, value in ipairs(rev_address_completion_values(prefix)) do
+      add_completion_candidate(items, seen, value .. ':')
+    end
+    return items
+  end
+
+  for _, repo in ipairs(repo_completion_values(prefix)) do
+    add_completion_candidate(items, seen, repo .. '@')
+  end
+  for _, ref in ipairs(ref_completion_values('')) do
+    add_completion_candidate(items, seen, '@' .. ref .. ':')
+  end
+  return filter(items, prefix)
+end
+
+local function completion_values(family_name, verb_name, flag_name, prefix)
   local command = M.resolve(family_name, verb_name)
   if not command then
     return nil
   end
+  if flag_name == 'repo' then
+    return repo_completion_values(prefix or '')
+  end
+  if flag_name == 'rev' or flag_name == 'head' or flag_name == 'base' then
+    return rev_address_completion_values(prefix or '')
+  end
+  if flag_name == 'target' then
+    return target_completion_values(prefix or '')
+  end
   if flag_name == 'template' then
-    return require('forge').template_slugs()
+    return filter(require('forge').template_slugs(), prefix or '')
   end
   if command.modifier_values and command.modifier_values[flag_name] then
-    return command.modifier_values[flag_name]
+    return filter(command.modifier_values[flag_name], prefix or '')
   end
   local spec = modifiers[flag_name]
   if spec and spec.values then
-    return spec.values
+    return filter(spec.values, prefix or '')
   end
   return nil
+end
+
+local function subject_completion_items(command, state, arglead)
+  local subject = command.subject or { min = 0, max = 0 }
+  local max = subject.max or subject.min or 0
+  if max ~= nil and #state.subjects >= max then
+    return {}
+  end
+  if subject.kind == 'branch' then
+    return ref_completion_values(arglead)
+  end
+  if subject.kind == 'rev' then
+    return ref_completion_values(arglead)
+  end
+  if subject.kind == 'sha' then
+    return filter(
+      system_lines({ 'git', 'rev-list', '--max-count=20', '--abbrev-commit', 'HEAD' }),
+      arglead
+    )
+  end
+  return {}
 end
 
 function M.complete(arglead, cmdline, _)
@@ -1149,20 +1351,20 @@ function M.complete(arglead, cmdline, _)
 
   local legacy_flag, legacy_prefix = arglead:match('^(%-%-[^=]+)=(.*)$')
   if legacy_flag then
-    local values = completion_values(family_name, explicit_verb, legacy_flag:sub(3))
+    local values = completion_values(family_name, explicit_verb, legacy_flag:sub(3), legacy_prefix)
     if values then
       return vim.tbl_map(function(v)
         return legacy_flag .. '=' .. v
-      end, filter(values, legacy_prefix))
+      end, values)
     end
   end
   local flag, value_prefix = arglead:match('^([%w%-_]+)=(.*)$')
   if flag then
-    local values = completion_values(family_name, explicit_verb, flag)
+    local values = completion_values(family_name, explicit_verb, flag, value_prefix)
     if values then
       return vim.tbl_map(function(v)
         return flag .. '=' .. v
-      end, filter(values, value_prefix))
+      end, values)
     end
   end
   if arg_idx == 1 then
@@ -1172,37 +1374,38 @@ function M.complete(arglead, cmdline, _)
     return {}
   end
   if arg_idx == 2 then
+    local command = M.resolve(family_name)
+    local state = command and completion_state(command, {}) or { modifiers = {}, subjects = {} }
     local candidates = {}
     for _, verb in ipairs(M.verb_names(family_name)) do
-      if verb ~= family.default_verb then
-        candidates[#candidates + 1] = verb
+      candidates[#candidates + 1] = verb
+    end
+    if command then
+      if arglead:match('^%-%-') then
+        vim.list_extend(candidates, filtered_modifier_completion_items(command, state, true))
+      else
+        vim.list_extend(candidates, filtered_modifier_completion_items(command, state, false))
+        vim.list_extend(candidates, subject_completion_items(command, state, arglead))
       end
-    end
-    local implicit = M.resolve(family_name)
-    if implicit then
-      vim.list_extend(candidates, modifier_completion_items(implicit, true))
-    end
-    if (family_name == 'ci' or family_name == 'commits') and not arglead:match('^%-') then
-      vim.list_extend(
-        candidates,
-        vim.fn.systemlist('git for-each-ref --format=%(refname:short) refs/heads refs/tags')
-      )
     end
     return filter(candidates, arglead)
   end
-  if family_name == 'review' and words[3] == 'branch' and arg_idx == 3 then
-    return filter(
-      vim.fn.systemlist('git for-each-ref --format=%(refname:short) refs/heads refs/tags'),
-      arglead
-    )
+  local command = M.resolve(family_name, explicit_verb)
+  if not command then
+    return {}
   end
-  if explicit_verb then
-    local command = M.resolve(family_name, explicit_verb)
-    if command then
-      return filter(modifier_completion_items(command, true), arglead)
-    end
+  local rest_index = explicit_verb and 4 or 3
+  local consumed = {}
+  for i = rest_index, arglead == '' and #words or (#words - 1) do
+    consumed[#consumed + 1] = words[i]
   end
-  return {}
+  local state = completion_state(command, consumed)
+  if arglead:match('^%-%-') then
+    return filter(filtered_modifier_completion_items(command, state, true), arglead)
+  end
+  local candidates = filtered_modifier_completion_items(command, state, false)
+  vim.list_extend(candidates, subject_completion_items(command, state, arglead))
+  return filter(candidates, arglead)
 end
 
 return M

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -48,6 +48,8 @@ describe(':Forge command', function()
         result = { code = 1, stdout = '', stderr = '' }
       elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
         result = { code = 0, stdout = 'origin/main\n', stderr = '' }
+      elseif key == 'git rev-list --max-count=20 --abbrev-commit HEAD' then
+        result = { code = 0, stdout = 'deadbee\nabc123\n', stderr = '' }
       end
       if cb then
         cb(result)
@@ -112,6 +114,19 @@ describe(':Forge command', function()
             root = '/repo',
             branch = 'main',
             head = 'abc123',
+          }
+        end,
+        config = function()
+          return {
+            targets = {
+              aliases = {
+                mirror = 'remote:upstream',
+                work = 'github.com/owner/work',
+              },
+              ci = {
+                repo = 'current',
+              },
+            },
           }
         end,
         create_pr = function(opts)
@@ -332,7 +347,7 @@ describe(':Forge command', function()
 
     vim.fn.systemlist = function(cmd)
       if cmd == 'git for-each-ref --format=%(refname:short) refs/heads refs/tags' then
-        return { 'main', 'feature' }
+        return { 'main', 'feature', 'v1.0.0' }
       end
       return old_systemlist(cmd)
     end
@@ -567,6 +582,62 @@ describe(':Forge command', function()
       name = 'ci_watch',
       run = { id = '456', scope = nil },
     }, captured.ops_calls[2])
+  end)
+
+  it('completes families, verbs, and valid canonical modifiers contextually', function()
+    local families = vim.fn.getcompletion('Forge ', 'cmdline')
+    local pr = vim.fn.getcompletion('Forge pr ', 'cmdline')
+    local pr_create = vim.fn.getcompletion('Forge pr create ', 'cmdline')
+    local issue_create = vim.fn.getcompletion('Forge issue create ', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(families, 'pr'))
+    assert.is_true(vim.tbl_contains(families, 'ci'))
+    assert.is_true(vim.tbl_contains(families, 'browse'))
+
+    assert.is_true(vim.tbl_contains(pr, 'list'))
+    assert.is_true(vim.tbl_contains(pr, 'approve'))
+    assert.is_true(vim.tbl_contains(pr, 'merge'))
+    assert.is_true(vim.tbl_contains(pr, 'draft'))
+    assert.is_true(vim.tbl_contains(pr, 'ready'))
+    assert.is_true(vim.tbl_contains(pr, 'state='))
+    assert.is_true(vim.tbl_contains(pr, 'repo='))
+
+    assert.is_true(vim.tbl_contains(pr_create, 'head='))
+    assert.is_true(vim.tbl_contains(pr_create, 'base='))
+    assert.is_true(vim.tbl_contains(pr_create, 'draft'))
+    assert.is_true(vim.tbl_contains(pr_create, 'fill'))
+    assert.is_true(vim.tbl_contains(pr_create, 'web'))
+    assert.is_false(vim.tbl_contains(pr_create, 'state='))
+
+    assert.is_true(vim.tbl_contains(issue_create, 'template='))
+    assert.is_true(vim.tbl_contains(issue_create, 'blank'))
+    assert.is_true(vim.tbl_contains(issue_create, 'web'))
+    assert.is_false(vim.tbl_contains(issue_create, 'head='))
+  end)
+
+  it('completes modifier values for repo, revision, and target addresses', function()
+    local repos = vim.fn.getcompletion('Forge pr list repo=', 'cmdline')
+    local revs = vim.fn.getcompletion('Forge ci list rev=', 'cmdline')
+    local heads = vim.fn.getcompletion('Forge pr create head=', 'cmdline')
+    local target_revs = vim.fn.getcompletion('Forge browse target=work@', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(repos, 'repo=work'))
+    assert.is_true(vim.tbl_contains(repos, 'repo=mirror'))
+    assert.is_true(vim.tbl_contains(repos, 'repo=origin'))
+    assert.is_true(vim.tbl_contains(repos, 'repo=upstream'))
+
+    assert.is_true(vim.tbl_contains(revs, 'rev=@main'))
+    assert.is_true(vim.tbl_contains(revs, 'rev=@feature'))
+    assert.is_true(vim.tbl_contains(revs, 'rev=@v1.0.0'))
+    assert.is_true(vim.tbl_contains(revs, 'rev=@deadbee'))
+
+    assert.is_true(vim.tbl_contains(heads, 'head=work@'))
+    assert.is_true(vim.tbl_contains(heads, 'head=origin@'))
+    assert.is_true(vim.tbl_contains(heads, 'head=@main'))
+    assert.is_true(vim.tbl_contains(heads, 'head=@deadbee'))
+
+    assert.is_true(vim.tbl_contains(target_revs, 'target=work@main:'))
+    assert.is_true(vim.tbl_contains(target_revs, 'target=work@feature:'))
   end)
 
   it('completes git-local subcommands and commit refs', function()


### PR DESCRIPTION
## Problem
The normalized `:Forge` command language still required users to memorize families, verbs, and target syntax because command-line completion only handled a few shallow cases. Closes #146.

## Solution
Drive `:Forge` completion from resolved command shape so each subcommand suggests only valid verbs, modifiers, and value forms, including repo aliases/remotes and revision or target address prefixes. Add command-spec coverage for the new completion behavior and document the completion model in the help text.