### PR TITLE
fix(ci): add load more for repo runs

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -356,7 +356,9 @@ Top-level keys: ~
     `branch`      `25`
 
   `display.limits`                               *forge-config-display-limits*
-    `table`  Maximum items fetched per list API call.
+    `table`  Maximum items fetched per list API call. Repo CI runs use the
+             `runs` limit as their initial page size and show `Load more...`
+             when additional runs are available.
 
     Key         Default ~
     `pulls`       `100`
@@ -492,7 +494,9 @@ BANG SEMANTICS                                            *forge-command-bang*
 
 `:Forge ci` [repo=...] [rev=...] [target=...] [all]                *:Forge-ci*
     Open the CI runs picker. Defaults to the current branch in the repo
-    selected by `targets.ci.repo`.
+    selected by `targets.ci.repo`. Repo CI runs respect
+    `display.limits.runs` and expose `Load more...` when more runs are
+    available.
     `all`              Show runs for all branches.
 
 `:Forge ci log` {run-id} [repo=...]                            *:Forge-ci-log*
@@ -683,6 +687,10 @@ ISSUE PICKER ~ Lists issues with number, title, author, and relative time.
                                                              *forge-picker-ci*
 CI PICKER ~ Used for both per-PR checks (`:Forge pr ci {num}`) and repo-wide
 CI runs (`:Forge ci`). Both share the `keys.ci` bindings.
+
+For repo-wide CI runs, Forge fetches an initial page using
+`display.limits.runs`. When more runs are available, the picker shows a
+`Load more...` row on `<cr>`.
 
 On GitHub, `<cr>` on a run opens a summary buffer showing all jobs with
 status, durations, and annotations. Press `<cr>` on a job line to open its

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -216,12 +216,12 @@ function M:live_tail_cmd(run_id, job_id, ref)
   return cmd
 end
 
-function M:list_runs_json_cmd(branch, ref)
-  local limit = tostring(forge.config().display.limits.runs)
+function M:list_runs_json_cmd(branch, ref, limit)
+  local limit_arg = tostring(limit or forge.config().display.limits.runs)
   local cmd = 'tea api --repo '
     .. repo_arg(ref)
     .. ' "/repos/{owner}/{repo}/actions/runs?limit='
-    .. limit
+    .. limit_arg
   if branch then
     cmd = cmd .. '&branch=' .. branch
   end

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -325,7 +325,7 @@ function M:run_log_cmd(id, failed_only, scope)
   }
 end
 
-function M:list_runs_json_cmd(branch, scope)
+function M:list_runs_json_cmd(branch, scope, limit)
   local cmd = {
     'gh',
     'run',
@@ -333,7 +333,7 @@ function M:list_runs_json_cmd(branch, scope)
     '--json',
     'databaseId,name,headBranch,status,conclusion,event,url,createdAt',
     '--limit',
-    tostring(forge.config().display.limits.runs),
+    tostring(limit or forge.config().display.limits.runs),
   }
   local repo = nwo(scope)
   if repo ~= '' then

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -252,7 +252,7 @@ function M:watch_cmd(id, ref)
   return cmd
 end
 
-function M:list_runs_json_cmd(branch, ref)
+function M:list_runs_json_cmd(branch, ref, limit)
   local cmd = {
     'glab',
     'ci',
@@ -260,7 +260,7 @@ function M:list_runs_json_cmd(branch, ref)
     '--output',
     'json',
     '--per-page',
-    tostring(forge.config().display.limits.runs),
+    tostring(limit or forge.config().display.limits.runs),
     '-R',
     repo_arg(ref),
   }

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -867,11 +867,14 @@ end
 ---@param f forge.Forge
 ---@param branch string?
 ---@param filter string?
----@param opts? forge.PickerBackOpts
+---@param opts? forge.PickerLimitOpts
 function M.ci(f, branch, filter, opts)
   opts = opts or {}
   filter = filter or 'all'
   local forge_mod = require('forge')
+  local limit_step = forge_mod.config().display.limits.runs
+  local visible_limit = opts.limit or limit_step
+  local fetch_limit = visible_limit + 1
   local ref = scoped_forge_ref(f, opts.scope)
   local request_key =
     forge_mod.list_key('ci', scoped_id(branch or 'all', scoped_key(forge_mod, ref)))
@@ -905,7 +908,11 @@ function M.ci(f, branch, filter, opts)
       run.scope = run.scope or ref
       table.insert(normalized, run)
     end
