### PR TITLE
fix(create-web): report web flow outcomes

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -440,8 +440,8 @@ function M:create_pr_cmd(title, body, base, _draft, _reviewers, labels, assignee
   return cmd
 end
 
----@return string[]?
-function M:create_pr_web_cmd(ref)
+---@return string
+function M:create_pr_web_url(ref)
   local branch = vim.trim(vim.fn.system('git branch --show-current'))
   local base_url = forge.remote_web_url(ref)
   local default = vim.trim(
@@ -452,8 +452,7 @@ function M:create_pr_web_cmd(ref)
   if default == '' then
     default = 'main'
   end
-  vim.ui.open(('%s/compare/%s...%s'):format(base_url, default, branch))
-  return nil
+  return ('%s/compare/%s...%s'):format(base_url, default, branch)
 end
 
 ---@param title string

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -55,6 +55,46 @@ local function git_root()
   return root
 end
 
+local function cmd_error(result, fallback)
+  local msg = vim.trim(result.stderr or '')
+  if msg == '' then
+    msg = vim.trim(result.stdout or '')
+  end
+  if msg == '' then
+    msg = fallback
+  end
+  return msg
+end
+
+local function open_web_create(label, cmd, url)
+  local log = require('forge.logger')
+  local success_msg = ('opened %s creation in browser'):format(label)
+  local fail_msg = ('failed to open %s creation in browser'):format(label)
+  if cmd then
+    log.info(('opening %s creation in browser...'):format(label))
+    vim.system(cmd, { text = true }, function(result)
+      vim.schedule(function()
+        if result.code == 0 then
+          log.info(success_msg)
+        else
+          log.error(cmd_error(result, fail_msg))
+        end
+      end)
+    end)
+    return
+  end
+  if not url or url == '' then
+    log.error(fail_msg)
+    return
+  end
+  local _, err = vim.ui.open(url)
+  if err then
+    log.error(err)
+    return
+  end
+  log.info(success_msg)
+end
+
 local builtin_hosts = {
   github = { 'github' },
   gitlab = { 'gitlab' },
@@ -340,10 +380,9 @@ function M.create_pr(opts)
                     log.error('push failed')
                     return
                   end
-                  local web_cmd = f:create_pr_web_cmd(ref)
-                  if web_cmd then
-                    vim.system(web_cmd)
-                  end
+                  local web_cmd = f.create_pr_web_cmd and f:create_pr_web_cmd(ref) or nil
+                  local web_url = f.create_pr_web_url and f:create_pr_web_url(ref) or nil
+                  open_web_create(f.labels.pr_one, web_cmd, web_url)
                 end)
               end
             )
@@ -480,15 +519,12 @@ function M.create_issue(opts)
   local ref = opts.scope or M.current_scope(f.name)
 
   if opts.web then
-    if f.create_issue_web_cmd then
-      local cmd = f:create_issue_web_cmd(ref)
-      if cmd then
-        vim.system(cmd)
-      end
-    else
-      local url = M.remote_web_url(ref) .. '/issues/new'
-      vim.ui.open(url)
+    local cmd = f.create_issue_web_cmd and f:create_issue_web_cmd(ref) or nil
+    local url = M.remote_web_url(ref)
+    if url ~= '' then
+      url = url .. '/issues/new'
     end
+    open_web_create('issue', cmd, url)
     return
   end
 

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -146,6 +146,7 @@
 ---@field parse_pr_details fun(self: forge.Forge, json: table): forge.PRDetails
 ---@field completion_cmd (fun(self: forge.Forge, field: string, scope?: forge.Scope): string[]?)?
 ---@field create_pr_web_cmd fun(self: forge.Forge, scope?: forge.Scope): string[]?
+---@field create_pr_web_url (fun(self: forge.Forge, scope?: forge.Scope): string?)?
 ---@field default_branch_cmd fun(self: forge.Forge, scope?: forge.Scope): string[]
 ---@field checks_json_cmd (fun(self: forge.Forge, num: string, scope?: forge.Scope): string[])?
 ---@field template_paths fun(self: forge.Forge): string[]

--- a/spec/create_issue_spec.lua
+++ b/spec/create_issue_spec.lua
@@ -2,17 +2,24 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 describe('create_issue', function()
   local captured
-  local old_system
+  local old_fn_system
+  local old_vim_system
   local old_executable
+  local old_ui_open
   local old_preload
 
   before_each(function()
     captured = {
       errors = {},
+      infos = {},
+      systems = {},
+      open_urls = {},
     }
 
-    old_system = vim.fn.system
+    old_fn_system = vim.fn.system
+    old_vim_system = vim.system
     old_executable = vim.fn.executable
+    old_ui_open = vim.ui.open
     old_preload = {
       ['forge.action'] = package.preload['forge.action'],
       ['forge.client'] = package.preload['forge.client'],
@@ -31,6 +38,39 @@ describe('create_issue', function()
         return 1
       end
       return 0
+    end
+
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/repo.git\n'
+      end
+      return ''
+    end
+
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      table.insert(captured.systems, key)
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    vim.ui.open = function(url)
+      table.insert(captured.open_urls, url)
+      return true
     end
 
     package.preload['forge.action'] = function()
@@ -81,6 +121,9 @@ describe('create_issue', function()
     package.preload['forge.github'] = function()
       return {
         cli = 'gh',
+        create_issue_web_cmd = function()
+          return { 'create-issue-web' }
+        end,
         issue_template_paths = function()
           return { '.github/ISSUE_TEMPLATE/' }
         end,
@@ -90,7 +133,9 @@ describe('create_issue', function()
     package.preload['forge.logger'] = function()
       return {
         debug = function() end,
-        info = function() end,
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
         warn = function(msg)
           table.insert(captured.warnings or {}, msg)
         end,
@@ -122,8 +167,10 @@ describe('create_issue', function()
   end)
 
   after_each(function()
-    vim.fn.system = old_system
+    vim.fn.system = old_fn_system
+    vim.system = old_vim_system
     vim.fn.executable = old_executable
+    vim.ui.open = old_ui_open
 
     package.preload['forge.action'] = old_preload['forge.action']
     package.preload['forge.client'] = old_preload['forge.client']
@@ -243,5 +290,69 @@ describe('create_issue', function()
     captured.picker.back()
 
     assert.equals(1, back_calls)
+  end)
+
+  it('reports success when the web issue command succeeds', function()
+    require('forge').create_issue({ web = true })
+
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.infos, 'opened issue creation in browser')
+    end)
+
+    assert.is_true(vim.tbl_contains(captured.systems, 'create-issue-web'))
+  end)
+
+  it('reports an error when the web issue command fails', function()
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      table.insert(captured.systems, key)
+      if key == 'create-issue-web' then
+        result.code = 1
+        result.stderr = 'issue web failed'
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    require('forge').create_issue({ web = true })
+
+    vim.wait(100, function()
+      return #captured.errors > 0
+    end)
+
+    assert.same({ 'issue web failed' }, captured.errors)
+    assert.is_false(vim.tbl_contains(captured.infos, 'opened issue creation in browser'))
+  end)
+
+  it('reports browser open failures for URL-based web issue flows', function()
+    package.preload['forge.github'] = function()
+      return {
+        cli = 'gh',
+        issue_template_paths = function()
+          return { '.github/ISSUE_TEMPLATE/' }
+        end,
+      }
+    end
+
+    vim.ui.open = function(url)
+      table.insert(captured.open_urls, url)
+      return nil, 'open failed'
+    end
+
+    require('forge').create_issue({ web = true })
+
+    assert.same({ 'open failed' }, captured.errors)
+    assert.same({ 'https://github.com/owner/repo/issues/new' }, captured.open_urls)
   end)
 end)

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -5,18 +5,22 @@ describe('create_pr', function()
   local old_system
   local old_fn_system
   local old_executable
+  local old_ui_open
   local old_preload
 
   before_each(function()
     captured = {
       errors = {},
+      infos = {},
       warnings = {},
       systems = {},
+      open_urls = {},
     }
 
     old_system = vim.system
     old_fn_system = vim.fn.system
     old_executable = vim.fn.executable
+    old_ui_open = vim.ui.open
     old_preload = {
       ['forge.action'] = package.preload['forge.action'],
       ['forge.client'] = package.preload['forge.client'],
@@ -142,7 +146,9 @@ describe('create_pr', function()
     package.preload['forge.logger'] = function()
       return {
         debug = function() end,
-        info = function() end,
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
         warn = function(msg)
           table.insert(captured.warnings or {}, msg)
         end,
@@ -150,6 +156,11 @@ describe('create_pr', function()
           table.insert(captured.errors, msg)
         end,
       }
+    end
+
+    vim.ui.open = function(url)
+      table.insert(captured.open_urls, url)
+      return true
     end
 
     package.preload['forge.picker'] = function()
@@ -200,6 +211,7 @@ describe('create_pr', function()
     vim.system = old_system
     vim.fn.system = old_fn_system
     vim.fn.executable = old_executable
+    vim.ui.open = old_ui_open
 
     package.preload['forge.action'] = old_preload['forge.action']
     package.preload['forge.client'] = old_preload['forge.client']
@@ -312,10 +324,85 @@ describe('create_pr', function()
     require('forge').create_pr({ web = true })
 
     vim.wait(100, function()
-      return vim.tbl_contains(captured.systems, 'create-pr-web')
+      return vim.tbl_contains(captured.infos, 'opened PR creation in browser')
     end)
 
     assert.is_true(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
     assert.is_true(vim.tbl_contains(captured.systems, 'create-pr-web'))
+    assert.is_true(vim.tbl_contains(captured.infos, 'opened PR creation in browser'))
+  end)
+
+  it('reports an error when the web PR command fails', function()
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      table.insert(captured.systems, key)
+      if key == 'pr-for-branch feature' then
+        result.stdout = '\n'
+      elseif key == 'default-branch' then
+        result.stdout = 'main\n'
+      elseif key == 'git diff --quiet origin/main..HEAD' then
+        result.code = 1
+      elseif key == 'create-pr-web' then
+        result.code = 1
+        result.stderr = 'web failed'
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    require('forge').create_pr({ web = true })
+
+    vim.wait(100, function()
+      return #captured.errors > 0
+    end)
+
+    assert.same({ 'web failed' }, captured.errors)
+    assert.is_false(vim.tbl_contains(captured.infos, 'opened PR creation in browser'))
+  end)
+
+  it('reports browser open failures for URL-based web PR flows', function()
+    package.preload['forge.github'] = function()
+      return {
+        cli = 'gh',
+        labels = { pr_one = 'PR' },
+        pr_for_branch_cmd = function(_, branch)
+          return { 'pr-for-branch', branch }
+        end,
+        default_branch_cmd = function()
+          return { 'default-branch' }
+        end,
+        create_pr_web_url = function()
+          return 'https://example.test/compare/main...feature'
+        end,
+        template_paths = function()
+          return { '.github/PULL_REQUEST_TEMPLATE/' }
+        end,
+      }
+    end
+
+    vim.ui.open = function(url)
+      table.insert(captured.open_urls, url)
+      return nil, 'open failed'
+    end
+
+    require('forge').create_pr({ web = true })
+
+    vim.wait(100, function()
+      return #captured.errors > 0
+    end)
+
+    assert.same({ 'open failed' }, captured.errors)
+    assert.same({ 'https://example.test/compare/main...feature' }, captured.open_urls)
   end)
 end)


### PR DESCRIPTION
## Problem

The web create paths ran their browser-opening command without checking whether it succeeded, so Forge could fail silently. That made `:Forge issue create web` and `:Forge pr create web` feel unreliable, and URL-based providers like Codeberg also bypassed Forge-level reporting.

## Solution

Route PR and issue web-create flows through shared outcome handling in `forge.init`. Command-backed flows now log a Forge-level success message on exit code 0 and surface stderr/stdout on failure. URL-based flows now report browser open failures too, and Codeberg PR creation now returns its compare URL so it goes through the same reporting path.
