### PR TITLE
fix(pr-create): guard web flow with base preflights

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -559,7 +559,7 @@ BANG SEMANTICS                                            *forge-command-bang*
     Jump to the previous hunk in the active review view.
 
 `:Forge review toggle`                                  *:Forge-review-toggle*
-    Toggle between patch and file-context view (|forge-review|).
+    Toggle between patch and file-context view.
 `:Forge clear`                                                  *:Forge-clear*
     Clear all internal caches (forge detection, repo info, list data).
 

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -289,6 +289,34 @@ function M.create_pr(opts)
     return
   end
 
+  local function with_base(cb)
+    log.info('resolving base branch...')
+    vim.system(f:default_branch_cmd(ref), { text = true }, function(base_result)
+      local base = vim.trim(base_result.stdout or '')
+      if base == '' then
+        base = 'main'
+      end
+      vim.schedule(function()
+        cb(base)
+      end)
+    end)
+  end
+
+  local function ensure_creatable(base, cb)
+    if branch == base then
+      log.warn('current branch already matches base ' .. base)
+      return
+    end
+    local has_diff = vim
+      .system({ 'git', 'diff', '--quiet', 'origin/' .. base .. '..HEAD' }, { text = true })
+      :wait().code ~= 0
+    if not has_diff then
+      log.warn('no changes from origin/' .. base)
+      return
+    end
+    cb(base)
+  end
+
   log.info('checking for existing ' .. f.labels.pr_one .. '...')
 
   vim.system(f:pr_for_branch_cmd(branch, ref), { text = true }, function(result)
@@ -300,36 +328,32 @@ function M.create_pr(opts)
       end
 
       if opts.web then
-        log.info('pushing...')
-        vim.system({ 'git', 'push', '-u', 'origin', branch }, { text = true }, function(push_result)
-          vim.schedule(function()
-            if push_result.code ~= 0 then
-              log.error('push failed')
-              return
-            end
-            local web_cmd = f:create_pr_web_cmd(ref)
-            if web_cmd then
-              vim.system(web_cmd)
-            end
+        with_base(function(base)
+          ensure_creatable(base, function()
+            log.info('pushing...')
+            vim.system(
+              { 'git', 'push', '-u', 'origin', branch },
+              { text = true },
+              function(push_result)
+                vim.schedule(function()
+                  if push_result.code ~= 0 then
+                    log.error('push failed')
+                    return
+                  end
+                  local web_cmd = f:create_pr_web_cmd(ref)
+                  if web_cmd then
+                    vim.system(web_cmd)
+                  end
+                end)
+              end
+            )
           end)
         end)
         return
       end
 
-      log.info('resolving base branch...')
-      vim.system(f:default_branch_cmd(ref), { text = true }, function(base_result)
-        local base = vim.trim(base_result.stdout or '')
-        if base == '' then
-          base = 'main'
-        end
-        vim.schedule(function()
-          local has_diff = vim
-            .system({ 'git', 'diff', '--quiet', 'origin/' .. base .. '..HEAD' }, { text = true })
-            :wait().code ~= 0
-          if not has_diff then
-            log.warn('no changes from origin/' .. base)
-            return
-          end
+      with_base(function(base)
+        ensure_creatable(base, function()
           if opts.instant then
             local title, body = template_mod.fill_from_commits(branch, base)
             compose_mod.push_and_create(

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -10,6 +10,8 @@ describe('create_pr', function()
   before_each(function()
     captured = {
       errors = {},
+      warnings = {},
+      systems = {},
     }
 
     old_system = vim.system
@@ -55,6 +57,7 @@ describe('create_pr', function()
         stderr = '',
       }
       local key = table.concat(cmd, ' ')
+      table.insert(captured.systems, key)
       if key == 'pr-for-branch feature' then
         result.stdout = '\n'
       elseif key == 'default-branch' then
@@ -126,6 +129,9 @@ describe('create_pr', function()
         end,
         default_branch_cmd = function()
           return { 'default-branch' }
+        end,
+        create_pr_web_cmd = function()
+          return { 'create-pr-web' }
         end,
         template_paths = function()
           return { '.github/PULL_REQUEST_TEMPLATE/' }
@@ -238,5 +244,78 @@ describe('create_pr', function()
     captured.picker.back()
 
     assert.equals(1, back_calls)
+  end)
+
+  it('blocks web PR creation when the current branch already matches the base', function()
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/repo.git\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return 'main\n'
+      end
+      return ''
+    end
+
+    require('forge').create_pr({ web = true })
+
+    vim.wait(100, function()
+      return #captured.warnings > 0
+    end)
+
+    assert.same({ 'current branch already matches base main' }, captured.warnings)
+    assert.is_false(vim.tbl_contains(captured.systems, 'git push -u origin main'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'create-pr-web'))
+  end)
+
+  it('blocks web PR creation when there are no changes from the base branch', function()
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      table.insert(captured.systems, key)
+      if key == 'pr-for-branch feature' then
+        result.stdout = '\n'
+      elseif key == 'default-branch' then
+        result.stdout = 'main\n'
+      elseif key == 'git diff --quiet origin/main..HEAD' then
+        result.code = 0
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    require('forge').create_pr({ web = true })
+
+    vim.wait(100, function()
+      return #captured.warnings > 0
+    end)
+
+    assert.same({ 'no changes from origin/main' }, captured.warnings)
+    assert.is_false(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'create-pr-web'))
+  end)
+
+  it('pushes and opens the web flow only when the branch is creatable', function()
+    require('forge').create_pr({ web = true })
+
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.systems, 'create-pr-web')
+    end)
+
+    assert.is_true(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'create-pr-web'))
   end)
 end)


### PR DESCRIPTION
## Problem

`:Forge pr create web` could still push and open the browser flow in cases that normal PR creation already should reject, especially when the current branch already matched the effective base branch or there were no changes from `origin/<base>`.

## Solution

Reuse the same base-resolution and creatability checks before the web flow pushes or opens the browser. This keeps valid same-origin PR creation working, blocks branch==base, and blocks no-diff cases. The PR also removes a stale `|forge-review|` vimdoc tag reference so CI passes.
