### PR TITLE
refactor(cmd): make :Forge action-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ without leaving your editor.
 
 - Neovim 0.10.0+
 - tree-sitter `yaml` parser for YAML issue form templates
-- [fzf-lua](https://github.com/ibhagwan/fzf-lua)
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive picker workflows
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
@@ -64,8 +64,13 @@ vim.g.forge = {
 }
 ```
 
+Install `fzf-lua` if you want the interactive picker surface via mappings such
+as `<Plug>(forge)` or Lua entrypoints such as `require('forge').open()`. Direct
+`:Forge` action commands do not depend on picker backends.
+
 **Q: How do I create a PR?**
 
-`<c-g>` to open the picker, select Pull Requests, then `ctrl-a` to compose. Or
-from a fugitive buffer: `cpr` (compose), `cpd` (draft), `cpf` (instant from
-commits), `cpw` (push and open web).
+Run `:Forge pr create`. Or use the interactive picker surface with `<c-g>`,
+then select Pull Requests and use `ctrl-a` to compose. From a fugitive buffer:
+`cpr` (compose), `cpd` (draft), `cpf` (instant from commits), `cpw` (push and
+open web).

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -26,7 +26,6 @@ CONTENTS                                                 *forge.nvim-contents*
     COMMAND COMPLETION................................|forge-command-completion|
     CANONICAL SYNTAX AND COMPATIBILITY..............|forge-command-compatibility|
     BANG SEMANTICS.........................................|forge-command-bang|
-    `:Forge pr` [state=...] [repo=...]............................|:Forge-pr|
     `:Forge pr create` [modifiers]......................|:Forge-pr-create|
     `:Forge pr checkout` {num} [repo=...]............|:Forge-pr-checkout|
     `:Forge pr worktree` {num}............................|:Forge-pr-worktree|
@@ -36,19 +35,13 @@ CONTENTS                                                 *forge.nvim-contents*
     `:Forge pr merge` {num} [`method=`]....................|:Forge-pr-merge|
     `:Forge pr draft` {num}..................................|:Forge-pr-draft|
     `:Forge pr ready` {num}..................................|:Forge-pr-ready|
-    `:Forge issue` [state=...] [repo=...]......................|:Forge-issue|
     `:Forge issue browse` {num} [repo=...]................|:Forge-issue-browse|
     `:Forge issue close` {num} [repo=...]..................|:Forge-issue-close|
     `:Forge issue reopen` {num} [repo=...]................|:Forge-issue-reopen|
     `:Forge issue create` [modifiers]......................|:Forge-issue-create|
     `:Forge issue edit` {num} [repo=...]....................|:Forge-issue-edit|
-    `:Forge ci` [repo=...] [rev=...] [target=...] [all]..........|:Forge-ci|
     `:Forge ci log` {run-id} [repo=...]......................|:Forge-ci-log|
     `:Forge ci watch` {run-id} [repo=...]..................|:Forge-ci-watch|
-    `:Forge branches`........................................|:Forge-branches|
-    `:Forge commits` [{branch}]..............................|:Forge-commits|
-    `:Forge worktrees`......................................|:Forge-worktrees|
-    `:Forge release` [state=...] [repo=...]....................|:Forge-release|
     `:Forge release browse` {tag} [repo=...]............|:Forge-release-browse|
     `:Forge release delete` {tag} [repo=...]............|:Forge-release-delete|
     `:Forge browse` [repo=...] [rev=...] [target=...]..........|:Forge-browse|
@@ -71,12 +64,15 @@ remote and delegates to the appropriate CLI (`gh`, `glab`, or `tea`).
 
 Requirements: ~
 - Neovim 0.10.0+
-- fzf-lua
+- fzf-lua for interactive picker workflows
 - tree-sitter `yaml` parser
 - One or more forge CLIs:
   - `gh` for GitHub
   - `glab` for GitLab
   - `tea` for Codeberg/Gitea/Forgejo
+
+Direct `:Forge` action commands work without `fzf-lua`. The interactive picker
+surface requires it.
 
 Run |:checkhealth| forge to verify CLIs and dependencies.
 
@@ -95,8 +91,8 @@ Top-level keys: ~
 
 `picker`                                                 *forge-config-picker*
   `string`  (default `"auto"`)
-    Picker backend to use. One of `"auto"` or `"fzf-lua"`. When `"auto"`,
-    forge.nvim tries fzf-lua.
+    Picker backend to use for interactive picker workflows. One of `"auto"`
+    or `"fzf-lua"`. When `"auto"`, forge.nvim tries fzf-lua.
 
 `client`                                                 *forge-config-client*
   `string`  (default `"picker"`)
@@ -163,19 +159,12 @@ Top-level keys: ~
     `host/owner/repo`. When unset, forge.nvim falls back to `upstream`,
     then `origin`.
 
-  `targets.ci.repo`      `string`  (default `"current"`)
-    Default repo policy for `:Forge ci` when no explicit repo is given.
-    One of `"current"` or `"collaboration"`.
-
   Example: >lua
       vim.g.forge = {
         targets = {
           default_repo = 'upstream',
           aliases = {
             work = 'github.com/barrettruth/forge.nvim',
-          },
-          ci = {
-            repo = 'collaboration',
           },
         },
       }
@@ -375,7 +364,10 @@ Top-level keys: ~
 COMMANDS                                                              *:Forge*
 
 `:Forge`                                                      *:Forge-no-args*
-    Open the root workflow surface (|forge-picker|).
+    The `:Forge` command surface is action-oriented. It does not open picker
+    UIs. `:Forge` with no arguments warns with `missing command`.
+    Use |forge-plug| mappings such as `<Plug>(forge)` or
+    `require('forge').open()` for the interactive picker surface.
 
 TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Supported verbs accept explicit target modifiers such as `repo=...`,
@@ -385,10 +377,6 @@ TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Default policy:
     - collaboration repo = `targets.default_repo`, else `upstream`, else
       `origin`
-    - `:Forge pr`, `:Forge issue`, and `:Forge release` default to the
-      collaboration repo
-    - `:Forge ci` defaults to the current branch and uses `targets.ci.repo`
-      for its repo policy
     - `:Forge pr create` defaults `head=` to the current branch push
       context and `base=` to the collaboration repo default branch
     - `:Forge browse` defaults to the current file/line selection on the
@@ -413,10 +401,11 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
 
     Compatibility sugar is still accepted, but it is not the primary
     interface:
-    - omitted default verbs such as `:Forge pr`, `:Forge issue`, `:Forge ci`,
-      `:Forge release`, and `:Forge browse`
     - legacy `--name` / `--name=value` forms for modifiers
     - `:Forge browse --root` and `:Forge browse --commit`
+
+    Commands that need interactive selection are intentionally not exposed
+    through `:Forge`; use the interactive picker surface instead.
 
 BANG SEMANTICS                                            *forge-command-bang*
     `!` is only accepted on mutating commands with an explicit force variant:
@@ -425,13 +414,6 @@ BANG SEMANTICS                                            *forge-command-bang*
     - `:Forge! release delete`
 
     All other `!` forms fail with `E477: No ! allowed`.
-
-`:Forge pr` [state=...] [repo=...]                                 *:Forge-pr*
-    Open the PR list picker for the collaboration repo. Defaults to open
-    PRs.
-    `state=open`       Show open PRs (default).
-    `state=closed`     Show closed PRs.
-    `state=all`        Show all PRs.
 
 `:Forge pr create` [repo=...] [head=...] [base=...] [draft] [fill] [web]
                                                             *:Forge-pr-create*
@@ -479,13 +461,6 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge pr ready` {num} [repo=...]                           *:Forge-pr-ready*
     Mark PR `{num}` as ready when supported by the forge.
 
-`:Forge issue` [state=...] [repo=...]                           *:Forge-issue*
-    Open the issue list picker for the collaboration repo. Defaults to
-    open issues.
-    `state=open`       Show open issues (default).
-    `state=closed`     Show closed issues.
-    `state=all`        Show all issues.
-
 `:Forge issue browse` {num} [repo=...]                   *:Forge-issue-browse*
     Open issue `{num}` in the browser.
 
@@ -506,33 +481,12 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge issue edit` {num} [repo=...]                       *:Forge-issue-edit*
     Open the issue edit compose flow for issue `{num}`.
 
-`:Forge ci` [repo=...] [rev=...] [target=...] [all]                *:Forge-ci*
-    Open the CI runs picker. Defaults to the current branch in the repo
-    selected by `targets.ci.repo`. Repo CI runs respect
-    `display.limits.runs` and expose `Load more...` when more runs are
-    available.
-    `all`              Show runs for all branches.
-
 `:Forge ci log` {run-id} [repo=...]                            *:Forge-ci-log*
     Open logs for CI run `{run-id}`.
 
 `:Forge ci watch` {run-id} [repo=...]                        *:Forge-ci-watch*
     Open the forge's live watch view for CI run `{run-id}` when
     supported.
-
-`:Forge branches`                                            *:Forge-branches*
-    Open the local branch picker (|forge-picker-branch|).
-
-`:Forge commits` [{branch}]                                   *:Forge-commits*
-    Open the commit picker for `{branch}`. Defaults to the current branch
-    when omitted (|forge-picker-commit|).
-
-`:Forge worktrees`                                          *:Forge-worktrees*
-    Open the worktree picker (|forge-picker-worktree|).
-
-`:Forge release` [state=...] [repo=...]                       *:Forge-release*
-    Open the release list picker for the collaboration repo
-    (|forge-picker-release|).
 
 `:Forge release browse` {tag} [repo=...]               *:Forge-release-browse*
     Open release `{tag}` in the browser.
@@ -699,8 +653,8 @@ ISSUE PICKER ~ Lists issues with number, title, author, and relative time.
   `refresh`     `<c-r>`          Clear cache and re-fetch
 
                                                              *forge-picker-ci*
-CI PICKER ~ Used for both per-PR checks (`:Forge pr ci {num}`) and repo-wide
-CI runs (`:Forge ci`). Both share the `keys.ci` bindings.
+CI PICKER ~ Used for both per-PR checks (`:Forge pr ci {num}`) and interactive
+repo/current-branch CI routes. Both share the `keys.ci` bindings.
 
 For repo-wide CI runs, Forge fetches an initial page using
 `display.limits.runs`. When more runs are available, the picker shows a
@@ -779,10 +733,14 @@ label-only entries so the top level stays compact, while the nested pickers
 and help docs carry the workflow detail.
 
 Architecture: ~
-- Root `:Forge` entries go through `require('forge.client').open_root()`.
+- Interactive root entries go through `require('forge.client').open_root()`.
 - Nested pickers go through `require('forge.picker').pick()`.
 - `require('forge.client').register()` can replace the root workflow surface.
 - Nested pickers use the built-in `fzf-lua` adapter.
+
+The interactive workflow surface is separate from `:Forge`. Use mappings such
+as `<Plug>(forge)` or Lua entrypoints such as `require('forge').open()` to
+launch it.
 
 Default root route inventory: ~
   `PRs` -> `prs.open`
@@ -1172,7 +1130,7 @@ HEALTH                                                          *forge-health*
 Reports on: ~
 - `git` availability
 - Forge CLI availability (`gh`, `glab`, `tea`)
-- Picker backend (`fzf-lua`) and whether it is active
+- Interactive picker UI backend (`fzf-lua`) availability
 - tree-sitter `yaml` parser availability
 - Custom registered sources and their CLI availability
 

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -32,9 +32,7 @@ local families = {
   {
     name = 'pr',
     surface = 'forge',
-    default_verb = 'list',
     verb_order = {
-      'list',
       'checkout',
       'worktree',
       'browse',
@@ -49,11 +47,6 @@ local families = {
       'ready',
     },
     verbs = {
-      list = {
-        subject = { min = 0, max = 0 },
-        modifiers = { 'state', 'repo' },
-        modifier_values = { state = { 'open', 'closed', 'all' } },
-      },
       checkout = {
         subject = { kind = 'pr', min = 1, max = 1 },
         modifiers = { 'repo' },
@@ -108,14 +101,8 @@ local families = {
   {
     name = 'issue',
     surface = 'forge',
-    default_verb = 'list',
-    verb_order = { 'list', 'browse', 'close', 'reopen', 'create', 'edit' },
+    verb_order = { 'browse', 'close', 'reopen', 'create', 'edit' },
     verbs = {
-      list = {
-        subject = { min = 0, max = 0 },
-        modifiers = { 'state', 'repo' },
-        modifier_values = { state = { 'open', 'closed', 'all' } },
-      },
       browse = {
         subject = { kind = 'issue', min = 1, max = 1 },
         modifiers = { 'repo' },
@@ -142,13 +129,8 @@ local families = {
   {
     name = 'ci',
     surface = 'forge',
-    default_verb = 'list',
-    verb_order = { 'list', 'log', 'watch' },
+    verb_order = { 'log', 'watch' },
     verbs = {
-      list = {
-        subject = { kind = 'rev', min = 0, max = 1 },
-        modifiers = { 'repo', 'rev', 'target', 'all' },
-      },
       log = {
         subject = { kind = 'run', min = 1, max = 1 },
         modifiers = { 'repo' },
@@ -162,14 +144,8 @@ local families = {
   {
     name = 'release',
     surface = 'forge',
-    default_verb = 'list',
-    verb_order = { 'list', 'browse', 'delete' },
+    verb_order = { 'browse', 'delete' },
     verbs = {
-      list = {
-        subject = { min = 0, max = 0 },
-        modifiers = { 'state', 'repo' },
-        modifier_values = { state = { 'all', 'draft', 'prerelease' } },
-      },
       browse = {
         subject = { kind = 'release', min = 1, max = 1 },
         modifiers = { 'repo' },
@@ -191,42 +167,6 @@ local families = {
         subject = { min = 0, max = 0 },
         modifiers = { 'repo', 'rev', 'target' },
         legacy_modifiers = { 'root', 'commit' },
-      },
-    },
-  },
-  {
-    name = 'branches',
-    surface = 'local',
-    default_verb = 'list',
-    verb_order = { 'list' },
-    verbs = {
-      list = {
-        subject = { min = 0, max = 0 },
-        modifiers = {},
-      },
-    },
-  },
-  {
-    name = 'commits',
-    surface = 'local',
-    default_verb = 'list',
-    verb_order = { 'list' },
-    verbs = {
-      list = {
-        subject = { kind = 'branch', min = 0, max = 1 },
-        modifiers = {},
-      },
-    },
-  },
-  {
-    name = 'worktrees',
-    surface = 'local',
-    default_verb = 'list',
-    verb_order = { 'list' },
-    verbs = {
-      list = {
-        subject = { min = 0, max = 0 },
-        modifiers = {},
       },
     },
   },
@@ -328,20 +268,16 @@ local function target_parse_opts()
   if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
     return {
       resolve_repo = true,
-      ci_repo = 'current',
     }
   end
   local cfg = forge.config()
   local targets = type(cfg) == 'table' and cfg.targets or nil
   local aliases = type(targets) == 'table' and targets.aliases or nil
   local default_repo = type(targets) == 'table' and targets.default_repo or nil
-  local ci = type(targets) == 'table' and targets.ci or nil
-  local ci_repo = type(ci) == 'table' and ci.repo or nil
   return {
     resolve_repo = true,
     aliases = type(aliases) == 'table' and aliases or {},
     default_repo = type(default_repo) == 'string' and default_repo or nil,
-    ci_repo = ci_repo == 'collaboration' and 'collaboration' or 'current',
   }
 end
 
@@ -361,15 +297,9 @@ local function repo_target(value)
   return value.repo
 end
 
-local function default_policy(command, parse_opts)
+local function default_policy(command, _)
   local policy = {}
-  if
-    not command.parsed_modifiers.repo
-    and (
-      (command.family == 'pr' and (command.name == 'list' or command.name == 'create'))
-      or (command.name == 'list' and (command.family == 'issue' or command.family == 'release'))
-    )
-  then
+  if not command.parsed_modifiers.repo and command.family == 'pr' and command.name == 'create' then
     policy.repo = 'collaboration'
   end
   if command.family == 'pr' and command.name == 'create' then
@@ -378,22 +308,6 @@ local function default_policy(command, parse_opts)
     end
     if not command.parsed_modifiers.base then
       policy.base = 'collaboration_default_branch'
-    end
-  elseif command.family == 'ci' and command.name == 'list' then
-    if
-      not repo_target(command.parsed_modifiers.target)
-      and not repo_target(command.parsed_modifiers.rev)
-      and not command.parsed_modifiers.repo
-    then
-      policy.repo = parse_opts.ci_repo
-    end
-    if
-      command.modifiers.all ~= true
-      and not command.parsed_modifiers.target
-      and not command.parsed_modifiers.rev
-      and command.subjects[1] == nil
-    then
-      policy.rev = 'current_branch'
     end
   elseif command.family == 'browse' and command.name == 'open' then
     if
@@ -489,10 +403,6 @@ local function dispatch_pr(command)
   end
   local num = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
-  if command.name == 'list' then
-    ops.pr_list(command.modifiers.state, { scope = scope })
-    return
-  end
   if command.name == 'create' then
     local target = require('forge.target')
     local head = command.parsed_modifiers.head or command.default_targets.head
@@ -566,10 +476,6 @@ local function dispatch_issue(command)
   end
   local num = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
-  if command.name == 'list' then
-    ops.issue_list(command.modifiers.state, { scope = scope })
-    return
-  end
   if command.name == 'create' then
     local template = command.modifiers.template
     ops.issue_create({
@@ -608,18 +514,6 @@ local function dispatch_ci(command)
     return
   end
   local scope = resolve_scope_modifier(command, f.name)
-  if command.name == 'list' then
-    local branch = nil
-    if command.modifiers.all ~= true then
-      local rev = command.parsed_modifiers.target and command.parsed_modifiers.target.rev
-        or command.parsed_modifiers.rev
-        or command.subjects[1] and { rev = command.subjects[1] }
-        or command.default_targets.rev
-      branch = rev and rev.rev or nil
-    end
-    ops.ci_list(command.modifiers.all and nil or branch, { scope = scope })
-    return
-  end
   if command.name == 'log' then
     ops.ci_log(f, { id = command.subjects[1], scope = scope })
     return
@@ -641,10 +535,6 @@ local function dispatch_release(command)
   end
   local tag = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
-  if command.name == 'list' then
-    ops.release_list(command.modifiers.state, { scope = scope })
-    return
-  end
   if command.name == 'browse' then
     ops.release_browse(f, { tag = tag, scope = scope })
     return
@@ -687,36 +577,12 @@ local function dispatch_browse(command)
   end
 end
 
-local function dispatch_branches()
-  if not require_git_or_warn() then
-    return
-  end
-  require('forge').open('branches')
-end
-
-local function dispatch_commits(command)
-  if not require_git_or_warn() then
-    return
-  end
-  require('forge').open('commits', { branch = command.subjects[1] })
-end
-
-local function dispatch_worktrees()
-  if not require_git_or_warn() then
-    return
-  end
-  require('forge').open('worktrees')
-end
-
 local dispatchers = {
   pr = dispatch_pr,
   issue = dispatch_issue,
   ci = dispatch_ci,
   release = dispatch_release,
   browse = dispatch_browse,
-  branches = dispatch_branches,
-  commits = dispatch_commits,
-  worktrees = dispatch_worktrees,
   clear = function()
     require('forge').clear_cache()
     require('forge.logger').info('cache cleared')
@@ -968,8 +834,8 @@ end
 function M.run(opts)
   opts = opts or {}
   if vim.trim(opts.args or '') == '' then
-    require('forge').open()
-    return true
+    warn('missing command')
+    return false
   end
 
   local command, err = M.parse(split_words(opts.args), { bang = opts.bang })

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -126,9 +126,6 @@ local DEFAULTS = {
   },
   targets = {
     aliases = {},
-    ci = {
-      repo = 'current',
-    },
   },
   sources = {},
   contexts = {
@@ -346,13 +343,6 @@ function M.config()
   vim.validate('forge.targets.aliases', cfg.targets.aliases, 'table')
   if cfg.targets.default_repo ~= nil then
     vim.validate('forge.targets.default_repo', cfg.targets.default_repo, 'string')
-  end
-  local target_ci = cfg.targets.ci or {}
-  vim.validate('forge.targets.ci', target_ci, 'table')
-  if target_ci.repo ~= nil then
-    vim.validate('forge.targets.ci.repo', target_ci.repo, function(v)
-      return v == 'current' or v == 'collaboration'
-    end, "'current' or 'collaboration'")
   end
 
   vim.validate('forge.display.icons', cfg.display.icons, 'table')

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -28,12 +28,14 @@ function M.check()
   for _, name in ipairs(picker_mod.detect_order) do
     if pcall(require, name) then
       local suffix = backend == name and ' (active)' or ''
-      vim.health.ok(name .. ' found' .. suffix)
+      vim.health.ok(name .. ' found' .. suffix .. ' (interactive picker UI enabled)')
       found_any = true
     end
   end
   if not found_any then
-    vim.health.error('no picker backend found (install fzf-lua)')
+    vim.health.warn(
+      'fzf-lua not found (interactive picker UI disabled; direct :Forge commands still available)'
+    )
   end
 
   local has_yaml = pcall(vim.treesitter.language.inspect, 'yaml')

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -294,14 +294,6 @@ function M.current_rev(opts)
   return M.branch_rev(M.current_branch(), M.current_repo(opts))
 end
 
-function M.ci_rev(opts)
-  local repo = type(opts) == 'table'
-      and opts.ci_repo == 'collaboration'
-      and M.collaboration_repo(opts)
-    or M.current_repo(opts)
-  return M.branch_rev(M.current_branch(), repo)
-end
-
 function M.push_rev(opts)
   return M.branch_rev(M.current_branch(), M.push_repo(opts))
 end

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -73,40 +73,46 @@ describe('command schema', function()
       'ci',
       'release',
       'browse',
-      'branches',
-      'commits',
-      'worktrees',
       'clear',
     }, cmd.family_names())
   end)
 
-  it('resolves default verbs for implicit family forms', function()
+  it('only resolves implicit verbs for direct command families', function()
     local pr = cmd.resolve('pr')
     local issue = cmd.resolve('issue')
     local ci = cmd.resolve('ci')
+    local release = cmd.resolve('release')
     local browse = cmd.resolve('browse')
+    local clear = cmd.resolve('clear')
 
-    assert.equals('list', pr.name)
-    assert.is_true(pr.implicit)
-    assert.equals('list', issue.name)
-    assert.is_true(issue.implicit)
-    assert.equals('list', ci.name)
-    assert.is_true(ci.implicit)
+    assert.is_nil(pr)
+    assert.is_nil(issue)
+    assert.is_nil(ci)
+    assert.is_nil(release)
     assert.equals('open', browse.name)
     assert.is_true(browse.implicit)
+    assert.equals('run', clear.name)
+    assert.is_true(clear.implicit)
   end)
 
-  it('parses normalized list forms', function()
-    local pr = assert(cmd.parse({ 'pr', '--state=closed' }))
-    local ci = assert(cmd.parse({ 'ci', 'feature' }))
+  it('rejects implicit picker forms and parses explicit direct actions', function()
+    local create = assert(cmd.parse({ 'pr', 'create', 'draft' }))
+    local ci = assert(cmd.parse({ 'ci', 'log', '123' }))
+    local _, pr_missing = cmd.parse({ 'pr' })
+    local _, ci_missing = cmd.parse({ 'ci' })
+    local _, pr_list = cmd.parse({ 'pr', 'list' })
 
-    assert.equals('pr', pr.family)
-    assert.equals('list', pr.name)
-    assert.same({}, pr.subjects)
-    assert.same({ state = 'closed' }, pr.modifiers)
+    assert.equals('pr', create.family)
+    assert.equals('create', create.name)
+    assert.same({ draft = true }, create.modifiers)
 
-    assert.equals('list', ci.name)
-    assert.same({ 'feature' }, ci.subjects)
+    assert.equals('ci', ci.family)
+    assert.equals('log', ci.name)
+    assert.same({ '123' }, ci.subjects)
+
+    assert.equals('missing action', pr_missing.message)
+    assert.equals('missing action', ci_missing.message)
+    assert.equals('unknown pr action: list', pr_list.message)
   end)
 
   it('attaches parsed target-bearing modifiers to normalized commands', function()
@@ -128,14 +134,9 @@ describe('command schema', function()
     assert.same({ start_line = 10, end_line = 20 }, browse.parsed_modifiers.target.range)
   end)
 
-  it('attaches default target policy for omitted addresses', function()
-    local pr = assert(cmd.parse({ 'pr' }))
+  it('attaches default target policy for omitted direct-action addresses', function()
     local create = assert(cmd.parse({ 'pr', 'create' }))
-    local ci = assert(cmd.parse({ 'ci' }))
     local browse = assert(cmd.parse({ 'browse' }))
-
-    assert.same({ repo = 'collaboration' }, pr.default_policy)
-    assert.equals('owner/upstream', pr.default_targets.repo.slug)
 
     assert.same({
       repo = 'collaboration',
@@ -146,10 +147,6 @@ describe('command schema', function()
     assert.equals('owner/current', create.default_targets.head.repo.slug)
     assert.is_true(create.default_targets.base.default_branch)
     assert.equals('owner/upstream', create.default_targets.base.repo.slug)
-
-    assert.same({ repo = 'collaboration', rev = 'current_branch' }, ci.default_policy)
-    assert.equals('feature', ci.default_targets.rev.rev)
-    assert.equals('owner/upstream', ci.default_targets.rev.repo.slug)
 
     assert.same(
       { repo = 'current', rev = 'current_branch', target = 'contextual' },
@@ -169,12 +166,12 @@ describe('command schema', function()
   end)
 
   it('exposes per-verb modifiers for canonical operations', function()
-    assert.same({ 'state', 'repo' }, cmd.modifier_names('pr', 'list'))
     assert.same(
       { 'repo', 'head', 'base', 'draft', 'fill', 'web' },
       cmd.modifier_names('pr', 'create')
     )
-    assert.same({ 'repo', 'rev', 'target', 'all' }, cmd.modifier_names('ci', 'list'))
+    assert.same({ 'repo' }, cmd.modifier_names('ci', 'log'))
+    assert.same({ 'repo', 'web', 'blank', 'template' }, cmd.modifier_names('issue', 'create'))
     assert.same({ 'repo', 'method' }, cmd.modifier_names('pr', 'merge'))
   end)
 
@@ -184,12 +181,8 @@ describe('command schema', function()
   end)
 
   it('exposes modifier value metadata where the grammar constrains it', function()
-    local pr_list = cmd.resolve('pr', 'list')
-    local release_list = cmd.resolve('release', 'list')
     local method = cmd.modifier('method')
 
-    assert.same({ 'open', 'closed', 'all' }, pr_list.modifier_values.state)
-    assert.same({ 'all', 'draft', 'prerelease' }, release_list.modifier_values.state)
     assert.same({ 'merge', 'squash', 'rebase' }, method.values)
   end)
 
@@ -202,10 +195,10 @@ describe('command schema', function()
 
   it('rejects invalid modifiers and duplicate modifiers', function()
     local _, unknown = cmd.parse({ 'pr', 'checkout', '42', '--wat=1' })
-    local _, duplicate = cmd.parse({ 'pr', '--state=open', 'state=closed' })
+    local _, duplicate = cmd.parse({ 'pr', 'create', 'repo=origin', 'repo=upstream' })
 
     assert.equals('unknown modifier: wat', unknown.message)
-    assert.equals('duplicate modifier: state', duplicate.message)
+    assert.equals('duplicate modifier: repo', duplicate.message)
   end)
 
   it('returns nil or empty data for unknown lookups', function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -351,17 +351,26 @@ describe(':Forge command', function()
     end
   end)
 
-  it('dispatches git-local route subcommands', function()
+  it('warns instead of opening interactive surfaces for missing or UI-only commands', function()
+    vim.cmd('Forge')
+    vim.cmd('Forge pr')
+    vim.cmd('Forge ci')
+    vim.cmd('Forge release')
     vim.cmd('Forge branches')
     vim.cmd('Forge commits feature')
     vim.cmd('Forge worktrees')
 
-    assert.equals('branches', captured.opens[1].route)
-    assert.is_nil(captured.opens[1].opts)
-    assert.equals('commits', captured.opens[2].route)
-    assert.same({ branch = 'feature' }, captured.opens[2].opts)
-    assert.equals('worktrees', captured.opens[3].route)
-    assert.is_nil(captured.opens[3].opts)
+    assert.same({
+      'missing command',
+      'missing action',
+      'missing action',
+      'missing action',
+      'unknown command: branches',
+      'unknown command: commits',
+      'unknown command: worktrees',
+    }, captured.warnings)
+    assert.is_nil(captured.opens[1])
+    assert.is_nil(captured.ops_calls[1])
   end)
 
   it('uses explicit browse defaults for omitted targets', function()
@@ -528,15 +537,19 @@ describe(':Forge command', function()
     }, captured.edit_issue)
   end)
 
-  it('applies collaboration and ci default scopes to list commands', function()
-    vim.cmd('Forge pr')
-    vim.cmd('Forge ci')
+  it('rejects explicit list verbs with no picker dispatch side effects', function()
+    vim.cmd('Forge pr list')
+    vim.cmd('Forge issue list')
+    vim.cmd('Forge ci list')
+    vim.cmd('Forge release list')
 
-    assert.equals('prs', captured.opens[1].route)
-    assert.equals('owner/upstream', captured.opens[1].opts.scope.slug)
-    assert.equals('ci.current_branch', captured.opens[2].route)
-    assert.equals('owner/current', captured.opens[2].opts.scope.slug)
-    assert.equals('main', captured.opens[2].opts.branch)
+    assert.same({
+      'unknown pr action: list',
+      'unknown issue action: list',
+      'unknown action: list',
+      'unknown release action: list',
+    }, captured.warnings)
+    assert.is_nil(captured.opens[1])
   end)
 
   it('rejects unsupported bang with E477 and no side effects', function()
@@ -629,21 +642,27 @@ describe(':Forge command', function()
     local families = vim.fn.getcompletion('Forge ', 'cmdline')
     local pr = vim.fn.getcompletion('Forge pr ', 'cmdline')
     local issue = vim.fn.getcompletion('Forge issue ', 'cmdline')
+    local release = vim.fn.getcompletion('Forge release ', 'cmdline')
     local pr_create = vim.fn.getcompletion('Forge pr create ', 'cmdline')
     local issue_create = vim.fn.getcompletion('Forge issue create ', 'cmdline')
 
     assert.is_true(vim.tbl_contains(families, 'pr'))
     assert.is_true(vim.tbl_contains(families, 'ci'))
     assert.is_true(vim.tbl_contains(families, 'browse'))
+    assert.is_false(vim.tbl_contains(families, 'branches'))
+    assert.is_false(vim.tbl_contains(families, 'commits'))
+    assert.is_false(vim.tbl_contains(families, 'worktrees'))
 
-    assert.is_true(vim.tbl_contains(pr, 'list'))
+    assert.is_true(vim.tbl_contains(pr, 'create'))
     assert.is_true(vim.tbl_contains(pr, 'approve'))
     assert.is_true(vim.tbl_contains(pr, 'merge'))
     assert.is_true(vim.tbl_contains(pr, 'draft'))
     assert.is_true(vim.tbl_contains(pr, 'ready'))
-    assert.is_true(vim.tbl_contains(pr, 'state='))
-    assert.is_true(vim.tbl_contains(pr, 'repo='))
+    assert.is_false(vim.tbl_contains(pr, 'state='))
+    assert.is_false(vim.tbl_contains(pr, 'repo='))
     assert.is_true(vim.tbl_contains(issue, 'edit'))
+    assert.is_true(vim.tbl_contains(release, 'browse'))
+    assert.is_true(vim.tbl_contains(release, 'delete'))
 
     assert.is_true(vim.tbl_contains(pr_create, 'head='))
     assert.is_true(vim.tbl_contains(pr_create, 'base='))
@@ -659,8 +678,8 @@ describe(':Forge command', function()
   end)
 
   it('completes modifier values for repo, revision, and target addresses', function()
-    local repos = vim.fn.getcompletion('Forge pr list repo=', 'cmdline')
-    local revs = vim.fn.getcompletion('Forge ci list rev=', 'cmdline')
+    local repos = vim.fn.getcompletion('Forge pr create repo=', 'cmdline')
+    local revs = vim.fn.getcompletion('Forge browse rev=', 'cmdline')
     local heads = vim.fn.getcompletion('Forge pr create head=', 'cmdline')
     local target_revs = vim.fn.getcompletion('Forge browse target=work@', 'cmdline')
 
@@ -683,11 +702,9 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(target_revs, 'target=work@feature:'))
   end)
 
-  it('completes git-local subcommands and commit refs', function()
-    assert.is_true(vim.tbl_contains(vim.fn.getcompletion('Forge br', 'cmdline'), 'branches'))
-    assert.is_true(vim.tbl_contains(vim.fn.getcompletion('Forge comm', 'cmdline'), 'commits'))
-    assert.is_true(vim.tbl_contains(vim.fn.getcompletion('Forge work', 'cmdline'), 'worktrees'))
-    assert.is_true(vim.tbl_contains(vim.fn.getcompletion('Forge commits ', 'cmdline'), 'main'))
-    assert.is_true(vim.tbl_contains(vim.fn.getcompletion('Forge commits f', 'cmdline'), 'feature'))
+  it('does not complete picker-only command families', function()
+    assert.is_false(vim.tbl_contains(vim.fn.getcompletion('Forge br', 'cmdline'), 'branches'))
+    assert.is_false(vim.tbl_contains(vim.fn.getcompletion('Forge comm', 'cmdline'), 'commits'))
+    assert.is_false(vim.tbl_contains(vim.fn.getcompletion('Forge work', 'cmdline'), 'worktrees'))
   end)
 end)

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -109,11 +109,28 @@ describe('health', function()
 
     assert.same({ 'forge.nvim' }, captured.starts)
     assert.is_true(vim.tbl_contains(captured.oks, 'git found'))
-    assert.is_true(vim.tbl_contains(captured.oks, 'fzf-lua found (active)'))
+    assert.is_true(
+      vim.tbl_contains(captured.oks, 'fzf-lua found (active) (interactive picker UI enabled)')
+    )
     assert.is_true(
       vim.tbl_contains(
         captured.errors,
         'tree-sitter yaml parser not found (required for YAML issue form templates)'
+      )
+    )
+  end)
+
+  it('warns when the interactive picker UI backend is unavailable', function()
+    package.preload['fzf-lua'] = nil
+    package.loaded['fzf-lua'] = nil
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(
+      vim.tbl_contains(
+        captured.warns,
+        'fzf-lua not found (interactive picker UI disabled; direct :Forge commands still available)'
       )
     )
   end)

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -47,7 +47,6 @@ describe('config', function()
     assert.is_true(cfg.confirm.branch_delete)
     assert.is_true(cfg.confirm.worktree_delete)
     assert.same({}, cfg.targets.aliases)
-    assert.equals('current', cfg.targets.ci.repo)
     assert.equals(45, cfg.display.widths.title)
     assert.equals(100, cfg.display.limits.pulls)
     assert.equals(100, cfg.display.limits.commits)
@@ -758,13 +757,6 @@ describe('config validation', function()
     end)
   end)
 
-  it('rejects invalid ci repo policy', function()
-    vim.g.forge = { targets = { ci = { repo = 'fork' } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
   it('accepts target alias and collaboration defaults', function()
     vim.g.forge = {
       targets = {
@@ -772,15 +764,11 @@ describe('config validation', function()
         aliases = {
           work = 'github.com/owner/repo',
         },
-        ci = {
-          repo = 'collaboration',
-        },
       },
     }
     local cfg = forge.config()
     assert.equals('upstream', cfg.targets.default_repo)
     assert.equals('github.com/owner/repo', cfg.targets.aliases.work)
-    assert.equals('collaboration', cfg.targets.ci.repo)
   end)
 
   it('accepts false for individual key binding', function()


### PR DESCRIPTION
## Problem
The `:Forge` command surface currently mixes direct actions with interactive picker entrypoints. Implicit and `list` forms such as `:Forge pr`, `:Forge ci`, and the local `branches`/`commits`/`worktrees` command families all dispatch into picker UI, which couples Ex commands to `fzf-lua` and leaves the command surface at odds with the plugin's interactive workflow surface. This also leaves command-only configuration and health/docs wording overstating picker requirements.

## Solution
Make `:Forge` action-only. Remove picker-dispatching `list` verbs and picker-only local command families from `lua/forge/cmd.lua`, make bare `:Forge` warn instead of opening the root picker, and keep interactive browsing behind mappings and `require('forge').open()`. Update command/config/help/README expectations to match that split, drop the now-dead `targets.ci.repo` command-default knob, and adjust health output to describe `fzf-lua` as enabling the interactive picker UI rather than the command surface. Closes #173.
