### PR TITLE
fix(fzf): reset streamed picker entries on resume

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -118,6 +118,7 @@ function M.pick(opts)
   local bindings = keys[opts.picker_name] or {}
   local entries = opts.entries or {}
   local stream = rawget(opts, 'stream')
+  local seed_entries = vim.list_extend({}, entries)
   local actions = vim.deepcopy(opts.actions or {})
 
   if opts.back and keys.back then
@@ -132,6 +133,7 @@ function M.pick(opts)
   local lines
   if stream then
     lines = function(fzf_cb)
+      entries = vim.list_extend({}, seed_entries)
       local next_index = 0
       for i, entry in ipairs(entries) do
         next_index = i

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -258,6 +258,43 @@ describe('fzf picker', function()
     assert.truthy(captured.lines[1]:find(' %[origin/main%]\t1$', 1))
   end)
 
+  it('does not duplicate streamed rows when the source is invoked again', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'CI> ',
+      entries = {},
+      actions = {},
+      picker_name = 'ci',
+      stream = function(emit)
+        emit({
+          display = { { 'check one' } },
+          value = 'check-1',
+        })
+        emit({
+          display = { { 'check two' } },
+          value = 'check-2',
+        })
+        emit(nil)
+      end,
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_function(captured.lines)
+
+    local function collect_lines()
+      local lines = {}
+      captured.lines(function(line)
+        if line then
+          table.insert(lines, line)
+        end
+      end)
+      return lines
+    end
+
+    assert.same({ 'check one\t1', 'check two\t2' }, collect_lines())
+    assert.same({ 'check one\t1', 'check two\t2' }, collect_lines())
+  end)
+
   it('renders worktree rows with visible labels and hidden selection ids', function()
     local picker = require('forge.picker.fzf')
     picker.pick({

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -22,6 +22,18 @@ local function repo_file(path)
   return vim.fn.getcwd() .. '/' .. path
 end
 
+local function use_named_current_buf(name)
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == name then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  vim.api.nvim_buf_set_name(buf, name)
+  return buf
+end
+
 describe('config', function()
   after_each(function()
     vim.g.forge = nil
@@ -150,7 +162,7 @@ describe('file_loc', function()
   end)
 
   it('returns no file location for special URI buffers', function()
-    vim.api.nvim_buf_set_name(0, 'canola://issue/123')
+    use_named_current_buf('canola://issue/123')
 
     assert.equals('', forge.file_loc())
   end)

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -35,6 +35,18 @@ local function fake_forge()
   }
 end
 
+local function use_named_current_buf(name)
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == name then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  vim.api.nvim_buf_set_name(buf, name)
+  return buf
+end
+
 describe('routes', function()
   before_each(function()
     captured = {}
@@ -278,7 +290,7 @@ describe('routes', function()
   end)
 
   it('treats special URI buffers as non-file context for contextual browse', function()
-    vim.api.nvim_buf_set_name(0, 'canola://issue/123')
+    use_named_current_buf('canola://issue/123')
 
     require('forge.routes').open('browse.contextual')
 


### PR DESCRIPTION
## Problem

Streaming fzf pickers reused and mutated their entry list across source invocations. When `:FzfLua resume` re-ran the source for CI/check pickers, the previously streamed rows were emitted again with fresh selection ids, so the list visibly duplicated entries.

## Solution

Reset the working entry list from a clean seed each time the streaming source runs. That keeps resumed CI/check pickers stable instead of appending duplicate rows. The PR also hardens two existing URI-buffer specs that were brittle about reusing a buffer name and could fail current full CI with `E95`.
