### PR TITLE
refactor(pr-picker): flatten root actions

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -32,7 +32,6 @@ CONTENTS                                                 *forge.nvim-contents*
     `:Forge pr worktree` {num}............................|:Forge-pr-worktree|
     `:Forge pr ci` {num}........................................|:Forge-pr-ci|
     `:Forge pr browse` {num}................................|:Forge-pr-browse|
-    `:Forge pr manage` {num}................................|:Forge-pr-manage|
     `:Forge pr approve` {num}..............................|:Forge-pr-approve|
     `:Forge pr merge` {num} [`method=`]....................|:Forge-pr-merge|
     `:Forge pr draft` {num}..................................|:Forge-pr-draft|
@@ -248,14 +247,24 @@ Top-level keys: ~
           worktree = '<c-w>',
           ci = '<c-t>',
           browse = '<c-x>',
-          create = '<c-a>',
+          edit = '<c-e>',
+          approve = '<c-a>',
+          merge = '<c-g>',
+          create = '<c-n>',
+          close = '<c-s>',
+          draft = '<c-d>',
           filter = '<tab>',
           refresh = '<c-r>',
         },
         issue = {
           browse = '<c-x>',
           close = '<c-s>',
-          create = '<c-a>',
+          edit = '<c-e>',
+          approve = '<c-a>',
+          merge = '<c-g>',
+          create = '<c-n>',
+          close = '<c-s>',
+          draft = '<c-d>',
           filter = '<tab>',
           refresh = '<c-r>',
         },
@@ -305,6 +314,10 @@ Top-level keys: ~
   `keys.back`
     Return to the parent picker when available. This action is active only on
     nested pickers and is not shown in header hints.
+
+  `keys.pr` supports secondary bindings for `worktree`, `ci`, `browse`,
+  `edit`, `approve`, `merge`, `create`, `close`, `draft`, and `refresh`.
+  The primary PR action remains `<cr>` checkout.
 
   Additional picker groups:
     `keys.branch` supports `delete`, `browse`, `yank`, and
@@ -428,7 +441,6 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge pr checkout` {num} [repo=...]                     *:Forge-pr-checkout*
     Check out the branch for PR `{num}`.
 
-
 `:Forge pr worktree` {num} [repo=...]                     *:Forge-pr-worktree*
     Fetch PR `{num}` and create a git worktree.
 
@@ -437,10 +449,6 @@ BANG SEMANTICS                                            *forge-command-bang*
 
 `:Forge pr browse` {num} [repo=...]                         *:Forge-pr-browse*
     Open PR `{num}` in the browser.
-
-`:Forge pr manage` {num} [repo=...]                         *:Forge-pr-manage*
-    Open the more picker for PR `{num}` (edit, approve, merge, close,
-    reopen, draft toggle).
 
 `:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
     Approve PR `{num}`.
@@ -618,11 +626,16 @@ placeholder row instead of appearing blank.
 PR PICKER ~ Lists PRs/MRs with number, title, author, and relative time.
 
   Action      Default Key    Description ~
-  `more`        `<cr>`           Open more picker
+  `checkout`    `<cr>`           Check out the selected PR
   `worktree`    `<c-w>`          Create worktree from PR
   `ci`          `<c-t>`          Open CI checks picker for this PR
   `browse`      `<c-x>`          Open PR in browser
-  `create`      `<c-a>`          Create new PR (|forge-compose|)
+  `edit`        `<c-e>`          Edit the selected PR
+  `approve`     `<c-a>`          Approve the selected PR
+  `merge`       `<c-g>`          Merge the selected PR
+  `create`      `<c-n>`          Create new PR (|forge-compose|)
+  `close`       `<c-s>`          Close or reopen the selected PR
+  `draft`       `<c-d>`          Toggle draft/ready for the selected PR
   `filter`      `<tab>`          Cycle state: open -> closed -> all
   `refresh`     `<c-r>`          Clear cache and re-fetch
 
