### PR TITLE
fix(browse): ignore special buffer file context

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -529,7 +529,9 @@ BANG SEMANTICS                                            *forge-command-bang*
     `--root`           Legacy compatibility flag for the repository root.
     `--commit`         Legacy compatibility flag for the current HEAD commit.
     (no modifiers)     Open the current file on the current branch. In visual
-                       mode, the selected line range is included.
+                       mode, the selected line range is included. In non-file
+                       buffers, this falls back to the repo root on the
+                       current branch.
 
 `:Forge review branch` [{branch}]                       *:Forge-review-branch*
     Start a branch review session. Defaults to the current branch and

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -661,7 +661,11 @@ local function dispatch_browse(command)
       return
     end
     local rev = effective_rev(command)
-    if rev and rev.rev and ops.browse_file(f, require('forge').file_loc(), rev.rev, scope) then
+    if rev and rev.rev then
+      if ops.browse_file(f, require('forge').file_loc(), rev.rev, scope) then
+        return
+      end
+      ops.browse_branch(rev.rev, { scope = scope })
       return
     end
     ops.browse_contextual({ scope = scope })

--- a/lua/forge/context.lua
+++ b/lua/forge/context.lua
@@ -13,9 +13,19 @@ end
 local function has_file_buffer()
   local buf_name = vim.api.nvim_buf_get_name(0)
   return buf_name ~= ''
+    and not buf_name:match('^%w[%w+.-]*://')
     and not buf_name:match('^fugitive://')
     and not buf_name:match('^term://')
     and not buf_name:match('^diffs://')
+end
+
+local function in_repo_file(root)
+  if not has_file_buffer() then
+    return false
+  end
+  local buf_name = vim.fs.normalize(vim.api.nvim_buf_get_name(0))
+  local prefix = vim.fs.normalize(root) .. '/'
+  return buf_name:sub(1, #prefix) == prefix
 end
 
 providers.current = function()
@@ -25,7 +35,7 @@ providers.current = function()
   end
 
   local forge_mod = require('forge')
-  local has_file = has_file_buffer()
+  local has_file = in_repo_file(root)
 
   return {
     id = 'current',

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -188,7 +188,16 @@ function M.file_loc()
   if not root then
     return vim.fn.expand('%:t')
   end
-  local file = vim.api.nvim_buf_get_name(0):sub(#root + 2)
+  local buf_name = vim.api.nvim_buf_get_name(0)
+  if buf_name == '' or buf_name:match('^%w[%w+.-]*://') then
+    return ''
+  end
+  local root_prefix = vim.fs.normalize(root) .. '/'
+  local path = vim.fs.normalize(buf_name)
+  if path:sub(1, #root_prefix) ~= root_prefix then
+    return ''
+  end
+  local file = path:sub(#root_prefix + 1)
   local mode = vim.fn.mode()
   if mode:match('[vV]') or mode == '\22' then
     local s = vim.fn.line('v')

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -139,6 +139,10 @@ describe(':Forge command', function()
           captured.cleared = true
         end,
         file_loc = function()
+          local name = vim.api.nvim_buf_get_name(0)
+          if name:match('^%w[%w+.-]*://') then
+            return ''
+          end
           return 'lua/forge/init.lua'
         end,
         open = function(route, opts)
@@ -264,6 +268,9 @@ describe(':Forge command', function()
           return true
         end,
         browse_file = function(f, file_loc, branch, scope)
+          if vim.trim(file_loc or '') == '' or vim.trim(branch or '') == '' then
+            return false
+          end
           table.insert(captured.ops_calls, {
             name = 'browse_file',
             file_loc = file_loc,
@@ -374,6 +381,30 @@ describe(':Forge command', function()
 
     assert.equals('browse.branch', captured.opens[1].route)
     assert.equals('browse.commit', captured.opens[2].route)
+  end)
+
+  it('uses explicit rev branch browsing when special buffers have no file location', function()
+    vim.api.nvim_buf_set_name(0, 'canola://issue/123')
+
+    vim.cmd('Forge browse rev=@main')
+
+    assert.same({
+      name = 'browse_branch',
+      branch = 'main',
+      opts = {
+        scope = {
+          kind = 'github',
+          host = 'github.com',
+          owner = 'owner',
+          repo = 'current',
+          slug = 'owner/current',
+          repo_arg = 'owner/current',
+          web_url = 'https://github.com/owner/current',
+        },
+      },
+    }, captured.ops_calls[1])
+    assert.equals('browse.branch', captured.opens[1].route)
+    assert.equals('main', captured.opens[1].opts.branch)
   end)
 
   it('dispatches normalized create and clear commands through the command layer', function()

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -148,6 +148,12 @@ describe('file_loc', function()
 
     assert.equals('tmp/file-loc-visual.lua:1-2', forge.file_loc())
   end)
+
+  it('returns no file location for special URI buffers', function()
+    vim.api.nvim_buf_set_name(0, 'canola://issue/123')
+
+    assert.equals('', forge.file_loc())
+  end)
 end)
 
 describe('format_pr', function()

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -103,6 +103,10 @@ describe('routes', function()
           return fake_forge()
         end,
         file_loc = function()
+          local name = vim.api.nvim_buf_get_name(0)
+          if name:match('^%w[%w+.-]*://') then
+            return ''
+          end
           return 'lua/forge/init.lua'
         end,
       }
@@ -267,6 +271,15 @@ describe('routes', function()
   end)
 
   it('uses branch browsing for contextual browse without a file buffer', function()
+    require('forge.routes').open('browse.contextual')
+
+    assert.same({ branch = 'main', scope = nil }, captured.browse_branch)
+    assert.is_nil(captured.browse)
+  end)
+
+  it('treats special URI buffers as non-file context for contextual browse', function()
+    vim.api.nvim_buf_set_name(0, 'canola://issue/123')
+
     require('forge.routes').open('browse.contextual')
 
     assert.same({ branch = 'main', scope = nil }, captured.browse_branch)


### PR DESCRIPTION
## Problem

Special URI buffers such as `canola://...` can leak bogus file paths into browse flows. That makes contextual browse treat those buffers like normal files, and it also makes explicit revision browse such as `:Forge browse rev=@main` try to open an invalid file target instead of falling back to the revision itself.

## Solution

Treat special URI buffers as non-file context, make `forge.file_loc()` return no file location for them, and teach explicit revision browse to fall back to branch browsing when no valid repo file path exists. Plain contextual `:Forge browse` now falls back to the repo root on the current branch when invoked from a non-file buffer. Add focused command, route, and helper regressions covering the `canola://` case.