### PR TITLE
fix(commit-picker): trim parsed rows and fallback locally

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -456,12 +456,17 @@ local function parse_commits(output)
   local commits = {}
   for _, fields in ipairs(split_records(output)) do
     if #fields >= 5 then
+      local sha = vim.trim(fields[1])
+      local short_sha = vim.trim(fields[2])
+      local subject = vim.trim(fields[3])
+      local author = vim.trim(fields[4])
+      local timestamp = vim.trim(fields[5])
       commits[#commits + 1] = {
-        sha = fields[1],
-        short_sha = fields[2],
-        subject = fields[3],
-        author = fields[4],
-        relative = format.relative_time_from_unix(fields[5]),
+        sha = sha,
+        short_sha = short_sha,
+        subject = subject,
+        author = author,
+        relative = format.relative_time_from_unix(timestamp),
       }
     end
   end
@@ -2074,7 +2079,7 @@ function M.commits(ctx, branch, opts)
     return
   end
 
-  local function fetch_commits(ref)
+  local function fetch_commits(ref, fallback_ref)
     log.info('fetching commits for ' .. branch .. '...')
     vim.system({
       'git',
@@ -2083,6 +2088,10 @@ function M.commits(ctx, branch, opts)
       '--format=%H%x1f%h%x1f%s%x1f%an%x1f%ct%x1e',
       ref,
     }, { text = true }, function(result)
+      if result.code ~= 0 and fallback_ref and fallback_ref ~= ref then
+        fetch_commits(fallback_ref)
+        return
+      end
       vim.schedule(function()
         if result.code ~= 0 then
           log.error(cmd_error(result, 'failed to fetch commits'))
@@ -2109,7 +2118,7 @@ function M.commits(ctx, branch, opts)
       if result.code == 0 then
         local upstream = vim.trim(result.stdout or '')
         if upstream ~= '' then
-          fetch_commits(upstream)
+          fetch_commits(upstream, branch)
           return
         end
       end

--- a/spec/git_sections_spec.lua
+++ b/spec/git_sections_spec.lua
@@ -347,6 +347,79 @@ describe('git sections', function()
     )
   end)
 
+  it('falls back to the local branch when the upstream log fetch fails and trims commit fields', function()
+    local ctx = {
+      forge = {
+        browse_commit = function(_, sha)
+          captured.browse_commit = sha
+        end,
+      },
+    }
+    local current_system = vim.system
+    vim.system = function(cmd, _, cb)
+      local key = table.concat(cmd, ' ')
+      captured.last_system = key
+      captured.systems[#captured.systems + 1] = key
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+
+      if key == 'git for-each-ref --format=%(upstream:short) refs/heads/main' then
+        result.stdout = 'origin/main\n'
+      elseif key == 'git log --max-count=101 --format=%H%x1f%h%x1f%s%x1f%an%x1f%ct%x1e origin/main' then
+        result.code = 128
+        result.stderr = 'fatal: bad revision origin/main'
+      elseif key == 'git log --max-count=101 --format=%H%x1f%h%x1f%s%x1f%an%x1f%ct%x1e main' then
+        local now = os.time()
+        result.stdout = record({
+          'abc123456789',
+          'abc1234',
+          'Add routes',
+          'Barrett',
+          tostring(now - 7200),
+        }) .. '\n' .. record({
+          'def567890123',
+          'def5678',
+          'Add sections',
+          'B',
+          tostring(now - 3600),
+        })
+      end
+
+      if cb then
+        cb(result)
+      end
+
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    require('forge.pickers').commits(ctx, 'main')
+    vim.wait(100, function()
+      return captured.picker ~= nil and captured.last_system == 'git log --max-count=101 --format=%H%x1f%h%x1f%s%x1f%an%x1f%ct%x1e main'
+    end)
+    vim.system = current_system
+
+    assert.equals(
+      'git log --max-count=101 --format=%H%x1f%h%x1f%s%x1f%an%x1f%ct%x1e main',
+      captured.last_system
+    )
+    assert.same({
+      { 'def5678', 'ForgeCommitHash' },
+      { ' Add sections' },
+      { ' B       ', 'ForgeCommitAuthor' },
+      { ' 1h', 'ForgeCommitTime' },
+    }, captured.picker.entries[2].display)
+
+    captured.picker.actions[2].fn(captured.picker.entries[2])
+    assert.equals('def567890123', captured.browse_commit)
+  end)
+
   it('adds a load more row when the commit list exceeds the configured limit', function()
     vim.g.forge = {
       display = {


### PR DESCRIPTION
## Problem

Commit picker rows can carry leading whitespace in parsed fields, and the picker can fail hard when a tracked upstream ref is stale or missing.

## Solution

Trim parsed commit fields before treating them as canonical picker data, and retry the history fetch against the local branch when the upstream `git log` call fails. Added targeted coverage for the retry path and the newline-prefixed SHA regression.