@@ -704,11 +717,6 @@ prerelease badges are shown for forges that support them (GitHub, Codeberg).
   `delete`      `<c-d>`          Delete release (with confirmation)
   `filter`      `<tab>`          Cycle filter: all -> draft -> prerelease
   `refresh`     `<c-r>`          Clear cache and re-fetch
-
-                                                         *forge-picker-manage*
-MORE PICKER ~ Contextual actions for a specific PR, shown based on permissions
-and state: Edit, Approve, Merge (per available method: squash, rebase, merge),
-Close/Reopen, Mark as draft/Mark as ready.
 
 ==============================================================================
 WORKFLOW SURFACE                                              *forge-workflow*
@@ -1326,15 +1334,11 @@ PUBLIC API: `require('forge.pickers')` ~
     Opens the release list picker. `state`: `"all"`, `"draft"`, or
     `"prerelease"`. `f`: `forge.Forge`.
 
-                                                   *forge.pickers.pr_manage()*
-`pr_manage(f, num)`
-    Opens the more picker for PR `num`.
-
                                                *forge.pickers.pr_action_fns()*
 `pr_action_fns(f, num)`
     Returns `table<string, function>`. Action functions for PR `num`,
     keyed by action name (`"checkout"`, `"worktree"`, `"browse"`, `"ci"`,
-    `"manage"`, `"edit"`).
+    `"edit"`).
 
                                                  *forge.pickers.issue_close()*
 `issue_close(f, num)`

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -39,7 +39,6 @@ local families = {
       'worktree',
       'browse',
       'ci',
-      'manage',
       'close',
       'reopen',
       'create',
@@ -68,10 +67,6 @@ local families = {
         modifiers = { 'repo' },
       },
       ci = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
-      },
-      manage = {
         subject = { kind = 'pr', min = 1, max = 1 },
         modifiers = { 'repo' },
       },
@@ -521,10 +516,6 @@ local function dispatch_pr(command)
   end
   if command.name == 'browse' then
     ops.pr_browse(f, { num = num, scope = scope })
-    return
-  end
-  if command.name == 'manage' then
-    ops.pr_manage(f, { num = num, scope = scope })
     return
   end
   if command.name == 'approve' then

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -33,14 +33,15 @@ local M = {}
 ---@field log forge.LogViewerKeys?
 
 ---@class forge.PRPickerKeys
----@field checkout? string|false
 ---@field worktree string|false
 ---@field ci string|false
 ---@field browse string|false
----@field manage? string|false
----@field edit? string|false
+---@field edit string|false
+---@field approve string|false
+---@field merge string|false
 ---@field create string|false
----@field close? string|false
+---@field close string|false
+---@field draft string|false
 ---@field filter string|false
 ---@field filter_prev string|false
 ---@field refresh string|false
