### PR TITLE
feat(delete): inline branch and worktree confirmations

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -135,6 +135,23 @@ Top-level keys: ~
     Default split direction for terminal views. One of `"horizontal"` or
     `"vertical"`. Individual scopes (e.g. `ci.split`) override this value.
 
+`confirm`                                               *forge-config-confirm*
+  `table`  (default shown below)
+    Confirmation settings for destructive picker actions.
+
+  Defaults: >lua
+      confirm = {
+        branch_delete = true,
+        worktree_delete = true,
+      }
+<
+
+  `branch_delete`   `boolean`  (default `true`)
+    Ask for confirmation before deleting a branch from the branch picker.
+
+  `worktree_delete` `boolean`  (default `true`)
+    Ask for confirmation before deleting a worktree from the worktree picker.
+
 `ci`                                                         *forge-config-ci*
   `ci.lines`        `integer`  (default `1000`)
     Maximum number of log lines fetched for CI/check log output.
@@ -719,7 +736,8 @@ markers, upstream, and tip commit summary. `*` marks the current branch and
   `switch`      `<cr>`           Switch to the selected branch, or jump to its
                                 worktree when the row is marked `+`
   `review`      `<c-d>`          Start branch review
-  `delete`      `<c-s>`          Delete a non-current branch after confirmation
+  `delete`      `<c-s>`          Delete a non-current branch after `[y/N]`
+                                confirmation
   `browse`      `<c-x>`          Open branch in browser
   `yank`        `<c-y>`          Copy branch name to `+` register
   `refresh`     `<c-r>`          Clear cache and re-fetch
@@ -745,7 +763,8 @@ path segments when needed to preserve the distinguishing tail.
   Action      Default Key    Description ~
   `switch cwd`  `<cr>`           Change Neovim's cwd to the selected worktree
   `add`         `<c-a>`          Add a sibling worktree for a branch name
-  `delete`      `<c-s>`          Delete a non-current worktree after confirmation
+  `delete`      `<c-s>`          Delete a non-current worktree after `[y/N]`
+                                confirmation
   `yank`        `<c-y>`          Copy worktree path to `+` register
   `refresh`     `<c-r>`          Clear cache and re-fetch
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -7,6 +7,7 @@ local M = {}
 ---@field debug boolean|string?
 ---@field split forge.Split
 ---@field ci forge.CIConfig
+---@field confirm forge.ConfirmConfig
 ---@field sources table<string, forge.SourceConfig>
 ---@field keys forge.KeysConfig|false
 ---@field display forge.DisplayConfig
@@ -15,6 +16,10 @@ local M = {}
 ---@field lines integer
 ---@field split forge.Split?
 ---@field refresh integer
+
+---@class forge.ConfirmConfig
+---@field branch_delete boolean
+---@field worktree_delete boolean
 
 ---@class forge.SourceConfig
 ---@field hosts string[]
