### PR TITLE
refactor(compose): drop PR metadata fields

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -801,19 +801,11 @@ Layout: ~
   Line 1      PR title (pre-filled from single commit subject or branch)
   Line 2      Empty separator
   Lines 3+    PR body (from commit body or discovered PR template)
-  `<!--`        Metadata comment block (branch, forge, draft, reviewers,
-              diff stat). Editable.
+  `<!--`        Informational comment block (branch, forge, diff stat).
   `-->`         End of metadata
 
 Write (`:w`) to push the branch and create the PR. An empty title or body
 aborts creation. The PR URL is copied to the `+` register on success.
-
-Metadata fields: ~
-  `Draft: true`      Create as draft. `false` = not draft.
-  `Reviewers:`       Comma or space separated usernames.
-  `Labels:`          Comma or space separated label names.
-  `Assignees:`       Comma or space separated usernames.
-  `Milestone:`       Milestone name.
 
 Creating an issue (without `--web`) opens a compose buffer at
 `forge://issue/new` with filetype `markdown` and buftype `acwrite`.
@@ -875,12 +867,11 @@ Compose buffer: ~
   `ForgeComposeComment`      `Comment`          Comment block lines
   `ForgeComposeBranch`       `Special`          Branch names
   `ForgeComposeForge`        `Label`            Forge name
-  `ForgeComposeDraft`        `DiagnosticWarn`   Draft status value
   `ForgeComposeFile`         `Directory`        File paths in diff stat
   `ForgeComposeAdded`        `Added`            Addition indicators (+)
   `ForgeComposeRemoved`      `Removed`          Deletion indicators (-)
   `ForgeComposeHeader`       `PreProc`          Section headers
-  `ForgeComposeLabel`        `Label`            Metadata labels (Draft:, etc.)
+  `ForgeComposeLabel`        `Label`            Metadata labels (Labels:, etc.)
 
 Picker lines: ~
 
@@ -938,10 +929,6 @@ support for features that vary:
   PR list/filter               yes       yes       yes
   PR create                    yes       yes       yes
   PR create (draft)            yes       yes        -
-  PR create (reviewers)        yes       yes        -
-  PR create (labels)           yes       yes       yes
-  PR create (assignees)        yes       yes       yes
-  PR create (milestone)        yes       yes       yes
   PR draft toggle              yes       yes        -
   Per-PR CI checks             yes       yes       yes*
   Per-check log viewing        yes       yes        -
@@ -964,9 +951,8 @@ support for features that vary:
     forge-native CI (GitHub Actions or GitLab pipelines).
 
 Features marked `-` are unavailable due to CLI or API limitations. When a
-feature is unsupported, forge.nvim either hides the option (draft and reviewer
-fields in the compose buffer) or falls back gracefully (log action shows a
-notification and suggests browse).
+feature is unsupported, forge.nvim either hides the option or falls back
+gracefully (log action shows a notification and suggests browse).
 
 Each source declares its capabilities in a `capabilities` table. See
 |forge-Forge-interface|.
@@ -1005,7 +991,6 @@ Fields: ~
                                  `ci = string }` -- display labels.
   `capabilities`   `table`        Feature flags (see |forge-compatibility|):
                                  `draft`           Create/toggle draft PRs.
-                                 `reviewers`       Assign reviewers on create.
                                  `per_pr_checks`   CI checks scoped to a PR.
                                  `ci_json`         Structured CI run data.
 
@@ -1059,7 +1044,7 @@ All methods receive `self` as the first argument (use `:` syntax).
   `close_issue_cmd(num)`               `string[]` cmd to close issue.
   `reopen_issue_cmd(num)`              `string[]` cmd to reopen issue.
   `create_pr_cmd(title, body,`          `string[]` cmd to create a PR.
-    `base, draft, reviewers?)`
+    `base, draft)`
   `create_issue_cmd(title, body,`       `string[]` cmd to create an issue.
     `labels?, assignees?)`
   `issue_template_paths()`              `string[]` repo-relative paths to
@@ -1108,7 +1093,6 @@ Skeleton: >lua
       },
       capabilities = {
         draft = false,
-        reviewers = false,
         per_pr_checks = false,
         ci_json = false,
       },

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -14,7 +14,6 @@ local M = {
   },
   capabilities = {
     draft = false,
-    reviewers = false,
     per_pr_checks = true,
     ci_json = true,
   },
@@ -350,12 +349,8 @@ end
 ---@param num string
 ---@param title string
 ---@param body string
----@param _reviewers string[]?
----@param _labels string[]?
----@param _assignees string[]?
----@param _milestone string?
 ---@return string[]
