### PR TITLE
fix(ci): keep repo runs in chronological order

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -704,7 +704,8 @@ CI runs (`:Forge ci`). Both share the `keys.ci` bindings.
 
 For repo-wide CI runs, Forge fetches an initial page using
 `display.limits.runs`. When more runs are available, the picker shows a
-`Load more...` row on `<cr>`.
+`Load more...` row on `<cr>`. The `all` view is shown newest-first, and
+loading more appends older runs below the current list.
 
 On GitHub, `<cr>` on a run opens a summary buffer showing all jobs with
 status, durations, and annotations. Press `<cr>` on a job line to open its

--- a/lua/forge/format.lua
+++ b/lua/forge/format.lua
@@ -546,6 +546,28 @@ end
 ---@param filter string?
 ---@return forge.CIRun[]
 function M.filter_runs(runs, filter)
+  local indexed = {}
+  for i, run in ipairs(runs) do
+    indexed[i] = { run = run, index = i }
+  end
+  table.sort(indexed, function(a, b)
+    local ta = a.run.created_at or ''
+    local tb = b.run.created_at or ''
+    if ta == tb then
+      return a.index < b.index
+    end
+    if ta == '' then
+      return false
+    end
+    if tb == '' then
+      return true
+    end
+    return ta > tb
+  end)
+  for i, item in ipairs(indexed) do
+    runs[i] = item.run
+  end
+
   local bucket_for = function(run)
     local status = (run.status or ''):lower()
     if status == 'success' then
@@ -569,12 +591,6 @@ function M.filter_runs(runs, filter)
   end
 
   if not filter or filter == 'all' then
-    table.sort(runs, function(a, b)
-      local order = { fail = 1, pending = 2, pass = 3, cancel = 4, skipping = 5 }
-      local oa = order[bucket_for(a)] or 9
-      local ob = order[bucket_for(b)] or 9
-      return oa < ob
-    end)
     return runs
   end
 

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -86,10 +86,42 @@ local function entry_display(entry, width)
   return entry.display or {}
 end
 
-local function render_line(index, entry, width)
+local function track_id(entry, index)
+  local explicit = rawget(entry, 'track_id')
+  if type(explicit) == 'string' and explicit ~= '' then
+    return explicit
+  end
+  if entry.load_more then
+    return '__load_more__'
+  end
+  if entry.placeholder then
+    return '__placeholder__:' .. (entry.ordinal or tostring(index))
+  end
+  local value = entry.value
+  if type(value) == 'string' or type(value) == 'number' then
+    return tostring(value)
+  end
+  if type(value) == 'table' then
+    for _, key in ipairs({ 'id', 'num', 'tag', 'sha', 'path', 'name', 'run_id' }) do
+      local item = rawget(value, key)
+      if item ~= nil and tostring(item) ~= '' then
+        return tostring(item)
+      end
+    end
+  end
+  if type(entry.ordinal) == 'string' and entry.ordinal ~= '' then
+    return entry.ordinal
+  end
+  return tostring(index)
+end
+
+local function render_line(index, entry, width, tracked)
   local text = render(entry_display(entry, width))
   if vim.trim(text) == '' then
     return nil
+  end
+  if tracked then
+    return ('%s\t%s\t%d'):format(track_id(entry, index), text, index)
   end
   return ('%s\t%d'):format(text, index)
 end
@@ -145,6 +177,7 @@ function M.pick(opts)
   local seed_entries = vim.list_extend({}, entries)
   local actions = vim.deepcopy(opts.actions or {})
   local live_width = stream ~= nil or type(entry_source) == 'function'
+  local tracked = type(entry_source) == 'function'
   local streamed = false
 
   local function source_entries()
@@ -194,7 +227,7 @@ function M.pick(opts)
       local next_index = 0
       for i, entry in ipairs(entries) do
         next_index = i
-        local line = render_line(i, entry, picker_width())
+        local line = render_line(i, entry, picker_width(), tracked)
         if line then
           fzf_cb(line)
         end
@@ -208,7 +241,7 @@ function M.pick(opts)
           end
           next_index = next_index + 1
           entries[next_index] = entry
-          local line = render_line(next_index, entry, picker_width())
+          local line = render_line(next_index, entry, picker_width(), tracked)
           if line then
             fzf_cb(line)
           end
@@ -220,7 +253,7 @@ function M.pick(opts)
   else
     lines = {}
     for i, entry in ipairs(entries) do