+    local has_more = #normalized > visible_limit
     local filtered = forge_mod.filter_runs(normalized, filter)
+    if #filtered > visible_limit then
+      filtered = vim.list_slice(filtered, 1, visible_limit)
+    end
     local count = #filtered
     local displays = forge_mod.format_runs(filtered, { width = layout.picker_width() })
 
@@ -916,6 +923,9 @@ function M.ci(f, branch, filter, opts)
         value = run,
         ordinal = run.name .. ' ' .. run.branch,
       })
+    end
+    if has_more then
+      entries[#entries + 1] = load_more_entry(visible_limit + limit_step)
     end
     local filter_label = labels[filter] or filter
     local empty_text
@@ -939,6 +949,10 @@ function M.ci(f, branch, filter, opts)
         if not entry then
           return
         end
+        if entry.load_more then
+          M.ci(f, branch, filter, { limit = entry.next_limit, back = opts.back, scope = ref })
+          return
+        end
         ops.ci_log(f, entry.value)
       end,
     },
@@ -946,7 +960,7 @@ function M.ci(f, branch, filter, opts)
       name = 'watch',
       label = 'watch',
       fn = function(entry)
-        if not entry then
+        if not entry or entry.load_more then
           return
         end
         ops.ci_watch(f, entry.value)
@@ -957,7 +971,7 @@ function M.ci(f, branch, filter, opts)
       label = 'web',
       close = false,
       fn = function(entry)
-        if entry and entry.value.url ~= '' then
+        if entry and not entry.load_more and entry.value.url ~= '' then
           vim.ui.open(entry.value.url)
         end
       end,
@@ -966,42 +980,52 @@ function M.ci(f, branch, filter, opts)
       name = 'filter',
       label = 'filter',
       fn = function()
-        M.ci(f, branch, next_ci_filter[filter] or 'all', { back = opts.back, scope = ref })
+        M.ci(
+          f,
+          branch,
+          next_ci_filter[filter] or 'all',
+          { limit = visible_limit, back = opts.back, scope = ref }
+        )
       end,
     },
     {
       name = 'filter_prev',
       label = 'prev',
       fn = function()
-        M.ci(f, branch, prev_ci_filter[filter] or 'all', { back = opts.back, scope = ref })
+        M.ci(
+          f,
+          branch,
+          prev_ci_filter[filter] or 'all',
+          { limit = visible_limit, back = opts.back, scope = ref }
+        )
       end,
     },
     {
       name = 'failed',
       label = 'failed',
       fn = function()
-        M.ci(f, branch, 'fail', { back = opts.back, scope = ref })
+        M.ci(f, branch, 'fail', { limit = visible_limit, back = opts.back, scope = ref })
       end,
     },
     {
       name = 'passed',
       label = 'passed',
       fn = function()
-        M.ci(f, branch, 'pass', { back = opts.back, scope = ref })
+        M.ci(f, branch, 'pass', { limit = visible_limit, back = opts.back, scope = ref })
       end,
     },
     {
       name = 'running',
       label = 'running',
       fn = function()
-        M.ci(f, branch, 'pending', { back = opts.back, scope = ref })
+        M.ci(f, branch, 'pending', { limit = visible_limit, back = opts.back, scope = ref })
       end,
     },
     {
       name = 'all',
       label = 'all',
       fn = function()
-        M.ci(f, branch, 'all', { back = opts.back, scope = ref })
+        M.ci(f, branch, 'all', { limit = visible_limit, back = opts.back, scope = ref })
       end,
     },
     {
@@ -1009,7 +1033,7 @@ function M.ci(f, branch, filter, opts)
       label = 'refresh',
       fn = function()
         log.info('refreshing CI runs...')
-        M.ci(f, branch, filter, { back = opts.back, scope = ref })
+        M.ci(f, branch, filter, { limit = visible_limit, back = opts.back, scope = ref })
       end,
     },
   }
@@ -1034,7 +1058,7 @@ function M.ci(f, branch, filter, opts)
       picker_name = 'ci',
       back = opts.back,
       cmd = function()
-        return f:list_runs_json_cmd(branch, ref)
+        return f:list_runs_json_cmd(branch, ref, fetch_limit)
       end,
       on_fetch = function()
         log.info('fetching CI runs...')

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -127,7 +127,7 @@
 ---@field watch_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
 ---@field run_status_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
 ---@field live_tail_cmd (fun(self: forge.Forge, run_id: string, job_id: string?, scope?: forge.Scope): string[])?
