### PR TITLE
fix(pr): use fetched metadata in edit compose

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -426,6 +426,8 @@ function M:parse_pr_details(json)
     title = json.title or '',
     body = json.body or '',
     draft = false,
+    head_branch = type(json.head) == 'table' and (json.head.ref or '') or json.head or '',
+    base_branch = type(json.base) == 'table' and (json.base.ref or '') or json.base or '',
     labels = labels,
     assignees = assignees,
     reviewers = {},

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -691,10 +691,9 @@ end
 ---@param f forge.Forge
 ---@param num string
 ---@param details forge.PRDetails
----@param branch string
----@param base string
+---@param current_branch string
 ---@param ref? forge.Scope
-function M.open_pr_edit(f, num, details, branch, base, ref)
+function M.open_pr_edit(f, num, details, current_branch, ref)
   local buf = create_compose_buf(('forge://pr/%s/edit'):format(num))
   vim.b[buf].forge_scope = ref
 
@@ -712,7 +711,12 @@ function M.open_pr_edit(f, num, details, branch, base, ref)
   local comment_start = #b.lines + 1
 
   local pr_kind = f.labels.pr_full:gsub('s$', '')
-  local diff_stat = vim.fn.system('git diff --stat origin/' .. base .. '..HEAD'):gsub('%s+$', '')
+  local branch = details.head_branch ~= '' and details.head_branch or current_branch
+  local base = details.base_branch ~= '' and details.base_branch or 'main'
+  local diff_stat = ''
+  if current_branch ~= '' and branch == current_branch then
+    diff_stat = vim.fn.system('git diff --stat origin/' .. base .. '..HEAD'):gsub('%s+$', '')
+  end
 
   b:add_line('<!--')
 

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -476,7 +476,7 @@ function M:fetch_pr_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,isDraft,labels,assignees,reviewRequests,milestone,url',
+    'title,body,isDraft,headRefName,baseRefName,labels,assignees,reviewRequests,milestone,url',
   }
 end
 
@@ -585,6 +585,8 @@ function M:parse_pr_details(json)
     title = json.title or '',
     body = json.body or '',
     draft = json.isDraft == true,
+    head_branch = json.headRefName or '',
+    base_branch = json.baseRefName or '',
     labels = labels,
     assignees = assignees,
     reviewers = reviewers,

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -490,6 +490,8 @@ function M:parse_pr_details(json)
     title = json.title or '',
     body = json.description or '',
     draft = json.draft == true,
+    head_branch = json.source_branch or '',
+    base_branch = json.target_branch or '',
     labels = labels,
     assignees = assignees,
     reviewers = reviewers,

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -480,11 +480,7 @@ function M.edit_pr(num, ref)
   end
   ref = ref or M.current_scope(f.name)
 
-  local branch = vim.trim(vim.fn.system('git branch --show-current'))
-  if branch == '' then
-    log.warn('detached HEAD')
-    return
-  end
+  local current_branch = vim.trim(vim.fn.system('git branch --show-current'))
 
   log.info(('fetching %s #%s...'):format(f.labels.pr_one, num))
 
@@ -503,14 +499,8 @@ function M.edit_pr(num, ref)
       return
     end
     local details = f:parse_pr_details(json)
-    vim.system(f:pr_base_cmd(num, ref), { text = true }, function(base_result)
-      local base = vim.trim(base_result.stdout or '')
-      if base == '' then
-        base = 'main'
-      end
-      vim.schedule(function()
-        compose_mod.open_pr_edit(f, num, details, branch, base, ref)
-      end)
+    vim.schedule(function()
+      compose_mod.open_pr_edit(f, num, details, current_branch, ref)
     end)
   end)
 end

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -44,6 +44,8 @@
 ---@field title string
 ---@field body string
 ---@field draft boolean