-      local line = render_line(i, entry)
+      local line = render_line(i, entry, nil, tracked)
       if line then
         lines[#lines + 1] = line
       end
@@ -286,9 +319,11 @@ function M.pick(opts)
       ['--ansi'] = '',
       ['--header'] = render_header(actions, bindings),
       ['--no-multi'] = '',
-      ['--with-nth'] = '1',
-      ['--accept-nth'] = '2',
+      ['--with-nth'] = tracked and '2' or '1',
+      ['--accept-nth'] = tracked and '3' or '2',
       ['--delimiter'] = '\t',
+      ['--track'] = tracked and '' or nil,
+      ['--id-nth'] = tracked and '1' or nil,
     },
     actions = fzf_actions,
   })

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -635,6 +635,10 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.same('function', type(captured.lines))
+    assert.equals('2', captured.opts.fzf_opts['--with-nth'])
+    assert.equals('3', captured.opts.fzf_opts['--accept-nth'])
+    assert.equals('1', captured.opts.fzf_opts['--id-nth'])
+    assert.equals('', captured.opts.fzf_opts['--track'])
 
     local first = {}
     captured.lines(function(line)
@@ -652,8 +656,14 @@ describe('fzf picker', function()
       end
     end)
 
-    assert.same({ '#1\t1' }, first)
-    assert.same({ '#1\t1', '#2\t2' }, second)
+    assert.same({ '1\t#1\t1' }, first)
+    assert.same({ '1\t#1\t1', '2\t#2\t2' }, second)
+
+    captured.opts.actions.enter.fn({ '2' })
+    vim.wait(100, function()
+      return selected ~= false
+    end)
+    assert.equals('2', selected.value)
   end)
 
   it('skips rows whose rendered display is blank', function()

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -619,13 +619,13 @@ end)
 
 describe('filter_runs', function()
   local runs = {
-    { name = 'a', status = 'success' },
-    { name = 'b', status = 'failure' },
-    { name = 'c', status = 'in_progress' },
-    { name = 'd', status = 'cancelled' },
+    { name = 'a', status = 'success', created_at = '2024-01-01T00:00:00Z' },
+    { name = 'b', status = 'failure', created_at = '2024-01-03T00:00:00Z' },
+    { name = 'c', status = 'in_progress', created_at = '2024-01-02T00:00:00Z' },
+    { name = 'd', status = 'cancelled', created_at = '2023-12-31T00:00:00Z' },
   }
 
-  it('returns all runs sorted by severity when filter is nil', function()
+  it('returns all runs in descending created_at order when filter is nil', function()
     local result = forge.filter_runs(vim.deepcopy(runs), nil)
     assert.equals(4, #result)
     assert.equals('b', result[1].name)
@@ -644,6 +644,17 @@ describe('filter_runs', function()
     local result = forge.filter_runs(vim.deepcopy(runs), 'pending')
     assert.equals(1, #result)
     assert.equals('c', result[1].name)
+  end)
+
+  it('preserves provider order when created_at is missing', function()
+    local result = forge.filter_runs({
+      { name = 'first', status = 'success', created_at = '' },
+      { name = 'second', status = 'failure', created_at = '' },
+      { name = 'third', status = 'in_progress', created_at = '' },
+    }, nil)
+    assert.equals('first', result[1].name)
+    assert.equals('second', result[2].name)
+    assert.equals('third', result[3].name)
   end)
 end)
 

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1485,6 +1485,77 @@ describe('pickers', function()
     assert.is_true(streamed[3].load_more)
   end)
 
+  it('keeps repo CI all ordered chronologically instead of regrouping by status', function()
+    vim.g.forge = {
+      display = {
+        limits = {
+          runs = 3,
+        },
+      },
+    }
+
+    local old_system = vim.system
+    vim.system = function(_, _, cb)
+      if cb then
+        cb({
+          code = 0,
+          stdout = vim.json.encode({
+            {
+              id = '1',
+              name = 'Newest pass',
+              branch = 'main',
+              status = 'success',
+              url = 'https://e/1',
+              created_at = '2024-01-03T00:00:00Z',
+            },
+            {
+              id = '2',
+              name = 'Middle fail',
+              branch = 'main',
+              status = 'failure',
+              url = 'https://e/2',
+              created_at = '2024-01-02T00:00:00Z',
+            },
+            {
+              id = '3',
+              name = 'Oldest running',
+              branch = 'main',
+              status = 'running',
+              url = 'https://e/3',
+              created_at = '2024-01-01T00:00:00Z',
+            },
+          }),
+        })
+      end
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.ci(fake_ci_forge(), 'main', 'all')
+
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+    vim.system = old_system
+
+    assert.equals('1', streamed[1].value.id)
+    assert.equals('2', streamed[2].value.id)
+    assert.equals('3', streamed[3].value.id)
+  end)
+
   it('requests more CI runs when the load more row is activated', function()
     vim.g.forge = {
       display = {


### PR DESCRIPTION
## Problem
The repo-wide CI `all` view was regrouping runs by status instead of behaving like a chronological feed. That made `Load more...` feel unpredictable because older runs could jump between status buckets rather than simply appearing below the existing list.

## Solution
Sort repo CI runs newest-first by `created_at` before filtering, preserve provider order when timestamps are missing, and document that `Load more...` extends the feed with older runs below the current list.