### PR TITLE
fix(picker): add forward history binding

### DIFF
--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -156,6 +156,7 @@ local DEFAULTS = {
   },
   keys = {
     back = '<c-o>',
+    forward = '<c-i>',
     pr = {
       worktree = '<c-w>',
       ci = '<c-t>',
@@ -384,6 +385,7 @@ function M.config()
   if type(cfg.keys) == 'table' then
     local keys = cfg.keys --[[@as forge.KeysConfig]]
     vim.validate('forge.keys.back', keys.back, key_or_false, 'string or false')
+    vim.validate('forge.keys.forward', keys.forward, key_or_false, 'string or false')
     if keys.pr ~= nil then
       vim.validate('forge.keys.pr', keys.pr, 'table')
       for _, k in ipairs({

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -13,6 +13,12 @@ local no_bg_highlights = {
 local special_keys = {
   ['<cr>'] = { fzf = 'enter', header = '<cr>' },
   ['<tab>'] = { fzf = 'tab', header = '<tab>' },
+  ['<c-i>'] = { fzf = 'tab', header = '^I' },
+}
+
+local history = {
+  stack = {},
+  index = 0,
 }
 
 local function strip_bg_ansi(text)
@@ -129,6 +135,93 @@ local function render_header(actions, bindings)
   return table.concat(parts, '|')
 end
 
+local function clone_opts(opts)
+  local copy = {}
+  for k, v in pairs(opts) do
+    if k ~= '_forge_history_replay' then
+      copy[k] = v
+    end
+  end
+  return copy
+end
+
+local function current_snapshot()
+  return history.stack[history.index]
+end
+
+local function has_back_history()
+  return history.index > 1
+end
+
+local function has_forward_history()
+  return history.index > 0 and history.index < #history.stack
+end
+
+local function same_picker(opts, current)
+  return current and opts.picker_name == current.picker_name and opts.back == current.back
+end
+
+local function remember_picker(opts)
+  if rawget(opts, '_forge_history_replay') then
+    return
+  end
+
+  local snapshot = { opts = clone_opts(opts) }
+  if opts.back == nil or history.index == 0 then
+    history.stack = { snapshot }
+    history.index = 1
+    return
+  end
+
+  local current = current_snapshot()
+  if current and same_picker(opts, current.opts) then
+    history.stack[history.index] = snapshot
+    return
+  end
+
+  for i = #history.stack, history.index + 1, -1 do
+    history.stack[i] = nil
+  end
+  history.index = history.index + 1
+  history.stack[history.index] = snapshot
+end
+
+local function reopen_history(index)
+  local snapshot = history.stack[index]
+  if not snapshot then
+    return false
+  end
+  history.index = index
+  local opts = clone_opts(snapshot.opts)
+  opts._forge_history_replay = true
+  M.pick(opts)
+  return true
+end
+
+local function action_key(def, bindings, keys)
+  return def.name == 'default' and '<cr>'
+    or def.name == 'back' and keys.back
+    or def.name == 'forward' and keys.forward
+    or bindings[def.name]
+end
+
+local function has_key_conflict(actions, bindings, keys, name)
+  local key = action_key({ name = name }, bindings, keys)
+  if not key then
+    return false
+  end
+  local mapped = to_fzf_key(key)
+  for _, def in ipairs(actions) do
+    if def.name ~= name then
+      local other = action_key(def, bindings, keys)
+      if other and to_fzf_key(other) == mapped then
+        return true
+      end
+    end
+  end
+  return false
+end
+
 ---@param opts forge.PickerOpts
 function M.pick(opts)
   local cfg = require('forge').config()
@@ -144,6 +237,8 @@ function M.pick(opts)
   local actions = vim.deepcopy(opts.actions or {})
   local live_width = stream ~= nil
 
+  remember_picker(opts)
+
   if not live_width then
     for _, entry in ipairs(entries) do
       if type(rawget(entry, 'render_display')) == 'function' then
@@ -153,11 +248,26 @@ function M.pick(opts)
     end
   end
 
-  if opts.back and keys.back then
+  if (opts.back or has_back_history()) and keys.back then
     actions[#actions + 1] = {
       name = 'back',
       fn = function()
-        opts.back()
+        if not reopen_history(history.index - 1) and opts.back then
+          opts.back()
+        end
+      end,
+    }
+  end
+
+  if
+    has_forward_history()
+    and keys.forward
+    and not has_key_conflict(actions, bindings, keys, 'forward')
+  then
+    actions[#actions + 1] = {
+      name = 'forward',
+      fn = function()
+        reopen_history(history.index + 1)
       end,
     }
   end
@@ -203,9 +313,7 @@ function M.pick(opts)
 
   local fzf_actions = {}
   for _, def in ipairs(actions) do
-    local key = def.name == 'default' and '<cr>'
-      or def.name == 'back' and keys.back
-      or bindings[def.name]
+    local key = action_key(def, bindings, keys)
     if key then
       local action_fn = function(selected)
         if not selected[1] then

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -171,6 +171,172 @@ describe('fzf picker', function()
     assert.equals(1, back_calls)
   end)
 
+  it('reopens previous pickers on back and next pickers on forward history', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Forge> ',
+      entries = {
+        {
+          display = { { 'Branches' } },
+          value = 'branches.local',
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function()
+            picker.pick({
+              prompt = 'Branches> ',
+              entries = {
+                {
+                  display = { { 'main' } },
+                  value = 'main',
+                },
+              },
+              actions = {
+                { name = 'default', label = 'switch', fn = function() end },
+              },
+              picker_name = 'branch',
+              back = function() end,
+            })
+          end,
+        },
+      },
+      picker_name = '_menu',
+    })
+
+    assert.is_not_nil(captured)
+    captured.opts.actions.enter({ '1' })
+
+    assert.equals('Branches> ', captured.opts.prompt)
+    assert.is_function(captured.opts.actions['ctrl-o'])
+
+    captured.opts.actions['ctrl-o']({})
+
+    assert.equals('Forge> ', captured.opts.prompt)
+    assert.is_function(captured.opts.actions.tab)
+
+    captured.opts.actions.tab({})
+
+    assert.equals('Branches> ', captured.opts.prompt)
+  end)
+
+  it('does not bind forward when ctrl-i would collide with tab actions', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Issues> ',
+      entries = {
+        {
+          display = { { '#7' }, { ' Bug' } },
+          value = '7',
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function()
+            local back = function() end
+            picker.pick({
+              prompt = 'Details> ',
+              entries = {
+                {
+                  display = { { 'Edit' } },
+                  value = 'edit',
+                },
+              },
+              actions = {
+                { name = 'default', label = 'run', fn = function() end },
+              },
+              picker_name = '_menu',
+              back = back,
+            })
+          end,
+        },
+        { name = 'filter', label = 'filter', fn = function() end },
+      },
+      picker_name = 'issue',
+    })
+
+    assert.is_not_nil(captured)
+    captured.opts.actions.enter({ '1' })
+
+    assert.equals('Details> ', captured.opts.prompt)
+    captured.opts.actions['ctrl-o']({})
+
+    assert.equals('Issues> ', captured.opts.prompt)
+    assert.is_function(captured.opts.actions.tab)
+    assert.is_nil(captured.opts.actions['ctrl-i'])
+  end)
+
+  it('replaces same-picker reloads instead of adding extra back history', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Forge> ',
+      entries = {
+        {
+          display = { { 'Issues' } },
+          value = 'issues.open',
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function()
+            local back = function() end
+            picker.pick({
+              prompt = 'Issues> ',
+              entries = {
+                {
+                  display = { { '#7' }, { ' Bug' } },
+                  value = '7',
+                },
+              },
+              actions = {
+                {
+                  name = 'filter',
+                  label = 'filter',
+                  fn = function()
+                    picker.pick({
+                      prompt = 'Closed Issues> ',
+                      entries = {
+                        {
+                          display = { { '#8' }, { ' Closed bug' } },
+                          value = '8',
+                        },
+                      },
+                      actions = {
+                        { name = 'filter', label = 'filter', fn = function() end },
+                      },
+                      picker_name = 'issue',
+                      back = back,
+                    })
+                  end,
+                },
+              },
+              picker_name = 'issue',
+              back = back,
+            })
+          end,
+        },
+      },
+      picker_name = '_menu',
+    })
+
+    assert.is_not_nil(captured)
+    captured.opts.actions.enter({ '1' })
+
+    assert.equals('Issues> ', captured.opts.prompt)
+    captured.opts.actions.tab({})
+
+    assert.equals('Closed Issues> ', captured.opts.prompt)
+    captured.opts.actions['ctrl-o']({})
+
+    assert.equals('Forge> ', captured.opts.prompt)
+  end)
+
   it('renders headers for git-local pickers without the legacy prefix', function()
     local picker = require('forge.picker.fzf')
     picker.pick({

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -66,6 +66,7 @@ describe('config', function()
     assert.equals('<c-s>', cfg.keys.pr.close)
     assert.equals('<c-d>', cfg.keys.pr.draft)
     assert.equals('<c-o>', cfg.keys.back)
+    assert.equals('<c-i>', cfg.keys.forward)
     assert.equals('<tab>', cfg.keys.pr.filter)
     assert.equals('<c-e>', cfg.keys.issue.edit)
     assert.equals('<tab>', cfg.keys.issue.filter)
@@ -120,6 +121,7 @@ describe('config', function()
     vim.g.forge = {
       keys = {
         back = false,
+        forward = false,
         branch = { browse = '<c-b>' },
         commit = { yank = false },
         worktree = { refresh = '<c-f>' },
@@ -127,6 +129,7 @@ describe('config', function()
     }
     local cfg = forge.config()
     assert.is_false(cfg.keys.back)
+    assert.is_false(cfg.keys.forward)
     assert.equals('<c-s>', cfg.keys.branch.delete)
     assert.equals('<c-b>', cfg.keys.branch.browse)
     assert.equals('<c-y>', cfg.keys.branch.yank)


### PR DESCRIPTION
## Problem
Forge exposes `<c-o>` to move back through picker navigation, but there is no inverse binding to move forward again. Adding `<c-i>` also needs to respect fzf's `ctrl-i`/`tab` alias so it does not steal existing picker-local tab actions.

## Solution
Track picker history inside the fzf backend, add a default `keys.forward = '<c-i>'` binding, and reopen the next picker when forward history exists. When fzf would treat `<c-i>` as the same key as an existing action such as `<tab>`, skip the forward binding for that picker so local actions keep working. The picker specs now cover forward navigation, the tab conflict case, and same-picker reloads staying in a single back step.