+---@field head_branch string
+---@field base_branch string
 ---@field reviewers string[]
 ---@field labels string[]
 ---@field assignees string[]

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -1,0 +1,99 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('compose pr edit', function()
+  local old_fn_system
+  local old_feedkeys
+
+  before_each(function()
+    old_fn_system = vim.fn.system
+    old_feedkeys = vim.api.nvim_feedkeys
+    vim.api.nvim_feedkeys = function() end
+  end)
+
+  after_each(function()
+    vim.fn.system = old_fn_system
+    vim.api.nvim_feedkeys = old_feedkeys
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if
+        vim.api.nvim_buf_is_valid(buf)
+        and vim.api.nvim_buf_get_name(buf) == 'forge://pr/23/edit'
+      then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+    vim.cmd('enew!')
+  end)
+
+  it('shows fetched head/base metadata in the header', function()
+    vim.fn.system = function(cmd)
+      if cmd == 'git diff --stat origin/main..HEAD' then
+        return ''
+      end
+      return ''
+    end
+
+    local compose = require('forge.compose')
+    compose.open_pr_edit(
+      {
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = true },
+        name = 'github',
+      },
+      '23',
+      {
+        title = 'PR title',
+        body = 'PR body',
+        draft = false,
+        head_branch = 'real-pr-head',
+        base_branch = 'main',
+        reviewers = { 'bob' },
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
+      },
+      'other-local-branch'
+    )
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    assert.is_truthy(vim.tbl_contains(lines, '  On branch real-pr-head against main.'))
+    assert.is_false(vim.tbl_contains(lines, '  On branch other-local-branch against main.'))
+  end)
+
+  it('hides the local diff stat when the checked-out branch differs from the PR head', function()
+    vim.fn.system = function(cmd)
+      if cmd == 'git diff --stat origin/main..HEAD' then
+        return ' lua/forge/init.lua | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
+      end
+      return ''
+    end
+
+    local compose = require('forge.compose')
+    compose.open_pr_edit(
+      {
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = true },
+        name = 'github',
+      },
+      '23',
+      {
+        title = 'PR title',
+        body = 'PR body',
+        draft = false,
+        head_branch = 'real-pr-head',
+        base_branch = 'main',
+        reviewers = {},
+        labels = {},
+        assignees = {},
+        milestone = '',
+      },
+      'other-local-branch'
+    )
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    for _, line in ipairs(lines) do
+      assert.is_false(line == '  Changes not in origin/main:')
+      assert.is_false(line == '   lua/forge/init.lua | 2 +-')
+    end
+  end)
+end)