@@ -158,7 +159,12 @@ local DEFAULTS = {
       worktree = '<c-w>',
       ci = '<c-t>',
       browse = '<c-x>',
-      create = '<c-a>',
+      edit = '<c-e>',
+      approve = '<c-a>',
+      merge = '<c-g>',
+      create = '<c-n>',
+      close = '<c-s>',
+      draft = '<c-d>',
       filter = '<tab>',
       filter_prev = false,
       refresh = '<c-r>',
@@ -377,14 +383,15 @@ function M.config()
     if keys.pr ~= nil then
       vim.validate('forge.keys.pr', keys.pr, 'table')
       for _, k in ipairs({
-        'checkout',
         'worktree',
         'ci',
         'browse',
-        'manage',
         'edit',
+        'approve',
+        'merge',
         'create',
         'close',
+        'draft',
         'filter',
         'filter_prev',
         'refresh',

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -157,10 +157,6 @@ function M.pr_ci(f, pr, opts)
   end
 end
 
-function M.pr_manage(f, pr, parent)
-  require('forge.pickers').pr_manage(f, normalize_pr_ref(pr), parent)
-end
-
 function M.pr_close(f, pr, opts)
   pr = normalize_pr_ref(pr)
   run_forge_cmd(

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -619,9 +619,6 @@ local function pr_action_fns(f, pr)
     ci = function(opts)
       ops.pr_ci(f, pr, opts)
     end,
-    manage = function(parent)
-      ops.pr_manage(f, pr, parent)
-    end,
     edit = function()
       ops.pr_edit(pr)
     end,
@@ -630,97 +627,14 @@ end
 
 ---@param f forge.Forge
 ---@param pr forge.PRRef
-local function pr_manage_picker(f, pr, parent)
-  local forge_mod = require('forge')
-  local num = pr.num
-  local ref = pr.scope
-  local kind = f.labels.pr_one
-  log.info('loading more for ' .. kind .. ' #' .. num .. '...')
-
-  local info = forge_mod.repo_info(f, ref)
-  local can_write = info.permission == 'ADMIN'
-    or info.permission == 'MAINTAIN'
-    or info.permission == 'WRITE'
-  local pr_state = f:pr_state(num, ref)
-  local is_open = pr_state.state == 'OPEN' or pr_state.state == 'OPENED'
-
-  local entries = {}
-  local action_map = {}
-  local function reopen_self()
-    pr_manage_picker(f, { num = num, scope = ref }, parent)
+local function pr_toggle_draft_action(f, pr, opts)
+  opts = opts or {}
+  local is_draft = rawget(pr, 'is_draft')
+  if is_draft == nil then
+    local pr_state = f:pr_state(pr.num, pr.scope)
+    is_draft = pr_state.is_draft == true
   end
-
-  local function add(label, fn)
-    table.insert(entries, {
-      display = { { label } },
-      value = label,
-    })
-    action_map[label] = fn
-  end
-
-  add('Edit', function()
-    ops.pr_edit(pr)
-  end)
-
-  if can_write and is_open then
-    add('Approve', function()
-      ops.pr_approve(f, pr, { on_success = reopen_self, on_failure = reopen_self })
-    end)
-  end
-
-  if can_write and is_open then
-    for _, method in ipairs(info.merge_methods) do
-      add('Merge (' .. method .. ')', function()
-        ops.pr_merge(f, pr, method, {
-          on_success = parent and parent.refresh or reopen_self,
-          on_failure = reopen_self,
-        })
-      end)
-    end
-  end
-
-  if is_open then
-    add('Close', function()
-      ops.pr_close(f, pr, {
-        on_success = parent and parent.refresh or reopen_self,
-        on_failure = reopen_self,
-      })
-    end)
-  else
-    add('Reopen', function()
-      ops.pr_reopen(f, pr, {
-        on_success = parent and parent.refresh or reopen_self,
-        on_failure = reopen_self,
-      })
-    end)
-  end
-
-  if f:draft_toggle_cmd(num, pr_state.is_draft, ref) then
-    add(pr_state.is_draft and 'Mark as ready' or 'Mark as draft', function()
-      ops.pr_toggle_draft(f, pr, pr_state.is_draft, {
-        on_success = reopen_self,
-        on_failure = reopen_self,
-      })
-    end)
-  end
-
-  picker.pick({
-    prompt = ('%s #%s More> '):format(kind, num),
-    entries = entries,
-    actions = {
-      {
-        name = 'default',
-        label = 'run',
-        fn = function(entry)
-          if entry and action_map[entry.value] then
-            action_map[entry.value]()
-          end
-        end,
-      },
-    },
-    picker_name = '_menu',
-    back = parent and parent.back or nil,
-  })
+  ops.pr_toggle_draft(f, pr, is_draft, opts)
 end
 
 ---@param f forge.Forge
@@ -1181,10 +1095,16 @@ function M.pr(state, f, opts)
     for i, pr in ipairs(prs) do
       local num = tostring(pr[pr_fields.number] or '')
       local s = (pr[pr_fields.state] or ''):lower()
+      local draft_field = rawget(pr_fields, 'is_draft')
       state_map[num] = s == 'open' or s == 'opened'
       table.insert(entries, {
         display = displays[i],
-        value = { num = num, scope = ref },
+        value = {
+          num = num,
+          scope = ref,
+          state = pr[pr_fields.state],
+          is_draft = draft_field and pr[draft_field] or nil,
+        },
         ordinal = (pr[pr_fields.title] or '') .. ' #' .. num,
       })
     end
@@ -1223,23 +1143,11 @@ function M.pr(state, f, opts)
   local actions = {
     {
       name = 'default',
-      label = 'more',
+      label = 'checkout',
       fn = function(entry)
         if entry and entry.load_more then
           M.pr(state, f, { limit = entry.next_limit, back = opts.back, scope = ref })
         elseif entry then
-          pr_manage_picker(f, entry.value, {
-            refresh = reopen_list,
-            back = back_to_list,
-          })
-        end
-      end,
-    },
-    {
-      name = 'checkout',
-      label = 'checkout',
-      fn = function(entry)
-        if entry and not entry.load_more then
           pr_action_fns(f, entry.value).checkout()
         end
       end,
@@ -1274,23 +1182,35 @@ function M.pr(state, f, opts)
       end,
     },
     {
-      name = 'manage',
-      label = 'more',
-      fn = function(entry)
-        if entry and not entry.load_more then
-          ops.pr_manage(f, entry.value, {
-            refresh = reopen_list,
-            back = back_to_list,
-          })
-        end
-      end,
-    },
-    {
       name = 'edit',
       label = 'edit',
       fn = function(entry)
         if entry and not entry.load_more then
           pr_action_fns(f, entry.value).edit()
+        end
+      end,
+    },
+    {
+      name = 'approve',
+      label = 'approve',
+      fn = function(entry)
+        if entry and not entry.load_more then
+          ops.pr_approve(f, entry.value, {
+            on_success = reopen_list,
+            on_failure = reopen_list,
+          })
+        end
+      end,
+    },
+    {
+      name = 'merge',
+      label = 'merge',
+      fn = function(entry)
+        if entry and not entry.load_more then
+          ops.pr_merge(f, entry.value, nil, {
+            on_success = reopen_list,
+            on_failure = reopen_list,
+          })
         end
       end,
     },
@@ -1303,7 +1223,7 @@ function M.pr(state, f, opts)
     },
     {
       name = 'close',
-      label = state == 'open' and 'close' or state == 'closed' and 'reopen' or 'toggle',
+      label = state == 'open' and 'close' or state == 'closed' and 'reopen' or 'close/reopen',
       fn = function(entry)
         if entry and not entry.load_more then
           pr_toggle_state(
@@ -1313,6 +1233,18 @@ function M.pr(state, f, opts)
             reopen_list,
             entry.value.scope
           )
+        end
+      end,
+    },
+    {
+      name = 'draft',
+      label = 'draft/ready',
+      fn = function(entry)
+        if entry and not entry.load_more and f.capabilities.draft then
+          pr_toggle_draft_action(f, entry.value, {
+            on_success = reopen_list,
+            on_failure = reopen_list,
+          })
         end
       end,
     },
@@ -1588,12 +1520,6 @@ function M.issue(state, f, opts)
       return placeholder_entry('Failed to fetch issues')
     end,
   })
-end
-
----@param f forge.Forge
----@param pr forge.PRRefLike
-function M.pr_manage(f, pr, parent)
-  pr_manage_picker(f, normalize_pr_ref(pr), parent)
 end
 
 ---@param f forge.Forge

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -177,9 +177,6 @@ describe(':Forge command', function()
           table.insert(captured.ops_calls, { name = 'pr_browse', pr = pr })
           f:view_web(f.kinds.pr, pr.num, pr.scope)
         end,
-        pr_manage = function(_, pr)
-          table.insert(captured.ops_calls, { name = 'pr_manage', pr = pr })
-        end,
         pr_approve = function(_, pr)
           table.insert(captured.ops_calls, { name = 'pr_approve', pr = pr })
         end,
@@ -292,7 +289,6 @@ describe(':Forge command', function()
         end,
         checks = function() end,
         ci = function() end,
-        pr_manage = function() end,
         pr_close = function(_, num)
           table.insert(captured.closed_prs, num)
         end,

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -36,10 +36,12 @@ describe('config', function()
     assert.equals(100, cfg.display.limits.pulls)
     assert.equals(100, cfg.display.limits.commits)
     assert.equals('o', cfg.display.icons.open)
-    assert.is_nil(cfg.keys.pr.checkout)
-    assert.is_nil(cfg.keys.pr.manage)
-    assert.is_nil(cfg.keys.pr.edit)
-    assert.is_nil(cfg.keys.pr.close)
+    assert.equals('<c-e>', cfg.keys.pr.edit)
+    assert.equals('<c-a>', cfg.keys.pr.approve)
+    assert.equals('<c-g>', cfg.keys.pr.merge)
+    assert.equals('<c-n>', cfg.keys.pr.create)
+    assert.equals('<c-s>', cfg.keys.pr.close)
+    assert.equals('<c-d>', cfg.keys.pr.draft)
     assert.equals('<c-o>', cfg.keys.back)
     assert.equals('<tab>', cfg.keys.pr.filter)
     assert.equals('<tab>', cfg.keys.issue.filter)
@@ -609,7 +611,7 @@ describe('config validation', function()
   end)
 
   it('rejects non-string key binding', function()
-    vim.g.forge = { keys = { pr = { checkout = 42 } } }
+    vim.g.forge = { keys = { pr = { edit = 42 } } }
     assert.has_error(function()
       forge.config()
     end)
@@ -655,9 +657,9 @@ describe('config validation', function()
   end)
 
   it('accepts false for individual key binding', function()
-    vim.g.forge = { keys = { pr = { checkout = false } } }
+    vim.g.forge = { keys = { pr = { edit = false } } }
     local cfg = forge.config()
-    assert.is_false(cfg.keys.pr.checkout)
+    assert.is_false(cfg.keys.pr.edit)
   end)
 
   it('rejects keys as a string', function()

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -13,6 +13,7 @@ local function fake_forge()
   return {
     labels = { pr = 'PRs', pr_one = 'PR' },
     kinds = { pr = 'pull_request' },
+    capabilities = { draft = true },
     pr_fields = {
       number = 'number',
       title = 'title',
@@ -193,10 +194,6 @@ describe('pickers', function()
         end,
         pr_ci = function(_, pr, opts)
           table.insert(op_calls, { name = 'pr_ci', pr = pr, opts = opts })
-        end,
-        pr_manage = function(_, pr, parent)
-          table.insert(op_calls, { name = 'pr_manage', pr = pr, parent = parent })
-          require('forge.pickers').pr_manage(fake_forge(), pr, parent)
         end,
         pr_edit = function(pr)
           table.insert(op_calls, { name = 'pr_edit', pr = pr })
@@ -403,10 +400,12 @@ describe('pickers', function()
 
   it('uses more as the default PR action without a separate default key binding', function()
     local cfg = require('forge.config').config()
-    assert.is_nil(cfg.keys.pr.checkout)
-    assert.is_nil(cfg.keys.pr.manage)
-    assert.is_nil(cfg.keys.pr.edit)
-    assert.is_nil(cfg.keys.pr.close)
+    assert.equals('<c-e>', cfg.keys.pr.edit)
+    assert.equals('<c-a>', cfg.keys.pr.approve)
+    assert.equals('<c-g>', cfg.keys.pr.merge)
+    assert.equals('<c-n>', cfg.keys.pr.create)
+    assert.equals('<c-s>', cfg.keys.pr.close)
+    assert.equals('<c-d>', cfg.keys.pr.draft)
     assert.equals('<tab>', cfg.keys.ci.filter)
 
     local pickers = require('forge.pickers')
@@ -418,10 +417,14 @@ describe('pickers', function()
     for _, def in ipairs(captured.actions) do
       labels[def.name] = def.label
     end
-    assert.equals('more', labels.default)
-    assert.equals('more', labels.manage)
+    assert.equals('checkout', labels.default)
     assert.equals('worktree', labels.worktree)
+    assert.equals('edit', labels.edit)
+    assert.equals('approve', labels.approve)
+    assert.equals('merge', labels.merge)
     assert.equals('create', labels.create)
+    assert.equals('close', labels.close)
+    assert.equals('draft/ready', labels.draft)
     assert.equals('filter', labels.filter)
     assert.equals('prev', labels.filter_prev)
     assert.equals('refresh', labels.refresh)
@@ -432,53 +435,42 @@ describe('pickers', function()
     pickers.pr('open', fake_forge())
 
     assert.is_not_nil(captured)
-    assert.equals('more', action_by_name('default').label)
+    assert.equals('checkout', action_by_name('default').label)
     assert.is_false(rawget(action_by_name('browse'), 'close'))
     assert.is_false(rawget(action_by_name('worktree'), 'close'))
-    assert.is_nil(rawget(action_by_name('checkout'), 'close'))
-    assert.is_nil(rawget(action_by_name('manage'), 'close'))
+    assert.is_nil(rawget(action_by_name('approve'), 'close'))
+    assert.is_nil(rawget(action_by_name('merge'), 'close'))
   end)
 
-  it('shows edit inside the more picker', function()
+  it('dispatches flattened PR actions directly from the root picker', function()
     local pickers = require('forge.pickers')
-    pickers.pr_manage(fake_forge(), '42')
+    pickers.pr('open', fake_forge())
 
     assert.is_not_nil(captured)
-    assert.equals('PR #42 More> ', captured.prompt)
-    assert.equals('_menu', captured.picker_name)
+    local entry = captured.entries[1]
+    action_by_name('default').fn(entry)
+    action_by_name('edit').fn(entry)
+    action_by_name('approve').fn(entry)
+    action_by_name('merge').fn(entry)
+    action_by_name('close').fn(entry)
+    action_by_name('draft').fn(entry)
 
-    local labels = {}
-    for _, entry in ipairs(captured.entries) do
-      labels[#labels + 1] = entry.display[1][1]
-    end
-    assert.same({ 'Edit', 'Approve', 'Merge (merge)', 'Close', 'Mark as draft' }, labels)
-  end)
-
-  it('passes back callbacks through nested PR menus', function()
-    local pickers = require('forge.pickers')
-    local back_calls = 0
-
-    pickers.pr('open', fake_forge(), {
-      back = function()
-        back_calls = back_calls + 1
-      end,
-    })
-
-    assert.is_not_nil(captured)
-    action_by_name('default').fn(captured.entries[1])
-
-    assert.equals('PR #42 More> ', captured.prompt)
-    assert.equals('_menu', captured.picker_name)
-    assert.is_function(captured.back)
-
-    captured.back()
-
-    assert.equals('Open PRs (1)> ', captured.prompt)
-    assert.is_function(captured.back)
-
-    captured.back()
-
-    assert.equals(1, back_calls)
+    assert.same({
+      { name = 'pr_checkout', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
+      { name = 'pr_edit', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
+      { name = 'pr_approve', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
+      {
+        name = 'pr_merge',
+        pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+        method = nil,
+      },
+      { name = 'pr_close', pr = { num = '42', scope = nil } },
+      {
+        name = 'pr_toggle_draft',
+        pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+        is_draft = false,
+      },
+    }, op_calls)
   end)
 
   it('shows an explicit empty PR row instead of a blank picker', function()


### PR DESCRIPTION
## Problem

PR actions were split between the root picker and a nested `manage` picker, which kept picker-only complexity in core while this surface is already on the path out of core.

## Solution

Remove the nested PR manage surface, move all PR actions into the root PR picker, and update the temporary key bindings, docs, and specs to match the flatter action layout.