### PR TITLE
fix(ci): use live picker widths for CI rows

### DIFF
--- a/lua/forge/format.lua
+++ b/lua/forge/format.lua
@@ -297,7 +297,7 @@ function M.format_checks(checks, opts)
     names[#names + 1] = check.name or ''
     elapsed[#elapsed + 1] = elapsed_for(check)
   end
-  local name_pref, name_max = elastic_width(widths.name, names, 10)
+  local name_pref, name_max = elastic_width(widths.name, names, 18, { max_quantile = 1 })
   local plan = layout.plan({
     width = opts and opts.width or layout.picker_width(),
     columns = {
@@ -305,7 +305,7 @@ function M.format_checks(checks, opts)
       {
         key = 'name',
         gap = '  ',
-        min = 10,
+        min = 18,
         preferred = name_pref,
         max = name_max,
         shrink = 2,

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -310,7 +310,7 @@ end
 ---@return string[]
 function M:summary_json_cmd(id, scope)
   local jq = table.concat({
-    '{name,status,conclusion,event,url,',
+    '{displayTitle,name,status,conclusion,event,url,',
     'jobs:[.jobs[]|{databaseId,name,status,conclusion,url,',
     'startedAt,completedAt,',
     'steps:[.steps[]|{name,status,conclusion,number}]}]}',
@@ -323,7 +323,7 @@ function M:summary_json_cmd(id, scope)
     '-R',
     nwo(scope),
     '--json',
-    'name,status,conclusion,event,url,jobs',
+    'displayTitle,name,status,conclusion,event,url,jobs',
     '--jq',
     jq,
   }
@@ -380,7 +380,7 @@ function M:normalize_run(entry)
   end
   return {
     id = tostring(entry.databaseId or ''),
-    name = entry.name or '',
+    name = entry.displayTitle or entry.name or '',
     branch = entry.headBranch or '',
     status = status,
     event = entry.event or '',

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -920,7 +920,7 @@ local function parse_summary_json(data)
   local job_lnums = {}
 
   local run_status = (data.conclusion and data.conclusion ~= '') and data.conclusion or data.status
-  local header = data.name or 'run'
+  local header = data.displayTitle or data.name or 'run'
   lines[#lines + 1] = header
   hls_list[#hls_list + 1] = summary_hls(header, run_status)
 

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -65,8 +65,29 @@ local function render(segments)
   return table.concat(parts)
 end
 
-local function render_line(index, entry)
-  local text = render(entry.display)
+local function picker_width()
+  local utils = require('fzf-lua.utils')
+  local win = type(utils.fzf_winobj) == 'function' and utils.fzf_winobj() or nil
+  local winid = win and rawget(win, 'fzf_winid') or nil
+  if type(winid) == 'number' and winid > 0 then
+    local ok, width = pcall(vim.api.nvim_win_get_width, winid)
+    if ok and type(width) == 'number' and width > 0 then
+      return width
+    end
+  end
+  return require('forge.layout').picker_width()
+end
+
+local function entry_display(entry, width)
+  local display = rawget(entry, 'render_display')
+  if type(display) == 'function' then
+    return display(width)
+  end
+  return entry.display or {}
+end
+
+local function render_line(index, entry, width)
+  local text = render(entry_display(entry, width))
   if vim.trim(text) == '' then
     return nil
   end
@@ -121,6 +142,16 @@ function M.pick(opts)
   local stream = rawget(opts, 'stream')
   local seed_entries = vim.list_extend({}, entries)
   local actions = vim.deepcopy(opts.actions or {})
+  local live_width = stream ~= nil
+
+  if not live_width then
+    for _, entry in ipairs(entries) do
+      if type(rawget(entry, 'render_display')) == 'function' then
+        live_width = true
+        break
+      end
+    end
+  end
 
   if opts.back and keys.back then
     actions[#actions + 1] = {
@@ -132,29 +163,33 @@ function M.pick(opts)
   end
 
   local lines
-  if stream then
+  if live_width then
     lines = function(fzf_cb)
       entries = vim.list_extend({}, seed_entries)
       local next_index = 0
       for i, entry in ipairs(entries) do
         next_index = i
-        local line = render_line(i, entry)
+        local line = render_line(i, entry, picker_width())
         if line then
           fzf_cb(line)
         end
       end
-      stream(function(entry)
-        if not entry then
-          fzf_cb(nil)
-          return
-        end
-        next_index = next_index + 1
-        entries[next_index] = entry
-        local line = render_line(next_index, entry)
-        if line then
-          fzf_cb(line)
-        end
-      end)
+      if stream then
+        stream(function(entry)
+          if not entry then
+            fzf_cb(nil)
+            return
+          end
+          next_index = next_index + 1
+          entries[next_index] = entry
+          local line = render_line(next_index, entry, picker_width())
+          if line then
+            fzf_cb(line)
+          end
+        end)
+      else
+        fzf_cb(nil)
+      end
     end
   else
     lines = {}

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -67,6 +67,19 @@ local function with_placeholder(entries, text)
   return { placeholder_entry(text) }
 end
 
+local function cached_rows(build)
+  local cache = {}
+  return function(width)
+    width = width or layout.picker_width()
+    local rows = cache[width]
+    if rows == nil then
+      rows = build(width)
+      cache[width] = rows
+    end
+    return rows
+  end
+end
+
 local function scoped_forge_ref(f, ref)
   if ref then
     return ref
@@ -196,7 +209,7 @@ local function display_path(path, width)
   return rendered
 end
 
-local function branch_layout(branches)
+local function branch_layout(branches, width)
   local branch_limit = 25
   local subject_limit = 45
   local ok, forge = pcall(require, 'forge')
@@ -219,7 +232,7 @@ local function branch_layout(branches)
     elastic_width(branch_limit, upstreams, 8, { max_quantile = 1 })
   local subject_pref, subject_max = elastic_width(subject_limit, subjects, 12)
   return layout.plan({
-    width = layout.picker_width(),
+    width = width or layout.picker_width(),
     columns = {
       { key = 'marker', fixed = 2 },
       {
@@ -263,7 +276,7 @@ local function branch_layout(branches)
   })
 end
 
-local function commit_layout(commits)
+local function commit_layout(commits, width)
   local title_limit = 45
   local author_limit = 15
   local ok, forge = pcall(require, 'forge')
@@ -286,7 +299,7 @@ local function commit_layout(commits)
   local subject_pref, subject_max = elastic_width(title_limit, subjects, 12)
   local author_pref, author_max = elastic_width(author_limit, authors, 8, { max_quantile = 1 })
   return layout.plan({
-    width = layout.picker_width(),
+    width = width or layout.picker_width(),
     columns = {
       { key = 'sha', fixed = math.max(7, layout.max_width(shas)) },
       {
@@ -369,7 +382,7 @@ local function worktree_label(item)
   return ''
 end
 
-local function worktree_layout(worktrees)
+local function worktree_layout(worktrees, width)
   local path_limit = 35
   local label_limit = 25
   local ok, forge = pcall(require, 'forge')
@@ -396,7 +409,7 @@ local function worktree_layout(worktrees)
   local label_pref = elastic_width(label_limit, labels, 8)
   local label_max = math.max(label_pref, layout.max_width(labels))
   return layout.plan({
-    width = layout.picker_width(),
+    width = width or layout.picker_width(),
     columns = {
       { key = 'marker', fixed = 2 },
       {
@@ -689,11 +702,17 @@ function M.checks(f, num, filter, cached_checks, opts)
   local function build_check_entries(checks)
     local filtered = forge_mod.filter_checks(checks, filter)
     local count = #filtered
-    local displays = forge_mod.format_checks(filtered, { width = layout.picker_width() })
+    local rows_for = cached_rows(function(width)
+      return forge_mod.format_checks(filtered, { width = width })
+    end)
+    local displays = rows_for()
     local entries = {}
     for i, c in ipairs(filtered) do
       table.insert(entries, {
         display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = c,
         ordinal = c.name or '',
       })
@@ -928,12 +947,18 @@ function M.ci(f, branch, filter, opts)
       filtered = vim.list_slice(filtered, 1, visible_limit)
     end
     local count = #filtered
-    local displays = forge_mod.format_runs(filtered, { width = layout.picker_width() })
+    local rows_for = cached_rows(function(width)
+      return forge_mod.format_runs(filtered, { width = width })
+    end)
+    local displays = rows_for()
 
     local entries = {}
     for i, run in ipairs(filtered) do
       table.insert(entries, {
         display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = run,
         ordinal = run.name .. ' ' .. run.branch,
       })
@@ -1128,8 +1153,10 @@ function M.pr(state, f, opts)
       prs = vim.list_slice(prs, 1, visible_limit)
     end
     local entries = {}
-    local displays =
-      forge_mod.format_prs(prs, pr_fields, show_state, { width = layout.picker_width() })
+    local rows_for = cached_rows(function(width)
+      return forge_mod.format_prs(prs, pr_fields, show_state, { width = width })
+    end)
+    local displays = rows_for()
     for i, pr in ipairs(prs) do
       local num = tostring(pr[pr_fields.number] or '')
       local s = (pr[pr_fields.state] or ''):lower()
@@ -1137,6 +1164,9 @@ function M.pr(state, f, opts)
       state_map[num] = s == 'open' or s == 'opened'
       table.insert(entries, {
         display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = {
           num = num,
           scope = ref,
@@ -1396,18 +1426,19 @@ function M.issue(state, f, opts)
     end
     local state_field = issue_fields.state
     local entries = {}
-    local displays = forge_mod.format_issues(
-      issues,
-      issue_fields,
-      issue_show_state,
-      { width = layout.picker_width() }
-    )
+    local rows_for = cached_rows(function(width)
+      return forge_mod.format_issues(issues, issue_fields, issue_show_state, { width = width })
+    end)
+    local displays = rows_for()
     for i, issue in ipairs(issues) do
       local n = tostring(issue[num_field] or '')
       local s = (issue[state_field] or ''):lower()
       state_map[n] = s == 'open' or s == 'opened'
       table.insert(entries, {
         display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = { num = n, scope = ref },
         ordinal = (issue[issue_fields.title] or '') .. ' #' .. n,
       })
@@ -1638,12 +1669,17 @@ function M.release(state, f, opts)
     end
 
     local entries = {}
-    local displays =
-      forge_mod.format_releases(filtered, rel_fields, { width = layout.picker_width() })
+    local rows_for = cached_rows(function(width)
+      return forge_mod.format_releases(filtered, rel_fields, { width = width })
+    end)
+    local displays = rows_for()
     for i, rel in ipairs(filtered) do
       local tag = tostring(rel[rel_fields.tag] or '')
       table.insert(entries, {
         display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = { tag = tag, rel = rel, scope = ref },
         ordinal = tag .. ' ' .. (rel[rel_fields.title] or ''),
       })
@@ -1776,11 +1812,20 @@ function M.branches(ctx, opts)
   local cache_key = forge_mod.list_key('branch', 'local-refs-v2')
 
   local function open_branch_list(branches)
-    local plan = branch_layout(branches)
+    local rows_for = cached_rows(function(width)
+      local plan = branch_layout(branches, width)
+      return vim.tbl_map(function(item)
+        return branch_display(item, plan)
+      end, branches)
+    end)
+    local displays = rows_for()
     local entries = {}
-    for _, item in ipairs(branches) do
+    for i, item in ipairs(branches) do
       entries[#entries + 1] = {
-        display = branch_display(item, plan),
+        display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = item,
       }
     end
@@ -1941,11 +1986,20 @@ function M.commits(ctx, branch, opts)
     if has_more then
       commits = vim.list_slice(commits, 1, visible_limit)
     end
-    local plan = commit_layout(commits)
+    local rows_for = cached_rows(function(width)
+      local plan = commit_layout(commits, width)
+      return vim.tbl_map(function(item)
+        return commit_display(item, plan)
+      end, commits)
+    end)
+    local displays = rows_for()
     local entries = {}
-    for _, item in ipairs(commits) do
+    for i, item in ipairs(commits) do
       entries[#entries + 1] = {
-        display = commit_display(item, plan),
+        display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = item,
         ordinal = item.sha .. ' ' .. item.subject .. ' ' .. item.author,
       }
@@ -2092,11 +2146,20 @@ function M.worktrees(ctx, opts)
   local cache_key = forge_mod.list_key('worktree', 'list')
 
   local function open_worktree_list(worktrees)
-    local plan = worktree_layout(worktrees)
+    local rows_for = cached_rows(function(width)
+      local plan = worktree_layout(worktrees, width)
+      return vim.tbl_map(function(item)
+        return worktree_display(item, plan)
+      end, worktrees)
+    end)
+    local displays = rows_for()
     local entries = {}
-    for _, item in ipairs(worktrees) do
+    for i, item in ipairs(worktrees) do
       entries[#entries + 1] = {
-        display = worktree_display(item, plan),
+        display = displays[i],
+        render_display = function(width)
+          return rows_for(width)[i]
+        end,
         value = item,
       }
     end

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -16,6 +16,7 @@ package.preload['fzf-lua.utils'] = function()
     end,
     fzf_winobj = function()
       return {
+        fzf_winid = vim.api.nvim_get_current_win(),
         close = function()
           close_calls = close_calls + 1
         end,
@@ -28,6 +29,19 @@ package.preload['fzf-lua.utils'] = function()
 end
 
 local captured
+
+local function collect_lines(lines)
+  if type(lines) ~= 'function' then
+    return vim.deepcopy(lines)
+  end
+  local collected = {}
+  lines(function(line)
+    if line then
+      collected[#collected + 1] = line
+    end
+  end)
+  return collected
+end
 
 package.preload['fzf-lua'] = function()
   return {
@@ -281,7 +295,7 @@ describe('fzf picker', function()
     assert.is_not_nil(captured)
     assert.is_function(captured.lines)
 
-    local function collect_lines()
+    local function collect_streamed_lines()
       local lines = {}
       captured.lines(function(line)
         if line then
@@ -291,8 +305,35 @@ describe('fzf picker', function()
       return lines
     end
 
-    assert.same({ 'check one\t1', 'check two\t2' }, collect_lines())
-    assert.same({ 'check one\t1', 'check two\t2' }, collect_lines())
+    assert.same({ 'check one\t1', 'check two\t2' }, collect_streamed_lines())
+    assert.same({ 'check one\t1', 'check two\t2' }, collect_streamed_lines())
+  end)
+
+  it('renders entries against the live picker width when available', function()
+    local old_win_get_width = vim.api.nvim_win_get_width
+    vim.api.nvim_win_get_width = function()
+      return 40
+    end
+
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'CI> ',
+      entries = {
+        {
+          display = { { 'Markdown Form...' } },
+          render_display = function(width)
+            return { { width >= 40 and 'Markdown Format Check' or 'Markdown Form...' } }
+          end,
+          value = 'check-1',
+        },
+      },
+      actions = {},
+      picker_name = 'ci',
+    })
+
+    assert.is_function(captured.lines)
+    assert.same({ 'Markdown Format Check\t1' }, collect_lines(captured.lines))
+    vim.api.nvim_win_get_width = old_win_get_width
   end)
 
   it('renders worktree rows with visible labels and hidden selection ids', function()

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -415,6 +415,80 @@ describe('format_runs', function()
   end)
 end)
 
+describe('format_checks', function()
+  it('drops elapsed metadata before truncating moderate check names in narrow layouts', function()
+    local rows = forge.format_checks({
+      {
+        name = 'Markdown Format Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+    }, { width = 24 })
+
+    local result = flatten(rows[1])
+    assert.truthy(result:find('Markdown Format Check', 1, true))
+    assert.falsy(result:find('25s', 1, true))
+  end)
+
+  it('uses spare width for longer check names instead of capping at the typical width', function()
+    local rows = forge.format_checks({
+      {
+        name = 'changes',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Lua Format Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Lua Lint Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Lua Type Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Lua Test Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Vimdoc Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Markdown Format Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+      {
+        name = 'Nix Format Check',
+        bucket = 'pass',
+        startedAt = '2024-01-01T00:00:00Z',
+        completedAt = '2024-01-01T00:00:25Z',
+      },
+    }, { width = 100 })
+
+    local result = flatten(rows[7])
+    assert.truthy(result:find('Markdown Format Check', 1, true))
+    assert.falsy(result:find('Markdown Format...', 1, true))
+  end)
+end)
+
 describe('format_release', function()
   local fields = {
     tag = 'tagName',

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -423,6 +423,18 @@ describe('parse_summary_json', function()
     assert.equals('ForgeFail', result.hls[1][1].group)
   end)
 
+  it('prefers displayTitle over workflow name in the summary header', function()
+    local result = parse_summary_json({
+      name = 'quality',
+      displayTitle = 'fix(pr): use fetched metadata in edit compose (#203)',
+      status = 'completed',
+      conclusion = 'success',
+      jobs = {},
+    })
+    assert.equals('fix(pr): use fetched metadata in edit compose (#203)', result.lines[1])
+    assert.equals('ForgePass', result.hls[1][1].group)
+  end)
+
   it('handles empty jobs list', function()
     local result = parse_summary_json({
       name = 'Empty',

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1151,6 +1151,21 @@ describe('pickers', function()
     assert.same({ 'no log available - job was not started' }, logger_messages.info)
   end)
 
+  it('builds checks entries with live display renderers', function()
+    local pickers = require('forge.pickers')
+    pickers.checks(fake_ci_forge(), '42', 'all', {
+      {
+        name = 'lint',
+        bucket = 'pass',
+        link = 'https://example.com/check',
+      },
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_function(captured.entries[1].render_display)
+    assert.same({ { 'lint' } }, captured.entries[1].render_display(120))
+  end)
+
   it('uses subject-first prompts for filtered checks', function()
     local pickers = require('forge.pickers')
     pickers.checks(fake_ci_forge(), '42', 'fail', {

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -139,6 +139,18 @@ describe('github', function()
       gh:normalize_run({ databaseId = 1, status = 'in_progress' }).status
     )
   end)
+
+  it('prefers displayTitle for normalized run names', function()
+    local run = gh:normalize_run({
+      databaseId = 123,
+      name = 'quality',
+      displayTitle = 'fix(ci): add load more for repo runs (#196)',
+      headBranch = 'main',
+      status = 'completed',
+      conclusion = 'success',
+    })
+    assert.equals('fix(ci): add load more for repo runs (#196)', run.name)
+  end)
 end)
 
 describe('github browse', function()


### PR DESCRIPTION
## Problem
CI and check picker rows were formatted from a guessed width before the live fzf window existed, so entries could still truncate even when the open picker had plenty of room. Check names also treated longer real job names like `Markdown Format Check` as outliers, which capped the name column too aggressively.

## Solution
Render Forge picker rows against the live fzf window width whenever a picker supports dynamic row rendering, while reusing the existing layout and formatter logic. For check rows, allow the name column to grow to the actual longest check name when space is available. This also updates GitHub CI run and summary titles to prefer `displayTitle`, so repo-level CI rows and summaries stay informative.