--- a/spec/edit_pr_spec.lua
+++ b/spec/edit_pr_spec.lua
@@ -1,0 +1,272 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('edit_pr', function()
+  local captured
+  local old_fn_system
+  local old_vim_system
+  local old_executable
+  local old_preload
+
+  before_each(function()
+    captured = {
+      errors = {},
+      infos = {},
+      systems = {},
+    }
+
+    old_fn_system = vim.fn.system
+    old_vim_system = vim.system
+    old_executable = vim.fn.executable
+    old_preload = {
+      ['forge.action'] = package.preload['forge.action'],
+      ['forge.client'] = package.preload['forge.client'],
+      ['forge.compose'] = package.preload['forge.compose'],
+      ['forge.config'] = package.preload['forge.config'],
+      ['forge.context'] = package.preload['forge.context'],
+      ['forge.format'] = package.preload['forge.format'],
+      ['forge.github'] = package.preload['forge.github'],
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.template'] = package.preload['forge.template'],
+    }
+
+    vim.fn.executable = function(bin)
+      if bin == 'gh' then
+        return 1
+      end
+      return 0
+    end
+
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/repo.git\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return 'other-local-branch\n'
+      end
+      return ''
+    end
+
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      table.insert(captured.systems, key)
+      if key == 'fetch-pr 23' then
+        result.stdout = vim.json.encode({
+          title = 'PR title',
+          body = 'PR body',
+          headRefName = 'real-pr-head',
+          baseRefName = 'main',
+          isDraft = false,
+          labels = {
+            { name = 'bug' },
+          },
+          assignees = {
+            { login = 'alice' },
+          },
+          reviewRequests = {
+            { login = 'bob' },
+          },
+          milestone = {
+            title = 'v1',
+          },
+        })
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    package.preload['forge.action'] = function()
+      return {
+        register = function() end,
+        run = function() end,
+      }
+    end
+
+    package.preload['forge.client'] = function()
+      return {
+        register = function() end,
+      }
+    end
+
+    package.preload['forge.compose'] = function()
+      return {
+        open_pr_edit = function(_, num, details, current_branch, scope)
+          captured.opened = {
+            num = num,
+            details = details,
+            current_branch = current_branch,
+            scope = scope,
+          }
+        end,
+      }
+    end
+
+    package.preload['forge.config'] = function()
+      return {
+        config = function()
+          return {
+            sources = {
+              github = { hosts = { 'github.com' } },
+              gitlab = { hosts = { 'gitlab.com' } },
+              codeberg = { hosts = { 'codeberg.org', 'gitea.com', 'forgejo.org' } },
+            },
+          }
+        end,
+      }
+    end
+
+    package.preload['forge.context'] = function()
+      return {
+        register = function() end,
+      }
+    end
+
+    package.preload['forge.format'] = function()
+      return {}
+    end
+
+    package.preload['forge.github'] = function()
+      return {
+        cli = 'gh',
+        labels = { pr_one = 'PR' },
+        fetch_pr_details_cmd = function(_, num)
+          return { 'fetch-pr', num }
+        end,
+        parse_pr_details = function(_, json)
+          return {
+            title = json.title,
+            body = json.body,
+            draft = json.isDraft == true,
+            head_branch = json.headRefName,
+            base_branch = json.baseRefName,
+            labels = { 'bug' },
+            assignees = { 'alice' },
+            reviewers = { 'bob' },
+            milestone = 'v1',
+          }
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
+        warn = function(msg)
+          table.insert(captured.warnings or {}, msg)
+        end,
+        error = function(msg)
+          table.insert(captured.errors, msg)
+        end,
+      }
+    end
+
+    package.preload['forge.template'] = function()
+      return {}
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.action'] = nil
+    package.loaded['forge.client'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.context'] = nil
+    package.loaded['forge.format'] = nil
+    package.loaded['forge.github'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.template'] = nil
+  end)
+
+  after_each(function()
+    vim.fn.system = old_fn_system
+    vim.system = old_vim_system
+    vim.fn.executable = old_executable
+
+    package.preload['forge.action'] = old_preload['forge.action']
+    package.preload['forge.client'] = old_preload['forge.client']
+    package.preload['forge.compose'] = old_preload['forge.compose']
+    package.preload['forge.config'] = old_preload['forge.config']
+    package.preload['forge.context'] = old_preload['forge.context']
+    package.preload['forge.format'] = old_preload['forge.format']
+    package.preload['forge.github'] = old_preload['forge.github']
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.template'] = old_preload['forge.template']
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.action'] = nil
+    package.loaded['forge.client'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.context'] = nil
+    package.loaded['forge.format'] = nil
+    package.loaded['forge.github'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.template'] = nil
+  end)
+
+  it('uses fetched PR head/base metadata instead of the current local branch', function()
+    require('forge').edit_pr('23')
+
+    vim.wait(100, function()
+      return captured.opened ~= nil
+    end)
+
+    assert.same({
+      num = '23',
+      details = {
+        title = 'PR title',
+        body = 'PR body',
+        draft = false,
+        head_branch = 'real-pr-head',
+        base_branch = 'main',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        reviewers = { 'bob' },
+        milestone = 'v1',
+      },
+      current_branch = 'other-local-branch',
+      scope = nil,
+    }, captured.opened)
+    assert.is_true(vim.tbl_contains(captured.infos, 'fetching PR #23...'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'pr-base 23'))
+  end)
+
+  it('still opens PR edit while detached HEAD', function()
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/repo.git\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return '\n'
+      end
+      return ''
+    end
+
+    require('forge').edit_pr('23')
+
+    vim.wait(100, function()
+      return captured.opened ~= nil
+    end)
+
+    assert.equals('', captured.opened.current_branch)
+    assert.same({}, captured.warnings or {})
+  end)
+end)


### PR DESCRIPTION
## Problem
Direct `:Forge pr edit <num>` could render compose metadata from the current local checkout instead of the PR being edited, which made the header misleading on a different branch or detached HEAD.

## Solution
Parse PR head/base metadata from the fetched PR details, use that data in the edit compose header, suppress the local diff-stat block when the checked-out branch does not match the PR head, and add focused regressions for both the edit flow and compose rendering.