-function M:update_pr_cmd(num, title, body, _reviewers, _labels, _assignees, _milestone, ref)
+function M:update_pr_cmd(num, title, body, ref)
   return {
     'tea',
     'pr',
@@ -410,28 +405,11 @@ end
 ---@param json table
 ---@return forge.PRDetails
 function M:parse_pr_details(json)
-  local labels = {}
-  for _, l in ipairs(json.labels or {}) do
-    table.insert(labels, l.name or '')
-  end
-  local assignees = {}
-  for _, a in ipairs(json.assignees or {}) do
-    table.insert(assignees, a.login or '')
-  end
-  local milestone = ''
-  if type(json.milestone) == 'table' and json.milestone.title then
-    milestone = json.milestone.title
-  end
   return {
     title = json.title or '',
     body = json.body or '',
-    draft = false,
     head_branch = type(json.head) == 'table' and (json.head.ref or '') or json.head or '',
     base_branch = type(json.base) == 'table' and (json.base.ref or '') or json.base or '',
-    labels = labels,
-    assignees = assignees,
-    reviewers = {},
-    milestone = milestone,
   }
 end
 
@@ -466,7 +444,7 @@ function M:completion_cmd(field, ref)
       '-c',
       'tea api --repo ' .. repo_arg(ref) .. " '/repos/{owner}/{repo}/labels' | jq -r '.[].name'",
     }
