### PR TITLE
fix(browse): keep normal contextual browse file-level

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -524,13 +524,42 @@ BANG SEMANTICS                                            *forge-command-bang*
 
 `:Forge browse` [repo=...] [rev=...] [target=...]              *:Forge-browse*
     Open a browser target on the forge. Without explicit target modifiers,
-    this defaults to the current file location on the current branch in
-    the current repo.
+    this defaults to the current file on the current branch in the current
+    repo.
     `--root`           Legacy compatibility flag for the repository root.
     `--commit`         Legacy compatibility flag for the current HEAD commit.
-    (no modifiers)     Open the current file and line(s) on the current
-                       branch. In visual mode, the selected line range is
-                       included.
+    (no modifiers)     Open the current file on the current branch. In visual
+                       mode, the selected line range is included.
+
+`:Forge review branch` [{branch}]                       *:Forge-review-branch*
+    Start a branch review session. Defaults to the current branch and
+    compares it against the detected default base branch.
+
+`:Forge review commit` [{sha}]                          *:Forge-review-commit*
+    Start a commit review session. Defaults to the current `HEAD` commit
+    and compares it against its first parent.
+
+`:Forge review end`                                        *:Forge-review-end*
+    End the current review session.
+
+`:Forge review files`                                    *:Forge-review-files*
+    Open the changed-files review index for the active review session.
+
+`:Forge review next-file`                            *:Forge-review-next-file*
+    Open the next file in the active review session, wrapping at the end.
+
+`:Forge review prev-file`                            *:Forge-review-prev-file*
+    Open the previous file in the active review session, wrapping at the
+    beginning.
+
+`:Forge review next-hunk`                            *:Forge-review-next-hunk*
+    Jump to the next hunk in the active review view.
+
+`:Forge review prev-hunk`                            *:Forge-review-prev-hunk*
+    Jump to the previous hunk in the active review view.
+
+`:Forge review toggle`                                  *:Forge-review-toggle*
+    Toggle between patch and file-context view (|forge-review|).
 `:Forge clear`                                                  *:Forge-clear*
     Clear all internal caches (forge detection, repo info, list data).
 
@@ -1214,12 +1243,11 @@ SHARED OPERATIONS: `require('forge.ops')` ~
 
                                                             *forge.file_loc()*
 `file_loc()`
-    Current buffer file path relative to git root with line number(s). In
-    visual mode, includes the selected line range (e.g.
-    `"src/foo.lua:10-20"`).
+    Current buffer file path relative to git root. In visual mode, includes
+    the selected line range (e.g. `"src/foo.lua:10-20"`).
 
     Return: ~
-        (`string`) Relative file location with line number or range
+        (`string`) Relative file path, or file path with selected range
 
                                                       *forge.remote_web_url()*
 `remote_web_url()`

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -201,7 +201,7 @@ function M.file_loc()
     end
     return ('%s:%d-%d'):format(file, s, e)
   end
-  return ('%s:%d'):format(file, vim.fn.line('.'))
+  return file
 end
 
 ---@return string

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -139,7 +139,7 @@ describe(':Forge command', function()
           captured.cleared = true
         end,
         file_loc = function()
-          return 'lua/forge/init.lua:10'
+          return 'lua/forge/init.lua'
         end,
         open = function(route, opts)
           table.insert(captured.opens, { route = route, opts = opts })
@@ -354,7 +354,7 @@ describe(':Forge command', function()
     vim.cmd('Forge browse')
 
     assert.same({
-      loc = 'lua/forge/init.lua:10',
+      loc = 'lua/forge/init.lua',
       branch = 'main',
       scope = {
         kind = 'github',

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -18,6 +18,10 @@ local function flatten(segments)
   return table.concat(parts)
 end
 
+local function repo_file(path)
+  return vim.fn.getcwd() .. '/' .. path
+end
+
 describe('config', function()
   after_each(function()
     vim.g.forge = nil
@@ -120,6 +124,29 @@ describe('config', function()
     vim.g.forge = { keys = false }
     local cfg = forge.config()
     assert.is_false(cfg.keys)
+  end)
+end)
+
+describe('file_loc', function()
+  after_each(function()
+    vim.cmd('enew!')
+    vim.api.nvim_buf_set_name(0, '')
+  end)
+
+  it('returns the current file path without a line in normal mode', function()
+    vim.api.nvim_buf_set_name(0, repo_file('tmp/file-loc-normal.lua'))
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three' })
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+    assert.equals('tmp/file-loc-normal.lua', forge.file_loc())
+  end)
+
+  it('returns the selected line range in visual mode', function()
+    vim.api.nvim_buf_set_name(0, repo_file('tmp/file-loc-visual.lua'))
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { 'one', 'two', 'three' })
+    vim.cmd('normal! ggVj')
+
+    assert.equals('tmp/file-loc-visual.lua:1-2', forge.file_loc())
   end)
 end)
 

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -103,7 +103,7 @@ describe('routes', function()
           return fake_forge()
         end,
         file_loc = function()
-          return 'lua/forge/init.lua:10'
+          return 'lua/forge/init.lua'
         end,
       }
     end
@@ -271,6 +271,15 @@ describe('routes', function()
 
     assert.same({ branch = 'main', scope = nil }, captured.browse_branch)
     assert.is_nil(captured.browse)
+  end)
+
+  it('uses file browsing for contextual browse with a file buffer', function()
+    vim.api.nvim_buf_set_name(0, '/repo/lua/forge/init.lua')
+
+    require('forge.routes').open('browse.contextual')
+
+    assert.same({ loc = 'lua/forge/init.lua', branch = 'main', scope = nil }, captured.browse)
+    assert.is_nil(captured.browse_branch)
   end)
 
   it('uses the current commit for commit browsing', function()


### PR DESCRIPTION
## Problem

Contextual browse currently anchors normal-mode file browsing to the cursor line. That makes the default `:Forge browse` and shared `browse.contextual` behavior more specific than it needs to be for ordinary file-level browsing, even though visual mode already provides a precise range-selection path.

## Solution

Make normal-mode contextual browse open the current file without a line suffix, while preserving visual-mode range browsing. Update the command, route, and helper specs to cover the split behavior and refresh the vimdoc to match.