----@field list_runs_json_cmd fun(self: forge.Forge, branch: string?, scope?: forge.Scope): string[]
+---@field list_runs_json_cmd fun(self: forge.Forge, branch: string?, scope?: forge.Scope, limit?: integer): string[]
 ---@field list_runs_cmd fun(self: forge.Forge, branch: string?, scope?: forge.Scope): string
 ---@field normalize_run fun(self: forge.Forge, entry: table): forge.CIRun
 ---@field run_log_cmd fun(self: forge.Forge, id: string, failed_only: boolean, scope?: forge.Scope): string[]

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -88,8 +88,8 @@ local function fake_ci_forge()
     checks_json_cmd = function(_, num)
       return { 'checks', num }
     end,
-    list_runs_json_cmd = function(_, branch)
-      return { 'runs', branch or '' }
+    list_runs_json_cmd = function(_, branch, _, limit)
+      return { 'runs', branch or '', tostring(limit or '') }
     end,
     normalize_run = function(_, run)
       return run
@@ -1306,6 +1306,122 @@ describe('pickers', function()
 
     assert.equals('1', streamed[1].value.id)
     assert.equals('CI', streamed[1].display[1][1])
+  end)
+
+  it('adds a load more row when the CI run list exceeds the configured limit', function()
+    vim.g.forge = {
+      display = {
+        limits = {
+          runs = 2,
+        },
+      },
+    }
+
+    local old_system = vim.system
+    vim.system = function(_, _, cb)
+      if cb then
+        cb({
+          code = 0,
+          stdout = vim.json.encode({
+            { id = '1', name = 'Build', branch = 'main', status = 'success', url = 'https://e/1' },
+            { id = '2', name = 'Lint', branch = 'main', status = 'failure', url = 'https://e/2' },
+            { id = '3', name = 'Docs', branch = 'main', status = 'success', url = 'https://e/3' },
+          }),
+        })
+      end
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.ci(fake_ci_forge(), 'main', 'all')
+
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+    vim.system = old_system
+
+    assert.equals('1', streamed[1].value.id)
+    assert.equals('2', streamed[2].value.id)
+    assert.equals('Load more...', streamed[3].display[1][1])
+    assert.is_true(streamed[3].load_more)
+  end)
+
+  it('requests more CI runs when the load more row is activated', function()
+    vim.g.forge = {
+      display = {
+        limits = {
+          runs = 2,
+        },
+      },
+    }
+
+    local old_system = vim.system
+    local calls = {}
+    vim.system = function(cmd, _, cb)
+      calls[#calls + 1] = { cmd = cmd, cb = cb }
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.ci(fake_ci_forge(), 'main', 'all')
+
+    assert.is_not_nil(captured)
+    assert.equals('CI for main> ', captured.prompt)
+    assert.same({}, captured.entries)
+    assert.same('function', type(captured.stream))
+
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+
+    assert.same({ 'runs', 'main', '3' }, calls[1].cmd)
+
+    calls[1].cb({
+      code = 0,
+      stdout = vim.json.encode({
+        { id = '1', name = 'Build', branch = 'main', status = 'success', url = 'https://e/1' },
+        { id = '2', name = 'Lint', branch = 'main', status = 'failure', url = 'https://e/2' },
+        { id = '3', name = 'Docs', branch = 'main', status = 'success', url = 'https://e/3' },
+      }),
+    })
+
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+
+    action_by_name('log').fn(streamed[3])
+
+    assert.equals('CI for main> ', captured.prompt)
+    assert.same({}, captured.entries)
+    assert.same('function', type(captured.stream))
+
+    captured.stream(function() end)
+
+    vim.system = old_system
+
+    assert.same({ 'runs', 'main', '5' }, calls[2].cmd)
   end)
 
   it('ignores stale CI responses after switching filters during fetch', function()


### PR DESCRIPTION
## Problem

Repo CI runs were already fetched with a hard cap from `display.limits.runs`, but the picker did not expose that limit. It looked like the first page was the whole list, and there was no way to request more runs from the picker.

## Solution

Use the existing picker pagination pattern for repo CI runs: fetch one extra run, show a `Load more...` row when more runs are available, and request a larger explicit run limit when that row is activated. The PR also updates vimdoc to explain that `:Forge ci` respects `display.limits.runs` and exposes `Load more...` when more runs exist.