-  elseif field == 'assignees' or field == 'reviewers' or field == 'mentions' then
+  elseif field == 'assignees' or field == 'mentions' then
     return {
       'sh',
       '-c',
@@ -501,12 +479,8 @@ end
 ---@param body string
 ---@param base string
 ---@param _draft boolean
----@param _reviewers string[]?
----@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
-function M:create_pr_cmd(title, body, base, _draft, _reviewers, labels, assignees, milestone, ref)
+function M:create_pr_cmd(title, body, base, _draft, ref)
   local cmd = {
     'tea',
     'pr',
@@ -520,18 +494,6 @@ function M:create_pr_cmd(title, body, base, _draft, _reviewers, labels, assignee
     '--repo',
     repo_arg(ref),
   }
-  if labels and #labels > 0 then
-    table.insert(cmd, '--labels')
-    table.insert(cmd, table.concat(labels, ','))
-  end
-  if assignees and #assignees > 0 then
-    table.insert(cmd, '--assignees')
-    table.insert(cmd, table.concat(assignees, ','))
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
-  end
   return cmd
 end
 

--- a/lua/forge/completion.lua
+++ b/lua/forge/completion.lua
@@ -11,14 +11,10 @@ local last_context
 ---@param line string
 ---@return string?
 local function detect_field(line)
-  if line:match('^%s*Draft:') then
-    return 'draft'
-  elseif line:match('^%s*Labels:') then
+  if line:match('^%s*Labels:') then
     return 'labels'
   elseif line:match('^%s*Assignees:') then
     return 'assignees'
-  elseif line:match('^%s*Reviewers:') then
-    return 'reviewers'
   elseif line:match('^%s*Milestone:') then
     return 'milestone'
   end
@@ -66,10 +62,6 @@ end
 ---@param scope? table
 ---@return string[]
 local function fetch(field, f, scope)
-  if field == 'draft' then
-    return { 'true', 'false' }
-  end
-
   local now = os.time()
   local key = f.name .. ':' .. field .. ':' .. require('forge').scope_key(scope)
   local entry = cache[key]

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -90,31 +90,18 @@ end
 ---@field labels string[]
 ---@field assignees string[]
 ---@field milestone string
----@field draft boolean
----@field reviewers string[]
 
 ---@param buf_lines string[]
 ---@return forge.CommentMetadata
 local function parse_comment_metadata(buf_lines)
   local in_comment = false
-  local meta = { labels = {}, assignees = {}, milestone = '', draft = false, reviewers = {} }
+  local meta = { labels = {}, assignees = {}, milestone = '' }
   for _, l in ipairs(buf_lines) do
     if l:match('^<!--') then
       in_comment = true
     elseif l:match('^%-%->') then
       break
     elseif in_comment then
-      local dv = l:match('^%s*Draft:%s*(.*)$')
-      if dv then
-        dv = vim.trim(dv):lower()
-        meta.draft = dv == 'yes' or dv == 'true'
-      end
-      local rv = l:match('^%s*Reviewers:%s*(.*)$')
-      if rv then
-        for r in vim.trim(rv):gmatch('[^,%s]+') do
-          table.insert(meta.reviewers, r)
-        end
-      end
       local lv = l:match('^%s*Labels:%s*(.*)$')
       if lv then
         for label in vim.trim(lv):gmatch('[^,%s]+') do
@@ -142,28 +129,10 @@ end
 ---@param body string
 ---@param pr_base string
 ---@param pr_draft boolean
----@param pr_reviewers string[]?
----@param pr_labels string[]?
----@param pr_assignees string[]?
----@param pr_milestone string?
 ---@param buf integer?
 ---@param ref? forge.Scope
 ---@param push_target string?
-local function push_and_create(
-  f,
-  branch,
-  title,
-  body,
-  pr_base,
-  pr_draft,
-  pr_reviewers,
-  pr_labels,
-  pr_assignees,
-  pr_milestone,
-  buf,
-  ref,
-  push_target
-)
+local function push_and_create(f, branch, title, body, pr_base, pr_draft, buf, ref, push_target)
   local log = require('forge.logger')
   log.info('pushing and creating ' .. f.labels.pr_one .. '...')
   vim.system(
@@ -181,17 +150,7 @@ local function push_and_create(
         return
       end
       vim.system(
-        f:create_pr_cmd(
-          title,
-          body,
-          pr_base,
-          pr_draft,
-          pr_reviewers,
-          pr_labels,
-          pr_assignees,
-          pr_milestone,
-          ref
-        ),
+        f:create_pr_cmd(title, body, pr_base, pr_draft, ref),
         { text = true },
         function(create_result)
           vim.schedule(function()
@@ -508,33 +467,6 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   b:mark(ln, 2, #creating_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
-  b:add_line('')
-  if f.capabilities.draft then
-    local draft_val = draft and 'true' or 'false'
-    local draft_prefix = '  Draft: '
-    ln = b:add_line('%s%s', draft_prefix, draft_val)
-    b:mark(ln, 2, 6, 'ForgeComposeLabel')
-    b:mark(ln, #draft_prefix, #draft_val, draft and 'ForgeComposeDraft' or 'ForgeDim')
-  end
-
-  if f.capabilities.reviewers then
-    local reviewers_prefix = '  Reviewers: '
-    ln = b:add_line('%s', reviewers_prefix)
-    b:mark(ln, 2, 10, 'ForgeComposeLabel')
-  end
-
-  local labels_prefix = '  Labels: '
-  ln = b:add_line('%s', labels_prefix)
-  b:mark(ln, 2, 7, 'ForgeComposeLabel')
-
-  local assignees_prefix = '  Assignees: '
-  ln = b:add_line('%s', assignees_prefix)
-  b:mark(ln, 2, 10, 'ForgeComposeLabel')
-
-  local milestone_prefix = '  Milestone: '
-  ln = b:add_line('%s', milestone_prefix)
-  b:mark(ln, 2, 10, 'ForgeComposeLabel')
-
   local stat_start, stat_end
   if diff_stat ~= '' then
     b:add_line('')
@@ -612,22 +544,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
         return
       end
 
-      local meta = parse_comment_metadata(buf_lines)
-      push_and_create(
-        f,
-        branch,
-        pr_title,
-        pr_body,
-        base,
-        meta.draft,
-        meta.reviewers,
-        meta.labels,
-        meta.assignees,
-        meta.milestone,
-        buf,
-        ref,
-        push_target
-      )
+      push_and_create(f, branch, pr_title, pr_body, base, draft, buf, ref, push_target)
     end,
   })
 
@@ -642,72 +559,32 @@ M.push_and_create = push_and_create
 ---@param num string
 ---@param title string
 ---@param body string
----@param pr_draft boolean
----@param original_draft boolean
----@param pr_reviewers string[]?
----@param pr_labels string[]?
----@param pr_assignees string[]?
----@param pr_milestone string?
 ---@param buf integer?
 ---@param ref? forge.Scope
-local function update_pr(
-  f,
-  num,
-  title,
-  body,
-  pr_draft,
-  original_draft,
-  pr_reviewers,
-  pr_labels,
-  pr_assignees,
-  pr_milestone,
-  buf,
-  ref
-)
+local function update_pr(f, num, title, body, buf, ref)
   local log = require('forge.logger')
   log.info('updating ' .. f.labels.pr_one .. ' #' .. num .. '...')
-  vim.system(
-    f:update_pr_cmd(num, title, body, pr_reviewers, pr_labels, pr_assignees, pr_milestone, ref),
-    { text = true },
-    function(result)
-      vim.schedule(function()
-        if result.code ~= 0 then
-          local msg = vim.trim(result.stderr or '')
-          if msg == '' then
-            msg = vim.trim(result.stdout or '')
-          end
-          if msg == '' then
-            msg = 'update failed'
-          end
-          log.error(msg)
-          return
+  vim.system(f:update_pr_cmd(num, title, body, ref), { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        local msg = vim.trim(result.stderr or '')
+        if msg == '' then
+          msg = vim.trim(result.stdout or '')
         end
-        if pr_draft ~= original_draft then
-          local draft_cmd = f:draft_toggle_cmd(num, original_draft, ref)
-          if draft_cmd then
-            vim.system(draft_cmd, { text = true }, function(dr)
-              vim.schedule(function()
-                if dr.code ~= 0 then
-                  log.warn('updated ' .. f.labels.pr_one .. ' but draft toggle failed')
-                else
-                  log.info(('updated %s #%s'):format(f.labels.pr_one, num))
-                end
-              end)
-            end)
-          else
-            log.info(('updated %s #%s'):format(f.labels.pr_one, num))
-          end
-        else
-          log.info(('updated %s #%s'):format(f.labels.pr_one, num))
+        if msg == '' then
+          msg = 'update failed'
         end
-        require('forge').clear_list()
-        if buf and vim.api.nvim_buf_is_valid(buf) then
-          vim.bo[buf].modified = false
-          vim.api.nvim_buf_delete(buf, { force = true })
-        end
-      end)
-    end
-  )
+        log.error(msg)
+        return
+      end
+      log.info(('updated %s #%s'):format(f.labels.pr_one, num))
+      require('forge').clear_list()
+      if buf and vim.api.nvim_buf_is_valid(buf) then
+        vim.bo[buf].modified = false
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end)
+  end)
 end
 
 ---@param f forge.Forge
@@ -752,37 +629,6 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
   ln = b:add_line('%s%s.', editing_prefix, f.name)
   b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
-
-  b:add_line('')
-  local original_draft = details.draft
-  if f.capabilities.draft then
-    local draft_val = details.draft and 'true' or 'false'
-    local draft_prefix = '  Draft: '
-    ln = b:add_line('%s%s', draft_prefix, draft_val)
-    b:mark(ln, 2, 6, 'ForgeComposeLabel')
-    b:mark(ln, #draft_prefix, #draft_val, details.draft and 'ForgeComposeDraft' or 'ForgeDim')
-  end
-
-  if f.capabilities.reviewers then
-    local reviewers_prefix = '  Reviewers: '
-    local reviewers_val = table.concat(details.reviewers, ', ')
-    ln = b:add_line('%s%s', reviewers_prefix, reviewers_val)
-    b:mark(ln, 2, 10, 'ForgeComposeLabel')
-  end
-
-  local labels_prefix = '  Labels: '
-  local labels_val = table.concat(details.labels, ', ')
-  ln = b:add_line('%s%s', labels_prefix, labels_val)
-  b:mark(ln, 2, 7, 'ForgeComposeLabel')
-
-  local assignees_prefix = '  Assignees: '
-  local assignees_val = table.concat(details.assignees, ', ')
-  ln = b:add_line('%s%s', assignees_prefix, assignees_val)
-  b:mark(ln, 2, 10, 'ForgeComposeLabel')
-
-  local milestone_prefix = '  Milestone: '
-  ln = b:add_line('%s%s', milestone_prefix, details.milestone)
-  b:mark(ln, 2, 10, 'ForgeComposeLabel')
 
   local stat_start, stat_end
   if diff_stat ~= '' then
@@ -855,21 +701,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
         return
       end
 
-      local meta = parse_comment_metadata(buf_lines)
-      update_pr(
-        f,
-        num,
-        pr_title,
-        pr_body,
-        meta.draft,
-        original_draft,
-        meta.reviewers,
-        meta.labels,
-        meta.assignees,
-        meta.milestone,
-        buf,
-        ref
-      )
+      update_pr(f, num, pr_title, pr_body, buf, ref)
     end,
   })
 

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -73,6 +73,13 @@ local function add_discard_hints(builder)
   builder:add_line('  Use :q!, :bd!, or :bwipeout! to discard it.')
 end
 
+local function set_clipboard(text)
+  local ok = pcall(vim.fn.setreg, '+', text)
+  if not ok then
+    pcall(vim.fn.setreg, '"', text)
+  end
+end
+
 ---@param buf_lines string[]
 ---@return string[] content_lines
 local function extract_content(buf_lines)
@@ -157,7 +164,7 @@ local function push_and_create(f, branch, title, body, pr_base, pr_draft, buf, r
             if create_result.code == 0 then
               local url = vim.trim(create_result.stdout or '')
               if url ~= '' then
-                vim.fn.setreg('+', url)
+                set_clipboard(url)
               end
               log.info(('created %s -> %s'):format(f.labels.pr_one, url))
               require('forge').clear_list()
@@ -193,7 +200,7 @@ local function submit_issue(f, title, body, labels, assignees, milestone, buf, r
         if result.code == 0 then
           local url = vim.trim(result.stdout or '')
           if url ~= '' then
-            vim.fn.setreg('+', url)
+            set_clipboard(url)
           end
           log.info(('created issue -> %s'):format(url))
           require('forge').clear_list()

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -252,7 +252,6 @@ local hl_defaults = {
   ForgeComposeComment = 'Comment',
   ForgeComposeBranch = 'Special',
   ForgeComposeForge = 'Label',
-  ForgeComposeDraft = 'DiagnosticWarn',
   ForgeComposeFile = 'Directory',
   ForgeComposeAdded = 'Added',
   ForgeComposeRemoved = 'Removed',

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -15,7 +15,6 @@ local M = {
   },
   capabilities = {
     draft = true,
-    reviewers = true,
     per_pr_checks = true,
     ci_json = true,
   },
@@ -476,7 +475,7 @@ function M:fetch_pr_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,isDraft,headRefName,baseRefName,labels,assignees,reviewRequests,milestone,url',
+    'title,body,headRefName,baseRefName,url',
   }
 end
 
@@ -496,33 +495,13 @@ end
 ---@param num string
 ---@param title string
 ---@param body string
----@param reviewers string[]?
----@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
-function M:update_pr_cmd(num, title, body, reviewers, labels, assignees, milestone, scope)
+function M:update_pr_cmd(num, title, body, scope)
   local cmd = { 'gh', 'pr', 'edit', num, '--title', title, '--body', body }
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
-  end
-  for _, r in ipairs(reviewers or {}) do
-    table.insert(cmd, '--add-reviewer')
-    table.insert(cmd, r)
-  end
-  for _, l in ipairs(labels or {}) do
-    table.insert(cmd, '--add-label')
-    table.insert(cmd, l)
-  end
-  for _, a in ipairs(assignees or {}) do
-    table.insert(cmd, '--add-assignee')
-    table.insert(cmd, a)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
   end
   return cmd
 end
@@ -565,32 +544,11 @@ end
 ---@param json table
 ---@return forge.PRDetails
 function M:parse_pr_details(json)
-  local labels = {}
-  for _, l in ipairs(json.labels or {}) do
-    table.insert(labels, l.name or '')
-  end
-  local assignees = {}
-  for _, a in ipairs(json.assignees or {}) do
-    table.insert(assignees, a.login or '')
-  end
-  local reviewers = {}
-  for _, r in ipairs(json.reviewRequests or {}) do
-    table.insert(reviewers, r.login or '')
-  end
-  local milestone = ''
-  if type(json.milestone) == 'table' and json.milestone.title then
-    milestone = json.milestone.title
-  end
   return {
     title = json.title or '',
     body = json.body or '',
-    draft = json.isDraft == true,
     head_branch = json.headRefName or '',
     base_branch = json.baseRefName or '',
-    labels = labels,
-    assignees = assignees,
-    reviewers = reviewers,
-    milestone = milestone,
   }
 end
 
@@ -621,7 +579,7 @@ end
 function M:completion_cmd(field, scope)
   if field == 'labels' then
     return { 'gh', 'label', 'list', '-R', nwo(scope), '--json', 'name', '--jq', '.[].name' }
-  elseif field == 'assignees' or field == 'reviewers' or field == 'mentions' then
+  elseif field == 'assignees' or field == 'mentions' then
     return { 'gh', 'api', 'repos/' .. nwo(scope) .. '/collaborators', '--jq', '.[].login' }
   elseif field == 'milestone' then
     return { 'gh', 'api', 'repos/' .. nwo(scope) .. '/milestones', '--jq', '.[].title' }
@@ -644,12 +602,8 @@ end
 ---@param body string
 ---@param base string
 ---@param draft boolean
----@param reviewers string[]?
----@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
-function M:create_pr_cmd(title, body, base, draft, reviewers, labels, assignees, milestone, scope)
+function M:create_pr_cmd(title, body, base, draft, scope)
   local cmd = { 'gh', 'pr', 'create', '--title', title, '--body', body, '--base', base }
   local repo = nwo(scope)
   if repo ~= '' then
@@ -658,22 +612,6 @@ function M:create_pr_cmd(title, body, base, draft, reviewers, labels, assignees,
   end
   if draft then
     table.insert(cmd, '--draft')
-  end
-  for _, r in ipairs(reviewers or {}) do
-    table.insert(cmd, '--reviewer')
-    table.insert(cmd, r)
-  end
-  for _, l in ipairs(labels or {}) do
-    table.insert(cmd, '--label')
-    table.insert(cmd, l)
-  end
-  for _, a in ipairs(assignees or {}) do
-    table.insert(cmd, '--assignee')
-    table.insert(cmd, a)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
   end
   return cmd
 end

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -15,7 +15,6 @@ local M = {
   },
   capabilities = {
     draft = true,
-    reviewers = true,
     per_pr_checks = true,
     ci_json = true,
   },
@@ -402,30 +401,10 @@ end
 ---@param num string
 ---@param title string
 ---@param body string
----@param reviewers string[]?
----@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
-function M:update_pr_cmd(num, title, body, reviewers, labels, assignees, milestone, ref)
+function M:update_pr_cmd(num, title, body, ref)
   local cmd =
     { 'glab', 'mr', 'update', num, '--title', title, '--description', body, '-R', repo_arg(ref) }
-  for _, r in ipairs(reviewers or {}) do
-    table.insert(cmd, '--reviewer')
-    table.insert(cmd, r)
-  end
-  if labels and #labels > 0 then
-    table.insert(cmd, '--label')
-    table.insert(cmd, table.concat(labels, ','))
-  end
-  for _, a in ipairs(assignees or {}) do
-    table.insert(cmd, '--assignee')
-    table.insert(cmd, a)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
-  end
   return cmd
 end
 
@@ -470,32 +449,11 @@ end
 ---@param json table
 ---@return forge.PRDetails
 function M:parse_pr_details(json)
-  local labels = {}
-  for _, l in ipairs(json.labels or {}) do
-    table.insert(labels, type(l) == 'string' and l or '')
-  end
-  local assignees = {}
-  for _, a in ipairs(json.assignees or {}) do
-    table.insert(assignees, a.username or '')
-  end
-  local reviewers = {}
-  for _, r in ipairs(json.reviewers or {}) do
-    table.insert(reviewers, r.username or '')
-  end
-  local milestone = ''
-  if type(json.milestone) == 'table' and json.milestone.title then
-    milestone = json.milestone.title
-  end
   return {
     title = json.title or '',
     body = json.description or '',
-    draft = json.draft == true,
     head_branch = json.source_branch or '',
     base_branch = json.target_branch or '',
-    labels = labels,
-    assignees = assignees,
-    reviewers = reviewers,
-    milestone = milestone,
   }
 end
 
@@ -526,7 +484,7 @@ end
 function M:completion_cmd(field, ref)
   if field == 'labels' then
     return { 'sh', '-c', "glab label list -F json -R '" .. repo_arg(ref) .. "' | jq -r '.[].name'" }
-  elseif field == 'assignees' or field == 'reviewers' or field == 'mentions' then
+  elseif field == 'assignees' or field == 'mentions' then
     return {
       'sh',
       '-c',
@@ -565,12 +523,8 @@ end
 ---@param body string
 ---@param base string
 ---@param draft boolean
----@param reviewers string[]?
----@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
-function M:create_pr_cmd(title, body, base, draft, reviewers, labels, assignees, milestone, ref)
+function M:create_pr_cmd(title, body, base, draft, ref)
   local cmd = {
     'glab',
     'mr',
@@ -587,22 +541,6 @@ function M:create_pr_cmd(title, body, base, draft, reviewers, labels, assignees,
   }
   if draft then
     table.insert(cmd, '--draft')
-  end
-  for _, r in ipairs(reviewers or {}) do
-    table.insert(cmd, '--reviewer')
-    table.insert(cmd, r)
-  end
-  if labels and #labels > 0 then
-    table.insert(cmd, '--label')
-    table.insert(cmd, table.concat(labels, ','))
-  end
-  for _, a in ipairs(assignees or {}) do
-    table.insert(cmd, '--assignee')
-    table.insert(cmd, a)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
   end
   return cmd
 end

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -483,10 +483,6 @@ function M.create_pr(opts)
               base,
               opts.draft or false,
               nil,
-              nil,
-              nil,
-              nil,
-              nil,
               base_scope,
               push_to
             )

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -73,6 +73,13 @@ local function with_placeholder(entries, text)
   return { placeholder_entry(text) }
 end
 
+local function set_clipboard(text)
+  local ok = pcall(vim.fn.setreg, '+', text)
+  if not ok then
+    pcall(vim.fn.setreg, '"', text)
+  end
+end
+
 local function cached_rows(build)
   local cache = {}
   return function(width)
@@ -1834,7 +1841,7 @@ function M.release(state, f, opts)
           local base = forge_mod.remote_web_url(entry.value.scope)
           local tag = entry.value.tag
           local url = base .. '/releases/tag/' .. tag
-          vim.fn.setreg('+', url)
+          set_clipboard(url)
           log.info('copied release URL')
         end
       end,
@@ -2024,7 +2031,7 @@ function M.branches(ctx, opts)
           if not entry then
             return
           end
-          vim.fn.setreg('+', entry.value.name)
+          set_clipboard(entry.value.name)
           log.info('copied branch name')
         end,
       },
@@ -2187,7 +2194,7 @@ function M.commits(ctx, branch, opts)
           if not entry or entry.load_more then
             return
           end
-          vim.fn.setreg('+', entry.value.sha)
+          set_clipboard(entry.value.sha)
           log.info('copied commit SHA')
         end,
       },
@@ -2425,7 +2432,7 @@ function M.worktrees(ctx, opts)
             if not entry then
               return
             end
-            vim.fn.setreg('+', entry.value.path)
+            set_clipboard(entry.value.path)
             log.info('copied worktree path')
           end,
         },

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -43,13 +43,8 @@
 ---@class forge.PRDetails
 ---@field title string
 ---@field body string
----@field draft boolean
 ---@field head_branch string
 ---@field base_branch string
----@field reviewers string[]
----@field labels string[]
----@field assignees string[]
----@field milestone string
 
 ---@class forge.IssueDetails
 ---@field title string
@@ -110,7 +105,6 @@
 
 ---@class forge.Capabilities
 ---@field draft boolean
----@field reviewers boolean
 ---@field per_pr_checks boolean
 ---@field ci_json boolean
 
@@ -153,8 +147,8 @@
 ---@field close_issue_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field reopen_issue_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field draft_toggle_cmd fun(self: forge.Forge, num: string, is_draft: boolean, scope?: forge.Scope): string[]?
----@field create_pr_cmd fun(self: forge.Forge, title: string, body: string, base: string, draft: boolean, reviewers: string[]?, labels: string[]?, assignees: string[]?, milestone: string?, scope?: forge.Scope): string[]
----@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, reviewers: string[]?, labels: string[]?, assignees: string[]?, milestone: string?, scope?: forge.Scope): string[]
+---@field create_pr_cmd fun(self: forge.Forge, title: string, body: string, base: string, draft: boolean, scope?: forge.Scope): string[]
+---@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope): string[]
 ---@field fetch_pr_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field parse_pr_details fun(self: forge.Forge, json: table): forge.PRDetails
 ---@field fetch_issue_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]

--- a/spec/compose_abandon_spec.lua
+++ b/spec/compose_abandon_spec.lua
@@ -101,7 +101,6 @@ describe('compose abandon behavior', function()
   local function pr_forge()
     return {
       labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
-      capabilities = { draft = true, reviewers = true },
       name = 'github',
     }
   end
@@ -148,13 +147,8 @@ describe('compose abandon behavior', function()
     compose.open_pr_edit(pr_forge(), '23', {
       title = 'PR title',
       body = 'PR body',
-      draft = false,
       head_branch = 'feature',
       base_branch = 'main',
-      reviewers = {},
-      labels = {},
-      assignees = {},
-      milestone = '',
     }, 'feature')
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -135,6 +135,44 @@ describe('compose issue create', function()
     assert.same({}, captured.warns)
     assert.same({}, captured.errors)
   end)
+
+  it('submits issues when the clipboard register is unavailable', function()
+    local old_setreg = vim.fn.setreg
+    vim.fn.setreg = function()
+      error('clipboard unavailable')
+    end
+
+    local compose = require('forge.compose')
+    local f = {
+      name = 'github',
+      create_issue_cmd = function(_, title, body)
+        captured.args = {
+          title = title,
+          body = body,
+        }
+        return { 'create-issue', title, body }
+      end,
+    }
+
+    compose.open_issue(f)
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# clipboard fallback' })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.args ~= nil and captured.cleared == 1
+    end)
+
+    vim.fn.setreg = old_setreg
+
+    assert.same({
+      title = 'clipboard fallback',
+      body = '',
+    }, captured.args)
+    assert.equals(1, captured.cleared)
+    assert.same({}, captured.errors)
+  end)
 end)
 
 describe('compose issue edit', function()

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -37,20 +37,14 @@ describe('compose pr edit', function()
     compose.open_pr_edit(
       {
         labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
-        capabilities = { draft = true, reviewers = true },
         name = 'github',
       },
       '23',
       {
         title = 'PR title',
         body = 'PR body',
-        draft = false,
         head_branch = 'real-pr-head',
         base_branch = 'main',
-        reviewers = { 'bob' },
-        labels = { 'bug' },
-        assignees = { 'alice' },
-        milestone = 'v1',
       },
       'other-local-branch'
     )
@@ -58,6 +52,11 @@ describe('compose pr edit', function()
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
     assert.is_truthy(vim.tbl_contains(lines, '  On branch real-pr-head against main.'))
     assert.is_false(vim.tbl_contains(lines, '  On branch other-local-branch against main.'))
+    assert.is_false(vim.tbl_contains(lines, '  Draft: false'))
+    assert.is_false(vim.tbl_contains(lines, '  Reviewers: bob'))
+    assert.is_false(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: alice'))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: v1'))
   end)
 
   it('hides the local diff stat when the checked-out branch differs from the PR head', function()
@@ -72,20 +71,14 @@ describe('compose pr edit', function()
     compose.open_pr_edit(
       {
         labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
-        capabilities = { draft = true, reviewers = true },
         name = 'github',
       },
       '23',
       {
         title = 'PR title',
         body = 'PR body',
-        draft = false,
         head_branch = 'real-pr-head',
         base_branch = 'main',
-        reviewers = {},
-        labels = {},
-        assignees = {},
-        milestone = '',
       },
       'other-local-branch'
     )

--- a/spec/edit_pr_spec.lua
+++ b/spec/edit_pr_spec.lua
@@ -63,19 +63,6 @@ describe('edit_pr', function()
           body = 'PR body',
           headRefName = 'real-pr-head',
           baseRefName = 'main',
-          isDraft = false,
-          labels = {
-            { name = 'bug' },
-          },
-          assignees = {
-            { login = 'alice' },
-          },
-          reviewRequests = {
-            { login = 'bob' },
-          },
-          milestone = {
-            title = 'v1',
-          },
         })
       end
       if cb then
@@ -149,13 +136,8 @@ describe('edit_pr', function()
           return {
             title = json.title,
             body = json.body,
-            draft = json.isDraft == true,
             head_branch = json.headRefName,
             base_branch = json.baseRefName,
-            labels = { 'bug' },
-            assignees = { 'alice' },
-            reviewers = { 'bob' },
-            milestone = 'v1',
           }
         end,
       }
@@ -231,13 +213,8 @@ describe('edit_pr', function()
       details = {
         title = 'PR title',
         body = 'PR body',
-        draft = false,
         head_branch = 'real-pr-head',
         base_branch = 'main',
-        labels = { 'bug' },
-        assignees = { 'alice' },
-        reviewers = { 'bob' },
-        milestone = 'v1',
       },
       current_branch = 'other-local-branch',
       scope = nil,

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1700,6 +1700,25 @@ describe('pickers', function()
     assert.is_nil(rawget(action_by_name('delete'), 'close'))
   end)
 
+  it('keeps release copy working when the clipboard register is unavailable', function()
+    local old_setreg = vim.fn.setreg
+    vim.fn.setreg = function()
+      error('clipboard unavailable')
+    end
+
+    cache['release:list'] = {
+      { tag = 'v1.0.0', title = 'First', is_draft = false, is_prerelease = false },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.release('all', fake_release_forge())
+    action_by_name('yank').fn(captured.entries[1])
+
+    vim.fn.setreg = old_setreg
+
+    assert.same({ 'copied release URL' }, logger_messages.info)
+  end)
+
   it('opens the release picker immediately on fzf before the fetch completes', function()
     cache['release:list'] = nil
 

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -52,7 +52,7 @@ describe('github', function()
   end)
 
   it('builds create_pr_cmd', function()
-    local cmd = gh:create_pr_cmd('title', 'body', 'main', false, nil)
+    local cmd = gh:create_pr_cmd('title', 'body', 'main', false)
     assert.truthy(vim.tbl_contains(cmd, '--title'))
     assert.truthy(vim.tbl_contains(cmd, '--base'))
     assert.falsy(vim.tbl_contains(cmd, '--draft'))
@@ -80,18 +80,7 @@ describe('github', function()
   end)
 
   it('adds draft flag to create_pr_cmd', function()
-    assert.truthy(vim.tbl_contains(gh:create_pr_cmd('t', 'b', 'main', true, nil), '--draft'))
-  end)
-
-  it('adds reviewers to create_pr_cmd', function()
-    local cmd = gh:create_pr_cmd('t', 'b', 'main', false, { 'alice', 'bob' })
-    local count = 0
-    for _, v in ipairs(cmd) do
-      if v == '--reviewer' then
-        count = count + 1
-      end
-    end
-    assert.equals(2, count)
+    assert.truthy(vim.tbl_contains(gh:create_pr_cmd('t', 'b', 'main', true), '--draft'))
   end)
 
   it('builds checkout_cmd', function()
@@ -312,7 +301,7 @@ describe('gitlab', function()
   end)
 
   it('builds create_pr_cmd with --description and --target-branch', function()
-    local cmd = gl:create_pr_cmd('title', 'desc', 'develop', false, nil)
+    local cmd = gl:create_pr_cmd('title', 'desc', 'develop', false)
     assert.truthy(vim.tbl_contains(cmd, '--description'))
     assert.truthy(vim.tbl_contains(cmd, '--target-branch'))
     assert.truthy(vim.tbl_contains(cmd, '--yes'))
@@ -398,10 +387,9 @@ describe('codeberg', function()
     assert.falsy(vim.tbl_contains(cmd, '--style'))
   end)
 
-  it('ignores draft and reviewers in create_pr_cmd', function()
-    local cmd = cb:create_pr_cmd('title', 'body', 'main', true, { 'alice' })
+  it('ignores draft in create_pr_cmd', function()
+    local cmd = cb:create_pr_cmd('title', 'body', 'main', true)
     assert.falsy(vim.tbl_contains(cmd, '--draft'))
-    assert.falsy(vim.tbl_contains(cmd, '--reviewer'))
     assert.truthy(vim.tbl_contains(cmd, '--base'))
   end)
 


### PR DESCRIPTION
## Problem

PR compose/edit exposes structured metadata fields that add parsing, completion, backend plumbing, and test surface for fields we no longer want to support.

## Solution

Remove PR compose/edit metadata beyond title/body, simplify backend PR create/update/detail interfaces, and update docs/tests to match the smaller surface.