@@ -114,6 +119,10 @@ local DEFAULTS = {
   debug = false,
   split = 'horizontal',
   ci = { lines = 1000, refresh = 5 },
+  confirm = {
+    branch_delete = true,
+    worktree_delete = true,
+  },
   targets = {
     aliases = {},
     ci = {
@@ -316,6 +325,9 @@ function M.config()
   vim.validate('forge.split', cfg.split, function(v)
     return v == 'horizontal' or v == 'vertical'
   end, "'horizontal' or 'vertical'")
+  vim.validate('forge.confirm', cfg.confirm, 'table')
+  vim.validate('forge.confirm.branch_delete', cfg.confirm.branch_delete, 'boolean')
+  vim.validate('forge.confirm.worktree_delete', cfg.confirm.worktree_delete, 'boolean')
   vim.validate('forge.display', cfg.display, 'table')
   vim.validate('forge.ci', cfg.ci, 'table')
   vim.validate('forge.ci.lines', cfg.ci.lines, 'number')

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -154,6 +154,26 @@ local function change_directory(path)
   log.info('changed directory to ' .. path)
 end
 
+local function confirm_input(prompt, enabled, on_confirm, on_cancel)
+  if enabled == false then
+    on_confirm()
+    return
+  end
+
+  vim.ui.input({
+    prompt = prompt .. ' [y/N] ',
+  }, function(input)
+    local choice = vim.trim((input or '')):lower()
+    if choice == 'y' or choice == 'yes' then
+      on_confirm()
+      return
+    end
+    if on_cancel then
+      on_cancel()
+    end
+  end)
+end
+
 local function split_records(text)
   return vim.tbl_map(function(record)
     return vim.split(record, field_sep, { plain = true })
@@ -1846,6 +1866,7 @@ function M.branches(ctx, opts)
             return
           end
           local item = entry.value
+          local confirm = require('forge').config().confirm
           if item.current then
             log.warn('cannot delete active branch ' .. item.name)
             return
@@ -1859,26 +1880,22 @@ function M.branches(ctx, opts)
             )
             return
           end
-          vim.ui.select({ 'Yes', 'No' }, {
-            prompt = 'Delete branch ' .. item.name .. '? ',
-          }, function(choice)
-            if choice == 'Yes' then
-              run_git_cmd(
-                'deleting branch ' .. item.name,
-                { 'git', 'branch', '--delete', item.name },
-                'deleted branch ' .. item.name,
-                'delete failed',
-                function()
-                  forge_mod.clear_list(cache_key)
-                  M.branches(ctx, { back = opts.back })
-                end,
-                function()
-                  M.branches(ctx, { back = opts.back })
-                end
-              )
-            else
-              M.branches(ctx, { back = opts.back })
-            end
+          confirm_input('Delete branch ' .. item.name .. '?', confirm.branch_delete, function()
+            run_git_cmd(
+              'deleting branch ' .. item.name,
+              { 'git', 'branch', '--delete', item.name },
+              'deleted branch ' .. item.name,
+              'delete failed',
+              function()
+                forge_mod.clear_list(cache_key)
+                M.branches(ctx, { back = opts.back })
+              end,
+              function()
+                M.branches(ctx, { back = opts.back })
+              end
+            )
+          end, function()
+            M.branches(ctx, { back = opts.back })
           end)
         end,
       },
@@ -2203,30 +2220,25 @@ function M.worktrees(ctx, opts)
               return
             end
             local item = entry.value
+            local confirm = require('forge').config().confirm
             if item.current then
               log.warn('cannot delete current worktree ' .. item.path)
               reopen()
               return
             end
-            vim.ui.select({ 'Yes', 'No' }, {
-              prompt = 'Delete worktree ' .. item.path .. '? ',
-            }, function(choice)
-              if choice == 'Yes' then
-                run_git_cmd(
-                  'deleting worktree ' .. item.path,
-                  { 'git', 'worktree', 'remove', item.path },
-                  'deleted worktree ' .. item.path,
-                  'worktree delete failed',
-                  function()
-                    forge_mod.clear_list(cache_key)
-                    reopen()
-                  end,
-                  reopen
-                )
-              else
-                reopen()
-              end
-            end)
+            confirm_input('Delete worktree ' .. item.path .. '?', confirm.worktree_delete, function()
+              run_git_cmd(
+                'deleting worktree ' .. item.path,
+                { 'git', 'worktree', 'remove', item.path },
+                'deleted worktree ' .. item.path,
+                'worktree delete failed',
+                function()
+                  forge_mod.clear_list(cache_key)
+                  reopen()
+                end,
+                reopen
+              )
+            end, reopen)
           end,
         },
         {

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -5,7 +5,6 @@ local cache
 local old_preload
 local old_system
 local old_cmd
-local old_ui_select
 local old_ui_input
 local old_win_get_width
 
@@ -18,13 +17,12 @@ end
 
 describe('git sections', function()
   before_each(function()
-    captured = { systems = {}, select_choice = 'Yes', input_value = 'new-tree' }
+    captured = { systems = {}, input_value = 'new-tree' }
     cache = {}
     local now = os.time()
 
     old_system = vim.system
     old_cmd = vim.cmd
-    old_ui_select = vim.ui.select
     old_ui_input = vim.ui.input
     old_win_get_width = vim.api.nvim_win_get_width
     vim.system = function(cmd, _, cb)
@@ -97,11 +95,6 @@ describe('git sections', function()
 
     vim.cmd = function(cmd)
       captured.cmd = cmd
-    end
-
-    vim.ui.select = function(_, opts, cb)
-      captured.select_prompt = opts.prompt
-      cb(captured.select_choice)
     end
 
     vim.ui.input = function(opts, cb)
@@ -195,7 +188,6 @@ describe('git sections', function()
   after_each(function()
     vim.system = old_system
     vim.cmd = old_cmd
-    vim.ui.select = old_ui_select
     vim.ui.input = old_ui_input
     vim.api.nvim_win_get_width = old_win_get_width
     package.preload['forge'] = old_preload['forge']
@@ -519,8 +511,9 @@ describe('git sections', function()
     assert.is_true(vim.tbl_contains(captured.systems, 'git worktree add /new-tree -b new-tree'))
 
     local entry = captured.picker.entries[2]
+    captured.input_value = 'y'
     captured.picker.actions[3].fn(entry)
-    assert.equals('Delete worktree /repo-feature? ', captured.select_prompt)
+    assert.equals('Delete worktree /repo-feature? [y/N] ', captured.input_prompt)
     vim.wait(100, function()
       return vim.tbl_contains(captured.systems, 'git worktree remove /repo-feature')
     end)
@@ -775,11 +768,56 @@ describe('git sections', function()
     )
 
     local delete_entry = captured.picker.entries[3]
+    captured.input_value = 'y'
     delete_action.fn(delete_entry)
-    assert.equals('Delete branch topic? ', captured.select_prompt)
+    assert.equals('Delete branch topic? [y/N] ', captured.input_prompt)
     vim.wait(100, function()
       return vim.tbl_contains(captured.systems, 'git branch --delete topic')
     end)
     assert.is_true(vim.tbl_contains(captured.systems, 'git branch --delete topic'))
+  end)
+
+
+  it('skips branch and worktree delete prompts when confirmation is disabled', function()
+    vim.g.forge = {
+      confirm = {
+        branch_delete = false,
+        worktree_delete = false,
+      },
+    }
+
+    require('forge.pickers').branches({
+      id = 'current',
+      root = '/repo',
+    })
+    vim.wait(100, function()
+      return captured.picker ~= nil
+    end)
+
+    local branch_delete
+    for _, action in ipairs(captured.picker.actions) do
+      if action.name == 'delete' then
+        branch_delete = action
+        break
+      end
+    end
+
+    branch_delete.fn(captured.picker.entries[3])
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.systems, 'git branch --delete topic')
+    end)
+    assert.is_nil(captured.input_prompt)
+
+    captured.picker = nil
+    require('forge.pickers').worktrees({ root = '/repo' })
+    vim.wait(100, function()
+      return captured.picker ~= nil
+    end)
+
+    captured.picker.actions[3].fn(captured.picker.entries[2])
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.systems, 'git worktree remove /repo-feature')
+    end)
+    assert.is_nil(captured.input_prompt)
   end)
 end)

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -28,6 +28,8 @@ describe('config', function()
     local cfg = forge.config()
     assert.equals(1000, cfg.ci.lines)
     assert.equals('horizontal', cfg.split)
+    assert.is_true(cfg.confirm.branch_delete)
+    assert.is_true(cfg.confirm.worktree_delete)
     assert.same({}, cfg.targets.aliases)
     assert.equals('current', cfg.targets.ci.repo)
     assert.equals(45, cfg.display.widths.title)
@@ -64,9 +66,15 @@ describe('config', function()
   end)
 
   it('deep-merges partial user config', function()
-    vim.g.forge = { ci = { lines = 500 }, display = { icons = { open = '>' } } }
+    vim.g.forge = {
+      ci = { lines = 500 },
+      confirm = { branch_delete = false },
+      display = { icons = { open = '>' } },
+    }
     local cfg = forge.config()
     assert.equals(500, cfg.ci.lines)
+    assert.is_false(cfg.confirm.branch_delete)
+    assert.is_true(cfg.confirm.worktree_delete)
     assert.equals('>', cfg.display.icons.open)
     assert.equals('m', cfg.display.icons.merged)
     assert.equals(45, cfg.display.widths.title)
@@ -695,6 +703,8 @@ describe('config validation', function()
     vim.g.forge = { split = 'horizontal' }
     local cfg = forge.config()
     assert.equals('horizontal', cfg.split)
+    assert.is_true(cfg.confirm.branch_delete)
+    assert.is_true(cfg.confirm.worktree_delete)
   end)
 
   it('accepts vertical split', function()
@@ -707,6 +717,8 @@ describe('config validation', function()
     vim.g.forge = { split = 'horizontal', ci = { split = 'vertical' } }
     local cfg = forge.config()
     assert.equals('horizontal', cfg.split)
+    assert.is_true(cfg.confirm.branch_delete)
+    assert.is_true(cfg.confirm.worktree_delete)
     assert.equals('vertical', cfg.ci.split)
   end)
 
@@ -731,6 +743,13 @@ describe('config validation', function()
 
   it('rejects non-number ci.refresh', function()
     vim.g.forge = { ci = { refresh = 'fast' } }
+    assert.has_error(function()
+      forge.config()
+    end)
+  end)
+
+  it('rejects invalid delete confirmation config', function()
+    vim.g.forge = { confirm = { branch_delete = 'nope' } }
     assert.has_error(function()
       forge.config()
     end)


### PR DESCRIPTION
## Problem

Branch and worktree deletes currently use a numbered choice prompt, which feels heavier than the rest of the picker UX and offers no way to skip confirmations for faster flows.

## Solution

Switch branch and worktree deletes to inline `[y/N]` prompts, add config flags to disable those confirmations, and update the picker docs and specs to match the new behavior.