### PR TITLE
fix(create): honor resolved head/base targets

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -436,13 +436,20 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge pr create` [repo=...] [head=...] [base=...] [draft] [fill] [web]
                                                             *:Forge-pr-create*
     Create a new PR.
-    Default targets: `head=` is the current branch push context and
-    `base=` is the collaboration repo default branch.
+    PR creation commands are branch-relative. Default targets: `head=` is
+    the current branch push context and `base=` is the collaboration repo
+    default branch.
     (no modifiers)     Open the compose buffer (|forge-compose|).
     `draft`            Open compose buffer with draft pre-set.
     `fill`             Create instantly from commits (skip compose).
-    `web`              Push and open the forge's web create-PR page.
+    `web`              Push and open the forge's web create-PR page for the
+                       resolved `head=` / `base=` pair.
     `draft fill`       Create draft instantly.
+
+    All other `:Forge pr` actions are PR-relative: command-line use
+    requires `{num}`, and picker/buffer actions operate on the visible PR
+    context. Forge does not remember a hidden "current PR" between
+    commands.
 
 `:Forge pr checkout` {num} [repo=...]                     *:Forge-pr-checkout*
     Check out the branch for PR `{num}`.

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -494,11 +494,18 @@ local function dispatch_pr(command)
     return
   end
   if command.name == 'create' then
+    local target = require('forge.target')
+    local head = command.parsed_modifiers.head or command.default_targets.head
+    local base = command.parsed_modifiers.base or command.default_targets.base
     ops.pr_create({
       draft = command.modifiers.draft == true,
       instant = command.modifiers.fill == true,
       web = command.modifiers.web == true,
       scope = scope,
+      head_branch = head and head.rev or nil,
+      head_scope = target.repo_scope(repo_target(head), f.name),
+      base_branch = base and base.rev or nil,
+      base_scope = target.repo_scope(repo_target(base), f.name) or scope,
     })
     return
   end

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -536,16 +536,19 @@ function M:create_pr_cmd(title, body, base, _draft, _reviewers, labels, assignee
 end
 
 ---@return string
-function M:create_pr_web_url(ref)
-  local branch = vim.trim(vim.fn.system('git branch --show-current'))
+function M:create_pr_web_url(ref, _, head_branch, base_branch)
+  local branch = head_branch or vim.trim(vim.fn.system('git branch --show-current'))
   local base_url = forge.remote_web_url(ref)
-  local default = vim.trim(
-    vim.fn.system(
-      "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'"
+  local default = base_branch
+  if not default or default == '' then
+    default = vim.trim(
+      vim.fn.system(
+        "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'"
+      )
     )
-  )
-  if default == '' then
-    default = 'main'
+    if default == '' then
+      default = 'main'
+    end
   end
   return ('%s/compare/%s...%s'):format(base_url, default, branch)
 end

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -142,6 +142,7 @@ end
 ---@param pr_milestone string?
 ---@param buf integer?
 ---@param ref? forge.Scope
+---@param push_target string?
 local function push_and_create(
   f,
   branch,
@@ -154,61 +155,66 @@ local function push_and_create(
   pr_assignees,
   pr_milestone,
   buf,
-  ref
+  ref,
+  push_target
 )
   local log = require('forge.logger')
   log.info('pushing and creating ' .. f.labels.pr_one .. '...')
-  vim.system({ 'git', 'push', '-u', 'origin', branch }, { text = true }, function(push_result)
-    if push_result.code ~= 0 then
-      local msg = vim.trim(push_result.stderr or '')
-      if msg == '' then
-        msg = 'push failed'
-      end
-      vim.schedule(function()
-        log.error(msg)
-      end)
-      return
-    end
-    vim.system(
-      f:create_pr_cmd(
-        title,
-        body,
-        pr_base,
-        pr_draft,
-        pr_reviewers,
-        pr_labels,
-        pr_assignees,
-        pr_milestone,
-        ref
-      ),
-      { text = true },
-      function(create_result)
+  vim.system(
+    { 'git', 'push', '-u', push_target ~= '' and push_target or 'origin', branch },
+    { text = true },
+    function(push_result)
+      if push_result.code ~= 0 then
+        local msg = vim.trim(push_result.stderr or '')
+        if msg == '' then
+          msg = 'push failed'
+        end
         vim.schedule(function()
-          if create_result.code == 0 then
-            local url = vim.trim(create_result.stdout or '')
-            if url ~= '' then
-              vim.fn.setreg('+', url)
-            end
-            log.info(('created %s -> %s'):format(f.labels.pr_one, url))
-            require('forge').clear_list()
-            if buf and vim.api.nvim_buf_is_valid(buf) then
-              vim.bo[buf].modified = false
-              vim.api.nvim_buf_delete(buf, { force = true })
-            end
-          else
-            local msg = vim.trim(create_result.stderr or '')
-            if msg == '' then
-              msg = vim.trim(create_result.stdout or '')
-            end
-            if msg == '' then
-              msg = 'creation failed'
-            end
-            log.error(msg)
-          end
+          log.error(msg)
         end)
+        return
       end
-    )
-  end)
+      vim.system(
+        f:create_pr_cmd(
+          title,
+          body,
+          pr_base,
+          pr_draft,
+          pr_reviewers,
+          pr_labels,
+          pr_assignees,
+          pr_milestone,
+          ref
+        ),
+        { text = true },
+        function(create_result)
+          vim.schedule(function()
+            if create_result.code == 0 then
+              local url = vim.trim(create_result.stdout or '')
+              if url ~= '' then
+                vim.fn.setreg('+', url)
+              end
+              log.info(('created %s -> %s'):format(f.labels.pr_one, url))
+              require('forge').clear_list()
+              if buf and vim.api.nvim_buf_is_valid(buf) then
+                vim.bo[buf].modified = false
+                vim.api.nvim_buf_delete(buf, { force = true })
+              end
+            else
+              local msg = vim.trim(create_result.stderr or '')
+              if msg == '' then
+                msg = vim.trim(create_result.stdout or '')
+              end
+              if msg == '' then
+                msg = 'creation failed'
+              end
+              log.error(msg)
+            end
+          end)
+        end
+      )
+    end
+  )
 end
 
 local function submit_issue(f, title, body, labels, assignees, milestone, buf, ref)
@@ -452,8 +458,13 @@ end
 ---@param draft boolean
 ---@param tmpl forge.TemplateResult?
 ---@param ref? forge.Scope
-function M.open_pr(f, branch, base, draft, tmpl, ref)
-  local title, commit_body = template.fill_from_commits(branch, base)
+---@param push_target string?
+---@param base_ref string?
+---@param head_ref string?
+function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, head_ref)
+  base_ref = base_ref or ('origin/' .. base)
+  head_ref = head_ref or 'HEAD'
+  local title, commit_body = template.fill_from_commits(branch, base_ref, head_ref)
   local body = (tmpl and tmpl.body) or commit_body
 
   local buf = create_compose_buf('forge://pr/new')
@@ -473,7 +484,8 @@ function M.open_pr(f, branch, base, draft, tmpl, ref)
   local comment_start = #b.lines + 1
 
   local pr_kind = f.labels.pr_full:gsub('s$', '')
-  local diff_stat = vim.fn.system('git diff --stat origin/' .. base .. '..HEAD'):gsub('%s+$', '')
+  local diff_stat =
+    vim.fn.system('git diff --stat ' .. base_ref .. '..' .. head_ref):gsub('%s+$', '')
 
   b:add_line('<!--')
 
@@ -518,10 +530,10 @@ function M.open_pr(f, branch, base, draft, tmpl, ref)
   local stat_start, stat_end
   if diff_stat ~= '' then
     b:add_line('')
-    local changes_prefix = '  Changes not in origin/'
-    ln = b:add_line('%s%s:', changes_prefix, base)
+    local changes_prefix = '  Changes not in '
+    ln = b:add_line('%s%s:', changes_prefix, base_ref)
     b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
-    b:mark(ln, #changes_prefix, #base, 'ForgeComposeBranch')
+    b:mark(ln, #changes_prefix, #base_ref, 'ForgeComposeBranch')
     b:add_line('')
     stat_start = #b.lines + 1
     for _, sl in ipairs(vim.split(diff_stat, '\n', { plain = true })) do
@@ -604,7 +616,8 @@ function M.open_pr(f, branch, base, draft, tmpl, ref)
         meta.assignees,
         meta.milestone,
         buf,
-        ref
+        ref,
+        push_target
       )
     end,
   })

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -679,12 +679,33 @@ function M:create_pr_cmd(title, body, base, draft, reviewers, labels, assignees,
 end
 
 ---@return string[]
-function M:create_pr_web_cmd(scope)
+function M:create_pr_web_cmd(scope, head_scope, head_branch, base_branch)
   local cmd = { 'gh', 'pr', 'create', '--web' }
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
+  end
+  if base_branch and base_branch ~= '' then
+    table.insert(cmd, '--base')
+    table.insert(cmd, base_branch)
+  end
+  local head = head_branch
+  if
+    head
+    and head ~= ''
+    and head_scope
+    and scope
+    and forge.scope_key(head_scope) ~= ''
+    and forge.scope_key(head_scope) ~= forge.scope_key(scope)
+    and head_scope.owner
+    and head_scope.owner ~= ''
+  then
+    head = head_scope.owner .. ':' .. head
+  end
+  if head and head ~= '' then
+    table.insert(cmd, '--head')
+    table.insert(cmd, head)
   end
   return cmd
 end
@@ -717,15 +738,13 @@ function M:create_issue_cmd(title, body, labels, assignees, milestone, scope)
   return cmd
 end
 
----@return string[]
-function M:create_issue_web_cmd(scope)
-  local cmd = { 'gh', 'issue', 'create', '--web' }
-  local repo = nwo(scope)
-  if repo ~= '' then
-    table.insert(cmd, '-R')
-    table.insert(cmd, repo)
+---@return string?
+function M:create_issue_web_url(scope)
+  local url = forge.remote_web_url(scope)
+  if url == '' then
+    return nil
   end
-  return cmd
+  return url .. '/issues/new'
 end
 
 ---@return string[]

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -608,8 +608,25 @@ function M:create_pr_cmd(title, body, base, draft, reviewers, labels, assignees,
 end
 
 ---@return string[]
-function M:create_pr_web_cmd(ref)
-  return { 'glab', 'mr', 'create', '--web', '-R', repo_arg(ref) }
+function M:create_pr_web_cmd(ref, head_scope, head_branch, base_branch)
+  local cmd = { 'glab', 'mr', 'create', '--web', '-R', repo_arg(ref) }
+  if
+    head_scope
+    and forge.scope_key(head_scope) ~= ''
+    and forge.scope_key(head_scope) ~= forge.scope_key(ref)
+  then
+    table.insert(cmd, '--head')
+    table.insert(cmd, repo_arg(head_scope))
+  end
+  if head_branch and head_branch ~= '' then
+    table.insert(cmd, '--source-branch')
+    table.insert(cmd, head_branch)
+  end
+  if base_branch and base_branch ~= '' then
+    table.insert(cmd, '--target-branch')
+    table.insert(cmd, base_branch)
+  end
+  return cmd
 end
 
 ---@param title string

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -66,6 +66,63 @@ local function cmd_error(result, fallback)
   return msg
 end
 
+local function system_text(cmd)
+  local result = vim.system(cmd, { text = true }):wait()
+  if result.code ~= 0 then
+    return ''
+  end
+  return vim.trim(result.stdout or '')
+end
+
+local function push_remote_name(branch)
+  local remote = system_text({ 'git', 'config', 'branch.' .. branch .. '.pushRemote' })
+  if remote == '' then
+    remote = system_text({ 'git', 'config', 'remote.pushDefault' })
+  end
+  if remote == '' then
+    local upstream = system_text({ 'git', 'rev-parse', '--abbrev-ref', branch .. '@{upstream}' })
+    remote = upstream:match('^([^/]+)/') or ''
+  end
+  if remote == '' then
+    local remotes = system_text({ 'git', 'remote' })
+    remote = vim.split(remotes, '\n', { plain = true, trimempty = true })[1] or ''
+  end
+  return remote
+end
+
+local function remote_scope(forge_name, remote)
+  if remote == '' then
+    return nil
+  end
+  local url = system_text({ 'git', 'remote', 'get-url', remote })
+  if url == '' then
+    return nil
+  end
+  return scope_mod.from_url(forge_name, url)
+end
+
+local function push_target(branch, scope)
+  if scope_mod.key(scope) ~= '' then
+    return scope_mod.remote_name(scope) or scope_mod.git_url(scope) or ''
+  end
+  return push_remote_name(branch)
+end
+
+local function branch_ref(branch, current_branch)
+  if branch ~= '' and branch == current_branch and current_branch ~= '' then
+    return 'HEAD'
+  end
+  return branch
+end
+
+local function base_ref(scope, base)
+  local ref = scope_mod.remote_ref(scope, base)
+  if ref and ref ~= '' then
+    return ref
+  end
+  return 'origin/' .. base
+end
+
 local function open_web_create(label, cmd, url)
   local log = require('forge.logger')
   local success_msg = ('opened %s creation in browser'):format(label)
@@ -330,17 +387,26 @@ function M.create_pr(opts)
     log.warn('no forge detected')
     return
   end
-  local ref = opts.scope or M.current_scope(f.name)
+  local ref = opts.base_scope or opts.scope or M.current_scope(f.name)
+  local base_scope = opts.base_scope or ref
 
-  local branch = vim.trim(vim.fn.system('git branch --show-current'))
+  local current_branch = vim.trim(vim.fn.system('git branch --show-current'))
+  local branch = opts.head_branch or current_branch
   if branch == '' then
     log.warn('detached HEAD')
     return
   end
+  local head_scope = opts.head_scope or remote_scope(f.name, push_remote_name(branch))
+  local push_to = push_target(branch, head_scope)
+  local head_ref = branch_ref(branch, current_branch)
 
   local function with_base(cb)
+    if opts.base_branch and opts.base_branch ~= '' then
+      cb(opts.base_branch)
+      return
+    end
     log.info('resolving base branch...')
-    vim.system(f:default_branch_cmd(ref), { text = true }, function(base_result)
+    vim.system(f:default_branch_cmd(base_scope), { text = true }, function(base_result)
       local base = vim.trim(base_result.stdout or '')
       if base == '' then
         base = 'main'
@@ -352,27 +418,28 @@ function M.create_pr(opts)
   end
 
   local function ensure_creatable(base, cb)
-    if branch == base then
+    local target_ref = base_ref(base_scope, base)
+    if branch == base and scope_mod.same(head_scope, base_scope) then
       log.warn('current branch already matches base ' .. base)
       return
     end
     local has_diff = vim
-      .system({ 'git', 'diff', '--quiet', 'origin/' .. base .. '..HEAD' }, { text = true })
+      .system({ 'git', 'diff', '--quiet', target_ref .. '..' .. head_ref }, { text = true })
       :wait().code ~= 0
     if not has_diff then
-      log.warn('no changes from origin/' .. base)
+      log.warn('no changes from ' .. target_ref)
       return
     end
-    cb(base)
+    cb(base, target_ref)
   end
 
   log.info('checking for existing ' .. f.labels.pr_one .. '...')
 
-  vim.system(f:pr_for_branch_cmd(branch, ref), { text = true }, function(result)
+  vim.system(f:pr_for_branch_cmd(branch, base_scope), { text = true }, function(result)
     local num = vim.trim(result.stdout or '')
     vim.schedule(function()
       if num ~= '' and num ~= 'null' then
-        M.edit_pr(num, ref)
+        M.edit_pr(num, base_scope)
         return
       end
 
@@ -381,7 +448,7 @@ function M.create_pr(opts)
           ensure_creatable(base, function()
             log.info('pushing...')
             vim.system(
-              { 'git', 'push', '-u', 'origin', branch },
+              { 'git', 'push', '-u', push_to ~= '' and push_to or 'origin', branch },
               { text = true },
               function(push_result)
                 vim.schedule(function()
@@ -389,8 +456,12 @@ function M.create_pr(opts)
                     log.error('push failed')
                     return
                   end
-                  local web_cmd = f.create_pr_web_cmd and f:create_pr_web_cmd(ref) or nil
-                  local web_url = f.create_pr_web_url and f:create_pr_web_url(ref) or nil
+                  local web_cmd = f.create_pr_web_cmd
+                      and f:create_pr_web_cmd(base_scope, head_scope, branch, base)
+                    or nil
+                  local web_url = f.create_pr_web_url
+                      and f:create_pr_web_url(base_scope, head_scope, branch, base)
+                    or nil
                   open_web_create(f.labels.pr_one, web_cmd, web_url)
                 end)
               end
@@ -401,9 +472,9 @@ function M.create_pr(opts)
       end
 
       with_base(function(base)
-        ensure_creatable(base, function()
+        ensure_creatable(base, function(_, target_ref)
           if opts.instant then
-            local title, body = template_mod.fill_from_commits(branch, base)
+            local title, body = template_mod.fill_from_commits(branch, target_ref, head_ref)
             compose_mod.push_and_create(
               f,
               branch,
@@ -416,7 +487,8 @@ function M.create_pr(opts)
               nil,
               nil,
               nil,
-              ref
+              base_scope,
+              push_to
             )
           else
             local root = git_root() or ''
@@ -427,7 +499,17 @@ function M.create_pr(opts)
               return
             end
             if tmpl or not templates then
-              compose_mod.open_pr(f, branch, base, draft, tmpl, ref)
+              compose_mod.open_pr(
+                f,
+                branch,
+                base,
+                draft,
+                tmpl,
+                base_scope,
+                push_to,
+                target_ref,
+                head_ref
+              )
             else
               local picker = require('forge.picker')
               local entries = {}
@@ -452,7 +534,17 @@ function M.create_pr(opts)
                           log.error(load_err)
                           return
                         end
-                        compose_mod.open_pr(f, branch, base, draft, template, ref)
+                        compose_mod.open_pr(
+                          f,
+                          branch,
+                          base,
+                          draft,
+                          template,
+                          base_scope,
+                          push_to,
+                          target_ref,
+                          head_ref
+                        )
                       end
                     end,
                   },
@@ -551,10 +643,14 @@ function M.create_issue(opts)
   local ref = opts.scope or M.current_scope(f.name)
 
   if opts.web then
-    local cmd = f.create_issue_web_cmd and f:create_issue_web_cmd(ref) or nil
-    local url = M.remote_web_url(ref)
-    if url ~= '' then
-      url = url .. '/issues/new'
+    local url = f.create_issue_web_url and f:create_issue_web_url(ref) or nil
+    local cmd = nil
+    if not url or url == '' then
+      cmd = f.create_issue_web_cmd and f:create_issue_web_cmd(ref) or nil
+      url = M.remote_web_url(ref)
+      if url ~= '' then
+        url = url .. '/issues/new'
+      end
     end
     open_web_create('issue', cmd, url)
     return

--- a/lua/forge/template.lua
+++ b/lua/forge/template.lua
@@ -15,11 +15,12 @@ function M.normalize_body(s)
 end
 
 ---@param branch string
----@param base string
+---@param base_ref string
+---@param head_ref string
 ---@return string title, string body
-function M.fill_from_commits(branch, base)
+function M.fill_from_commits(branch, base_ref, head_ref)
   local result = vim
-    .system({ 'git', 'log', 'origin/' .. base .. '..HEAD', '--format=%s%n%b%x00' }, { text = true })
+    .system({ 'git', 'log', base_ref .. '..' .. head_ref, '--format=%s%n%b%x00' }, { text = true })
     :wait()
   local raw = vim.trim(result.stdout or '')
   if raw == '' then

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -64,6 +64,10 @@
 ---@field web boolean?
 ---@field back fun()?
 ---@field scope forge.Scope?
+---@field head_branch string?
+---@field head_scope forge.Scope?
+---@field base_branch string?
+---@field base_scope forge.Scope?
 
 ---@class forge.CreateIssueOpts
 ---@field web boolean?
@@ -156,8 +160,8 @@
 ---@field fetch_issue_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field parse_issue_details fun(self: forge.Forge, json: table): forge.IssueDetails
 ---@field completion_cmd (fun(self: forge.Forge, field: string, scope?: forge.Scope): string[]?)?
----@field create_pr_web_cmd fun(self: forge.Forge, scope?: forge.Scope): string[]?
----@field create_pr_web_url (fun(self: forge.Forge, scope?: forge.Scope): string?)?
+---@field create_pr_web_cmd (fun(self: forge.Forge, scope?: forge.Scope, head_scope?: forge.Scope, head_branch?: string, base_branch?: string): string[]?)?
+---@field create_pr_web_url (fun(self: forge.Forge, scope?: forge.Scope, head_scope?: forge.Scope, head_branch?: string, base_branch?: string): string?)?
 ---@field default_branch_cmd fun(self: forge.Forge, scope?: forge.Scope): string[]
 ---@field checks_json_cmd (fun(self: forge.Forge, num: string, scope?: forge.Scope): string[])?
 ---@field template_paths fun(self: forge.Forge): string[]
@@ -169,3 +173,4 @@
 ---@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, labels: string[]?, assignees: string[]?, milestone: string?, original: forge.IssueDetails, scope?: forge.Scope): string[]
 ---@field issue_template_paths fun(self: forge.Forge): string[]
 ---@field create_issue_web_cmd (fun(self: forge.Forge, scope?: forge.Scope): string[]?)?
+---@field create_issue_web_url (fun(self: forge.Forge, scope?: forge.Scope): string?)?

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -432,9 +432,68 @@ describe(':Forge command', function()
         repo_arg = 'owner/upstream',
         web_url = 'https://github.com/owner/upstream',
       },
+      head_branch = 'main',
+      head_scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'current',
+        slug = 'owner/current',
+        repo_arg = 'owner/current',
+        web_url = 'https://github.com/owner/current',
+      },
+      base_branch = nil,
+      base_scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'upstream',
+        slug = 'owner/upstream',
+        repo_arg = 'owner/upstream',
+        web_url = 'https://github.com/owner/upstream',
+      },
     }, captured.create_pr)
     assert.same({ web = false, blank = true, template = 'bug', scope = nil }, captured.create_issue)
     assert.is_true(captured.cleared)
+  end)
+
+  it('passes explicit create head and base targets through the command layer', function()
+    vim.cmd('Forge pr create head=origin@topic base=upstream@release')
+
+    assert.same({
+      draft = false,
+      instant = false,
+      web = false,
+      scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'upstream',
+        slug = 'owner/upstream',
+        repo_arg = 'owner/upstream',
+        web_url = 'https://github.com/owner/upstream',
+      },
+      head_branch = 'topic',
+      head_scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'current',
+        slug = 'owner/current',
+        repo_arg = 'owner/current',
+        web_url = 'https://github.com/owner/current',
+      },
+      base_branch = 'release',
+      base_scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'upstream',
+        slug = 'owner/upstream',
+        repo_arg = 'owner/upstream',
+        web_url = 'https://github.com/owner/upstream',
+      },
+    }, captured.create_pr)
   end)
 
   it('dispatches issue edit through forge.ops with scoped parity', function()

--- a/spec/create_issue_spec.lua
+++ b/spec/create_issue_spec.lua
@@ -120,6 +120,7 @@ describe('create_issue', function()
 
     package.preload['forge.github'] = function()
       return {
+        name = 'github',
         cli = 'gh',
         create_issue_web_cmd = function()
           return { 'create-issue-web' }
@@ -129,6 +130,8 @@ describe('create_issue', function()
         end,
       }
     end
+    package.loaded['forge'] = nil
+    package.loaded['forge.github'] = nil
 
     package.preload['forge.logger'] = function()
       return {
@@ -338,6 +341,7 @@ describe('create_issue', function()
   it('reports browser open failures for URL-based web issue flows', function()
     package.preload['forge.github'] = function()
       return {
+        name = 'github',
         cli = 'gh',
         issue_template_paths = function()
           return { '.github/ISSUE_TEMPLATE/' }
@@ -354,5 +358,28 @@ describe('create_issue', function()
 
     assert.same({ 'open failed' }, captured.errors)
     assert.same({ 'https://github.com/owner/repo/issues/new' }, captured.open_urls)
+  end)
+
+  it('prefers URL-based web issue flows over command-based ones when both exist', function()
+    package.preload['forge.github'] = function()
+      return {
+        cli = 'gh',
+        create_issue_web_cmd = function()
+          return { 'create-issue-web' }
+        end,
+        create_issue_web_url = function()
+          return 'https://github.com/owner/repo/issues/new'
+        end,
+        issue_template_paths = function()
+          return { '.github/ISSUE_TEMPLATE/' }
+        end,
+      }
+    end
+
+    require('forge').create_issue({ web = true })
+
+    assert.same({}, captured.systems)
+    assert.same({ 'https://github.com/owner/repo/issues/new' }, captured.open_urls)
+    assert.same({ 'opened issue creation in browser' }, captured.infos)
   end)
 end)

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -61,13 +61,26 @@ describe('create_pr', function()
         stderr = '',
       }
       local key = table.concat(cmd, ' ')
+      local fail = {
+        ['git config branch.feature.pushRemote'] = true,
+        ['git config remote.pushDefault'] = true,
+        ['git remote get-url upstream'] = true,
+        ['git diff --quiet origin/main..HEAD'] = true,
+      }
       table.insert(captured.systems, key)
+      if fail[key] then
+        result.code = 1
+      end
       if key == 'pr-for-branch feature' then
         result.stdout = '\n'
       elseif key == 'default-branch' then
         result.stdout = 'main\n'
-      elseif key == 'git diff --quiet origin/main..HEAD' then
-        result.code = 1
+      elseif key == 'git rev-parse --abbrev-ref feature@{upstream}' then
+        result.stdout = 'origin/feature\n'
+      elseif key == 'git remote' then
+        result.stdout = 'origin\nupstream\n'
+      elseif key == 'git remote get-url origin' then
+        result.stdout = 'git@github.com:owner/repo.git\n'
       end
       if cb then
         cb(result)
@@ -126,6 +139,7 @@ describe('create_pr', function()
 
     package.preload['forge.github'] = function()
       return {
+        name = 'github',
         cli = 'gh',
         labels = { pr_one = 'PR' },
         pr_for_branch_cmd = function(_, branch)
@@ -134,7 +148,13 @@ describe('create_pr', function()
         default_branch_cmd = function()
           return { 'default-branch' }
         end,
-        create_pr_web_cmd = function()
+        create_pr_web_cmd = function(_, scope, head_scope, head_branch, base_branch)
+          captured.web_create = {
+            scope = scope,
+            head_scope = head_scope,
+            head_branch = head_branch,
+            base_branch = base_branch,
+          }
           return { 'create-pr-web' }
         end,
         template_paths = function()
@@ -271,6 +291,43 @@ describe('create_pr', function()
       end
       return ''
     end
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      local fail = {
+        ['git config branch.main.pushRemote'] = true,
+        ['git config remote.pushDefault'] = true,
+        ['git remote get-url upstream'] = true,
+        ['git diff --quiet origin/main..HEAD'] = true,
+      }
+      table.insert(captured.systems, key)
+      if fail[key] then
+        result.code = 1
+      end
+      if key == 'pr-for-branch main' then
+        result.stdout = '\n'
+      elseif key == 'default-branch' then
+        result.stdout = 'main\n'
+      elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
+        result.stdout = 'origin/main\n'
+      elseif key == 'git remote' then
+        result.stdout = 'origin\nupstream\n'
+      elseif key == 'git remote get-url origin' then
+        result.stdout = 'git@github.com:owner/repo.git\n'
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
 
     require('forge').create_pr({ web = true })
 
@@ -281,6 +338,81 @@ describe('create_pr', function()
     assert.same({ 'current branch already matches base main' }, captured.warnings)
     assert.is_false(vim.tbl_contains(captured.systems, 'git push -u origin main'))
     assert.is_false(vim.tbl_contains(captured.systems, 'create-pr-web'))
+  end)
+
+  it('allows web PR creation when the branch matches the base name in a different repo', function()
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/fork.git\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return 'main\n'
+      end
+      return ''
+    end
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      local fail = {
+        ['git config branch.main.pushRemote'] = true,
+        ['git config remote.pushDefault'] = true,
+        ['git diff --quiet upstream/main..HEAD'] = true,
+      }
+      table.insert(captured.systems, key)
+      if fail[key] then
+        result.code = 1
+      end
+      if key == 'pr-for-branch main' then
+        result.stdout = '\n'
+      elseif key == 'default-branch' then
+        result.stdout = 'main\n'
+      elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
+        result.stdout = 'origin/main\n'
+      elseif key == 'git remote' then
+        result.stdout = 'origin\nupstream\n'
+      elseif key == 'git remote get-url origin' then
+        result.stdout = 'git@github.com:owner/fork.git\n'
+      elseif key == 'git remote get-url upstream' then
+        result.stdout = 'git@github.com:owner/repo.git\n'
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    require('forge').create_pr({
+      web = true,
+      scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'repo',
+        slug = 'owner/repo',
+        repo_arg = 'owner/repo',
+        web_url = 'https://github.com/owner/repo',
+      },
+    })
+
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.infos, 'opened PR creation in browser')
+    end)
+
+    assert.same({}, captured.warnings)
+    assert.is_true(vim.tbl_contains(captured.systems, 'git diff --quiet upstream/main..HEAD'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'git push -u origin main'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'create-pr-web'))
   end)
 
   it('blocks web PR creation when there are no changes from the base branch', function()
@@ -330,6 +462,78 @@ describe('create_pr', function()
     assert.is_true(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
     assert.is_true(vim.tbl_contains(captured.systems, 'create-pr-web'))
     assert.is_true(vim.tbl_contains(captured.infos, 'opened PR creation in browser'))
+    assert.equals('feature', captured.web_create.head_branch)
+    assert.equals('main', captured.web_create.base_branch)
+  end)
+
+  it('uses explicit head and base overrides for web PR creation', function()
+    vim.system = function(cmd, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      local key = table.concat(cmd, ' ')
+      local fail = {
+        ['git diff --quiet upstream/stable..topic'] = true,
+      }
+      table.insert(captured.systems, key)
+      if fail[key] then
+        result.code = 1
+      end
+      if key == 'pr-for-branch topic' then
+        result.stdout = '\n'
+      elseif key == 'git remote' then
+        result.stdout = 'origin\nupstream\n'
+      elseif key == 'git remote get-url origin' then
+        result.stdout = 'git@github.com:owner/fork.git\n'
+      elseif key == 'git remote get-url upstream' then
+        result.stdout = 'git@github.com:owner/repo.git\n'
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    require('forge').create_pr({
+      web = true,
+      head_branch = 'topic',
+      head_scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'fork',
+        slug = 'owner/fork',
+        repo_arg = 'owner/fork',
+        web_url = 'https://github.com/owner/fork',
+      },
+      base_branch = 'stable',
+      base_scope = {
+        kind = 'github',
+        host = 'github.com',
+        owner = 'owner',
+        repo = 'repo',
+        slug = 'owner/repo',
+        repo_arg = 'owner/repo',
+        web_url = 'https://github.com/owner/repo',
+      },
+    })
+
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.infos, 'opened PR creation in browser')
+    end)
+
+    assert.is_true(vim.tbl_contains(captured.systems, 'git diff --quiet upstream/stable..topic'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'git push -u origin topic'))
+    assert.equals('topic', captured.web_create.head_branch)
+    assert.equals('stable', captured.web_create.base_branch)
+    assert.equals('owner/repo', captured.web_create.scope.slug)
+    assert.equals('owner/fork', captured.web_create.head_scope.slug)
   end)
 
   it('reports an error when the web PR command fails', function()


### PR DESCRIPTION
## Problem
PR create flows mixed branch-relative and origin-relative behavior. `:Forge pr create` advertised `head=` and `base=` modifiers but dropped them at dispatch time, web create did not consistently target the resolved head/base pair, and GitHub issue web create still depended on the non-interactive CLI path.

## Solution
Wire `head=` and `base=` through the PR create command path and use the resolved head/base pair consistently for preflight, diffing, push, compose, and web opening. Pass explicit head/base information into GitHub and GitLab web create flows, make Codeberg compare URLs respect the resolved pair, route GitHub issue web create through the browser URL path, and document that only PR create commands are branch-relative while other PR verbs remain PR-relative.