### PR TITLE
feat(picker): add vim.ui fallback backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ without leaving your editor.
 
 - Neovim 0.10.0+
 - tree-sitter `yaml` parser for YAML issue form templates
-- [fzf-lua](https://github.com/ibhagwan/fzf-lua)
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
@@ -60,9 +59,11 @@ vim.g.forge = {
 ```lua
 {
   'barrettruth/forge.nvim',
-  dependencies = { 'ibhagwan/fzf-lua' },
 }
 ```
+
+`fzf-lua` is optional. When it is not installed, forge.nvim falls back to
+`vim.ui.select`.
 
 **Q: How do I create a PR?**
 

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -71,12 +71,14 @@ remote and delegates to the appropriate CLI (`gh`, `glab`, or `tea`).
 
 Requirements: ~
 - Neovim 0.10.0+
-- fzf-lua
 - tree-sitter `yaml` parser
 - One or more forge CLIs:
   - `gh` for GitHub
   - `glab` for GitLab
   - `tea` for Codeberg/Gitea/Forgejo
+
+`fzf-lua` is optional. When it is unavailable, forge.nvim falls back to
+`vim.ui.select`.
 
 Run |:checkhealth| forge to verify CLIs and dependencies.
 
@@ -95,8 +97,8 @@ Top-level keys: ~
 
 `picker`                                                 *forge-config-picker*
   `string`  (default `"auto"`)
-    Picker backend to use. One of `"auto"` or `"fzf-lua"`. When `"auto"`,
-    forge.nvim tries fzf-lua.
+    Picker backend to use. One of `"auto"`, `"fzf-lua"`, or `"vim-ui"`.
+    When `"auto"`, forge.nvim prefers fzf-lua and falls back to vim.ui.select.
 
 `client`                                                 *forge-config-client*
   `string`  (default `"picker"`)
@@ -1172,7 +1174,7 @@ HEALTH                                                          *forge-health*
 Reports on: ~
 - `git` availability
 - Forge CLI availability (`gh`, `glab`, `tea`)
-- Picker backend (`fzf-lua`) and whether it is active
+- Picker backends (`fzf-lua`, `vim-ui`) and which one is active
 - tree-sitter `yaml` parser availability
 - Custom registered sources and their CLI availability
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -3,7 +3,7 @@ local M = {}
 ---@alias forge.Split 'horizontal'|'vertical'
 
 ---@class forge.Config
----@field picker 'fzf-lua'|'auto'
+---@field picker 'fzf-lua'|'vim-ui'|'auto'
 ---@field debug boolean|string?
 ---@field split forge.Split
 ---@field ci forge.CIConfig
@@ -314,7 +314,7 @@ function M.config()
   local picker_backends = require('forge.picker').backends
   vim.validate('forge.picker', cfg.picker, function(v)
     return v == 'auto' or picker_backends[v] ~= nil
-  end, "'auto' or 'fzf-lua'")
+  end, "'auto', 'fzf-lua', or 'vim-ui'")
   vim.validate('forge.client', cfg.client, 'string')
   vim.validate('forge.context', cfg.context, 'string')
   vim.validate('forge.debug', cfg.debug, function(v)

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -26,14 +26,15 @@ function M.check()
   local backend = picker_mod.backend()
   local found_any = false
   for _, name in ipairs(picker_mod.detect_order) do
-    if pcall(require, name) then
+    local mod_path = picker_mod.backends[name]
+    if mod_path and pcall(require, mod_path) then
       local suffix = backend == name and ' (active)' or ''
       vim.health.ok(name .. ' found' .. suffix)
       found_any = true
     end
   end
   if not found_any then
-    vim.health.error('no picker backend found (install fzf-lua)')
+    vim.health.error('no picker backend found')
   end
 
   local has_yaml = pcall(vim.treesitter.language.inspect, 'yaml')

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -23,9 +23,10 @@ local M = {}
 
 M.backends = {
   ['fzf-lua'] = 'forge.picker.fzf',
+  ['vim-ui'] = 'forge.picker.ui',
 }
 
-M.detect_order = { 'fzf-lua' }
+M.detect_order = { 'fzf-lua', 'vim-ui' }
 
 local root_search_terms = {
   ['prs.all'] = { 'prs', 'pull', 'requests', 'reviews' },
@@ -154,11 +155,12 @@ local function detect()
     return name
   end
   for _, backend in ipairs(M.detect_order) do
-    if pcall(require, backend) then
+    local mod_path = M.backends[backend]
+    if mod_path and pcall(require, mod_path) then
       return backend
     end
   end
-  return M.detect_order[1]
+  return 'vim-ui'
 end
 
 ---@param entry forge.PickerEntry

--- a/lua/forge/picker/ui.lua
+++ b/lua/forge/picker/ui.lua
@@ -1,0 +1,70 @@
+local M = {}
+
+local function flatten_display(entry)
+  local parts = {}
+  for _, seg in ipairs(entry.display or {}) do
+    parts[#parts + 1] = seg[1]
+  end
+  return table.concat(parts)
+end
+
+local function action_choices(actions, entry)
+  local picker = require('forge.picker')
+  local choices = {}
+  for _, def in ipairs(actions or {}) do
+    if def.label and picker.selected(entry) ~= nil then
+      choices[#choices + 1] = def
+    end
+  end
+  return choices
+end
+
+---@param opts forge.PickerOpts
+function M.pick(opts)
+  local entries = opts.entries or {}
+  local actions = vim.deepcopy(opts.actions or {})
+  local cfg = require('forge').config()
+  local keys = cfg.keys == false and {} or (cfg.keys or {})
+
+  if opts.back and keys.back then
+    actions[#actions + 1] = {
+      name = 'back',
+      label = 'back',
+      fn = function()
+        opts.back()
+      end,
+    }
+  end
+
+  vim.ui.select(entries, {
+    prompt = opts.prompt or '',
+    format_item = function(entry)
+      return flatten_display(entry)
+    end,
+  }, function(entry)
+    if not entry then
+      return
+    end
+    local selected = require('forge.picker').selected(entry)
+    local choices = action_choices(actions, entry)
+    if #choices <= 1 then
+      local action = choices[1] or actions[1]
+      if action then
+        action.fn(selected)
+      end
+      return
+    end
+    vim.ui.select(choices, {
+      prompt = (opts.prompt or '') .. 'Action> ',
+      format_item = function(action)
+        return action.label or action.name
+      end,
+    }, function(action)
+      if action then
+        action.fn(selected)
+      end
+    end)
+  end)
+end
+
+return M

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -29,6 +29,7 @@ describe('health', function()
       ['forge'] = package.preload['forge'],
       ['forge.picker'] = package.preload['forge.picker'],
       ['fzf-lua'] = package.preload['fzf-lua'],
+      ['forge.picker.ui'] = package.preload['forge.picker.ui'],
     }
 
     vim.fn.executable = function(bin)
@@ -68,14 +69,18 @@ describe('health', function()
 
     package.preload['forge.picker'] = function()
       return {
+        backends = { ['fzf-lua'] = 'fzf-lua', ['vim-ui'] = 'forge.picker.ui' },
         backend = function()
           return 'fzf-lua'
         end,
-        detect_order = { 'fzf-lua' },
+        detect_order = { 'fzf-lua', 'vim-ui' },
       }
     end
 
     package.preload['fzf-lua'] = function()
+      return {}
+    end
+    package.preload['forge.picker.ui'] = function()
       return {}
     end
 
@@ -83,6 +88,7 @@ describe('health', function()
     package.loaded['forge.picker'] = nil
     package.loaded['forge.health'] = nil
     package.loaded['fzf-lua'] = nil
+    package.loaded['forge.picker.ui'] = nil
   end)
 
   after_each(function()
@@ -97,11 +103,13 @@ describe('health', function()
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.picker'] = old_preload['forge.picker']
     package.preload['fzf-lua'] = old_preload['fzf-lua']
+    package.preload['forge.picker.ui'] = old_preload['forge.picker.ui']
 
     package.loaded['forge'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.health'] = nil
     package.loaded['fzf-lua'] = nil
+    package.loaded['forge.picker.ui'] = nil
   end)
 
   it('reports a missing yaml parser as a health error', function()
@@ -110,11 +118,32 @@ describe('health', function()
     assert.same({ 'forge.nvim' }, captured.starts)
     assert.is_true(vim.tbl_contains(captured.oks, 'git found'))
     assert.is_true(vim.tbl_contains(captured.oks, 'fzf-lua found (active)'))
+    assert.is_true(vim.tbl_contains(captured.oks, 'vim-ui found'))
     assert.is_true(
       vim.tbl_contains(
         captured.errors,
         'tree-sitter yaml parser not found (required for YAML issue form templates)'
       )
     )
+  end)
+
+  it('falls back to vim-ui when fzf-lua is unavailable', function()
+    package.preload['forge.picker'] = function()
+      return {
+        backends = { ['fzf-lua'] = 'forge.picker.fzf', ['vim-ui'] = 'forge.picker.ui' },
+        backend = function()
+          return 'vim-ui'
+        end,
+        detect_order = { 'fzf-lua', 'vim-ui' },
+      }
+    end
+    package.preload['fzf-lua'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.health'] = nil
+    package.loaded['fzf-lua'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(vim.tbl_contains(captured.oks, 'vim-ui found (active)'))
   end)
 end)

--- a/spec/ui_picker_spec.lua
+++ b/spec/ui_picker_spec.lua
@@ -1,0 +1,133 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('ui picker backend', function()
+  local captured
+  local old_ui_select
+  local old_preload
+
+  before_each(function()
+    captured = {
+      prompts = {},
+      items = {},
+      actions = {},
+    }
+    old_ui_select = vim.ui.select
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.picker'] = package.preload['forge.picker'],
+    }
+
+    vim.ui.select = function(items, opts, cb)
+      table.insert(captured.prompts, opts.prompt)
+      table.insert(captured.items, items)
+      if #captured.prompts == 1 then
+        cb(items[1])
+      else
+        cb(items[2])
+      end
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            keys = {
+              back = '<c-o>',
+            },
+          }
+        end,
+      }
+    end
+
+    package.preload['forge.picker'] = function()
+      return require('forge.picker.init')
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.ui'] = nil
+  end)
+
+  after_each(function()
+    vim.ui.select = old_ui_select
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.picker'] = old_preload['forge.picker']
+    package.loaded['forge'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.ui'] = nil
+  end)
+
+  it('offers an action menu after selecting an entry', function()
+    require('forge.picker.ui').pick({
+      prompt = 'PRs> ',
+      picker_name = 'pr',
+      entries = {
+        {
+          display = { { 'Entry 1' } },
+          value = 1,
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(entry)
+            table.insert(captured.actions, { name = 'open', value = entry.value })
+          end,
+        },
+        {
+          name = 'browse',
+          label = 'browse',
+          fn = function(entry)
+            table.insert(captured.actions, { name = 'browse', value = entry.value })
+          end,
+        },
+      },
+    })
+
+    assert.same({ 'PRs> ', 'PRs> Action> ' }, captured.prompts)
+    assert.same({ { name = 'browse', value = 1 } }, captured.actions)
+  end)
+
+  it('runs back when the action menu selects it', function()
+    local first_action_menu = true
+    vim.ui.select = function(items, opts, cb)
+      table.insert(captured.prompts, opts.prompt)
+      if opts.prompt == 'PRs> ' then
+        cb(items[1])
+        return
+      end
+      if first_action_menu then
+        first_action_menu = false
+        cb(items[#items])
+      else
+        cb(nil)
+      end
+    end
+
+    require('forge.picker.ui').pick({
+      prompt = 'PRs> ',
+      picker_name = 'pr',
+      entries = {
+        {
+          display = { { 'Entry 1' } },
+          value = 1,
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(entry)
+            table.insert(captured.actions, { name = 'open', value = entry.value })
+          end,
+        },
+      },
+      back = function()
+        table.insert(captured.actions, { name = 'back' })
+      end,
+    })
+
+    assert.same({ { name = 'back' } }, captured.actions)
+  end)
+end)


### PR DESCRIPTION
## Problem
Forge's picker surface is effectively hard-wired to fzf-lua today. Health and docs still frame it as required, and without it the picker layer cannot fall back to a built-in Neovim UI path.

## Solution
Add a built-in `vim-ui` picker backend based on `vim.ui.select`, make picker auto-detection prefer fzf-lua and fall back to that backend, and update health/docs/README to describe fzf-lua as optional. This keeps the richer fzf-lua experience when available while making the picker surface usable without it.