### PR TITLE
refactor(spec): reduce test harness duplication

### DIFF
--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -1,5 +1,46 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+local preload_modules = {
+  'forge',
+  'forge.logger',
+  'forge.ops',
+  'forge.pickers',
+}
+
+local loaded_modules = {
+  'forge',
+  'forge.cmd',
+  'forge.logger',
+  'forge.ops',
+  'forge.pickers',
+}
+
+local function repo_scope(repo)
+  return {
+    kind = 'github',
+    host = 'github.com',
+    owner = 'owner',
+    repo = repo,
+    slug = 'owner/' .. repo,
+    repo_arg = 'owner/' .. repo,
+    web_url = 'https://github.com/owner/' .. repo,
+  }
+end
+
+local function use_named_current_buf(name)
+  for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == name then
+      vim.api.nvim_buf_delete(buf, { force = true })
+    end
+  end
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+  vim.api.nvim_buf_set_name(buf, name)
+  return buf
+end
+
 describe(':Forge command', function()
   local captured
   local old_preload
@@ -17,46 +58,28 @@ describe(':Forge command', function()
       closed_issues = {},
       browse_calls = {},
     }
-    old_preload = {
-      ['forge'] = package.preload['forge'],
-      ['forge.logger'] = package.preload['forge.logger'],
-      ['forge.ops'] = package.preload['forge.ops'],
-      ['forge.pickers'] = package.preload['forge.pickers'],
-    }
+    old_preload = helpers.capture_preload(preload_modules)
     old_systemlist = vim.fn.systemlist
     old_system = vim.system
 
-    vim.system = function(cmd, _, cb)
-      local key = table.concat(cmd, ' ')
-      local result = {
-        code = 1,
-        stdout = '',
-        stderr = '',
-      }
-      if key == 'git remote get-url origin' then
-        result = { code = 0, stdout = 'git@github.com:owner/current.git\n', stderr = '' }
-      elseif key == 'git remote get-url upstream' then
-        result = { code = 0, stdout = 'git@github.com:owner/upstream.git\n', stderr = '' }
-      elseif key == 'git remote' then
-        result = { code = 0, stdout = 'origin\nupstream\n', stderr = '' }
-      elseif key == 'git branch --show-current' then
-        result = { code = 0, stdout = 'main\n', stderr = '' }
-      elseif key == 'git config branch.main.pushRemote' then
-        result = { code = 1, stdout = '', stderr = '' }
-      elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
-        result = { code = 0, stdout = 'origin/main\n', stderr = '' }
-      elseif key == 'git rev-list --max-count=20 --abbrev-commit HEAD' then
-        result = { code = 0, stdout = 'deadbee\nabc123\n', stderr = '' }
-      end
-      if cb then
-        cb(result)
-      end
-      return {
-        wait = function()
-          return result
-        end,
-      }
-    end
+    vim.system = helpers.system_router({
+      default = helpers.command_result('', 1),
+      responses = {
+        ['git remote get-url origin'] = helpers.command_result(
+          'git@github.com:owner/current.git\n'
+        ),
+        ['git remote get-url upstream'] = helpers.command_result(
+          'git@github.com:owner/upstream.git\n'
+        ),
+        ['git remote'] = helpers.command_result('origin\nupstream\n'),
+        ['git branch --show-current'] = helpers.command_result('main\n'),
+        ['git config branch.main.pushRemote'] = helpers.command_result('', 1),
+        ['git rev-parse --abbrev-ref main@{upstream}'] = helpers.command_result('origin/main\n'),
+        ['git rev-list --max-count=20 --abbrev-commit HEAD'] = helpers.command_result(
+          'deadbee\nabc123\n'
+        ),
+      },
+    })
 
     package.preload['forge.logger'] = function()
       return {
@@ -325,11 +348,7 @@ describe(':Forge command', function()
       vim.api.nvim_del_user_command('Forge')
     end
 
-    package.loaded['forge'] = nil
-    package.loaded['forge.cmd'] = nil
-    package.loaded['forge.logger'] = nil
-    package.loaded['forge.ops'] = nil
-    package.loaded['forge.pickers'] = nil
+    helpers.clear_loaded(loaded_modules)
 
     dofile(vim.fn.getcwd() .. '/plugin/forge.lua')
   end)
@@ -337,15 +356,8 @@ describe(':Forge command', function()
   after_each(function()
     vim.system = old_system
     vim.fn.systemlist = old_systemlist
-    package.preload['forge'] = old_preload['forge']
-    package.preload['forge.logger'] = old_preload['forge.logger']
-    package.preload['forge.ops'] = old_preload['forge.ops']
-    package.preload['forge.pickers'] = old_preload['forge.pickers']
-    package.loaded['forge'] = nil
-    package.loaded['forge.cmd'] = nil
-    package.loaded['forge.logger'] = nil
-    package.loaded['forge.ops'] = nil
-    package.loaded['forge.pickers'] = nil
+    helpers.restore_preload(old_preload)
+    helpers.clear_loaded(loaded_modules)
     if vim.api.nvim_get_commands({ builtin = false }).Forge then
       vim.api.nvim_del_user_command('Forge')
     end
@@ -400,7 +412,7 @@ describe(':Forge command', function()
   end)
 
   it('uses explicit rev branch browsing when special buffers have no file location', function()
-    vim.api.nvim_buf_set_name(0, 'canola://issue/123')
+    use_named_current_buf('canola://issue/123')
 
     vim.cmd('Forge browse rev=@main')
 
@@ -569,38 +581,51 @@ describe(':Forge command', function()
   end)
 
   it('dispatches PR management parity subcommands through forge.ops', function()
-    vim.cmd('Forge pr approve 42')
-    vim.cmd('Forge pr merge 42 repo=upstream')
-    vim.cmd('Forge pr draft 42')
-    vim.cmd('Forge pr ready 42')
-
-    assert.same({ name = 'pr_approve', pr = { num = '42', scope = nil } }, captured.ops_calls[1])
-    assert.same({
-      name = 'pr_merge',
-      pr = {
-        num = '42',
-        scope = {
-          kind = 'github',
-          host = 'github.com',
-          owner = 'owner',
-          repo = 'upstream',
-          slug = 'owner/upstream',
-          repo_arg = 'owner/upstream',
-          web_url = 'https://github.com/owner/upstream',
+    for _, case in ipairs({
+      {
+        cmd = 'Forge pr approve 42',
+        expected = { name = 'pr_approve', pr = { num = '42', scope = nil } },
+      },
+      {
+        cmd = 'Forge pr merge 42 repo=upstream',
+        expected = {
+          name = 'pr_merge',
+          pr = { num = '42', scope = repo_scope('upstream') },
+          method = nil,
         },
       },
-      method = nil,
-    }, captured.ops_calls[2])
-    assert.same({
-      name = 'pr_toggle_draft',
-      pr = { num = '42', scope = nil },
-      is_draft = false,
-    }, captured.ops_calls[3])
-    assert.same({
-      name = 'pr_toggle_draft',
-      pr = { num = '42', scope = nil },
-      is_draft = true,
-    }, captured.ops_calls[4])
+      {
+        cmd = 'Forge pr draft 42',
+        expected = { name = 'pr_toggle_draft', pr = { num = '42', scope = nil }, is_draft = false },
+      },
+      {
+        cmd = 'Forge pr ready 42',
+        expected = { name = 'pr_toggle_draft', pr = { num = '42', scope = nil }, is_draft = true },
+      },
+    }) do
+      vim.cmd(case.cmd)
+    end
+
+    for index, case in ipairs({
+      {
+        expected = { name = 'pr_approve', pr = { num = '42', scope = nil } },
+      },
+      {
+        expected = {
+          name = 'pr_merge',
+          pr = { num = '42', scope = repo_scope('upstream') },
+          method = nil,
+        },
+      },
+      {
+        expected = { name = 'pr_toggle_draft', pr = { num = '42', scope = nil }, is_draft = false },
+      },
+      {
+        expected = { name = 'pr_toggle_draft', pr = { num = '42', scope = nil }, is_draft = true },
+      },
+    }) do
+      assert.same(case.expected, captured.ops_calls[index])
+    end
   end)
 
   it('passes through an explicit merge method when provided', function()

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -1,5 +1,34 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+local preload_modules = {
+  'forge.action',
+  'forge.client',
+  'forge.compose',
+  'forge.config',
+  'forge.context',
+  'forge.format',
+  'forge.github',
+  'forge.logger',
+  'forge.picker',
+  'forge.template',
+}
+
+local loaded_modules = vim.list_extend({ 'forge' }, preload_modules)
+
+local function repo_scope(repo)
+  return {
+    kind = 'github',
+    host = 'github.com',
+    owner = 'owner',
+    repo = repo,
+    slug = 'owner/' .. repo,
+    repo_arg = 'owner/' .. repo,
+    web_url = 'https://github.com/owner/' .. repo,
+  }
+end
+
 describe('create_pr', function()
   local captured
   local old_system
@@ -21,18 +50,7 @@ describe('create_pr', function()
     old_fn_system = vim.fn.system
     old_executable = vim.fn.executable
     old_ui_open = vim.ui.open
-    old_preload = {
-      ['forge.action'] = package.preload['forge.action'],
-      ['forge.client'] = package.preload['forge.client'],
-      ['forge.compose'] = package.preload['forge.compose'],
-      ['forge.config'] = package.preload['forge.config'],
-      ['forge.context'] = package.preload['forge.context'],
-      ['forge.format'] = package.preload['forge.format'],
-      ['forge.github'] = package.preload['forge.github'],
-      ['forge.logger'] = package.preload['forge.logger'],
-      ['forge.picker'] = package.preload['forge.picker'],
-      ['forge.template'] = package.preload['forge.template'],
-    }
+    old_preload = helpers.capture_preload(preload_modules)
 
     vim.fn.executable = function(bin)
       if bin == 'gh' then
@@ -214,17 +232,7 @@ describe('create_pr', function()
       }
     end
 
-    package.loaded['forge'] = nil
-    package.loaded['forge.action'] = nil
-    package.loaded['forge.client'] = nil
-    package.loaded['forge.compose'] = nil
-    package.loaded['forge.config'] = nil
-    package.loaded['forge.context'] = nil
-    package.loaded['forge.format'] = nil
-    package.loaded['forge.github'] = nil
-    package.loaded['forge.logger'] = nil
-    package.loaded['forge.picker'] = nil
-    package.loaded['forge.template'] = nil
+    helpers.clear_loaded(loaded_modules)
   end)
 
   after_each(function()
@@ -233,29 +241,28 @@ describe('create_pr', function()
     vim.fn.executable = old_executable
     vim.ui.open = old_ui_open
 
-    package.preload['forge.action'] = old_preload['forge.action']
-    package.preload['forge.client'] = old_preload['forge.client']
-    package.preload['forge.compose'] = old_preload['forge.compose']
-    package.preload['forge.config'] = old_preload['forge.config']
-    package.preload['forge.context'] = old_preload['forge.context']
-    package.preload['forge.format'] = old_preload['forge.format']
-    package.preload['forge.github'] = old_preload['forge.github']
-    package.preload['forge.logger'] = old_preload['forge.logger']
-    package.preload['forge.picker'] = old_preload['forge.picker']
-    package.preload['forge.template'] = old_preload['forge.template']
-
-    package.loaded['forge'] = nil
-    package.loaded['forge.action'] = nil
-    package.loaded['forge.client'] = nil
-    package.loaded['forge.compose'] = nil
-    package.loaded['forge.config'] = nil
-    package.loaded['forge.context'] = nil
-    package.loaded['forge.format'] = nil
-    package.loaded['forge.github'] = nil
-    package.loaded['forge.logger'] = nil
-    package.loaded['forge.picker'] = nil
-    package.loaded['forge.template'] = nil
+    helpers.restore_preload(old_preload)
+    helpers.clear_loaded(loaded_modules)
   end)
+
+  local function use_branch_context(branch, origin_url)
+    local values = {
+      ['git rev-parse --show-toplevel'] = '/repo\n',
+      ['git remote get-url origin'] = origin_url or 'git@github.com:owner/repo.git\n',
+      ['git branch --show-current'] = branch .. '\n',
+    }
+    vim.fn.system = function(cmd)
+      return values[cmd] or ''
+    end
+  end
+
+  local function use_system_responses(responses)
+    vim.system = helpers.system_router({
+      calls = captured.systems,
+      responses = responses,
+      default = helpers.command_result(),
+    })
+  end
 
   it('preserves back on the PR template picker', function()
     local back_calls = 0
@@ -279,55 +286,18 @@ describe('create_pr', function()
   end)
 
   it('blocks web PR creation when the current branch already matches the base', function()
-    vim.fn.system = function(cmd)
-      if cmd == 'git rev-parse --show-toplevel' then
-        return '/repo\n'
-      end
-      if cmd == 'git remote get-url origin' then
-        return 'git@github.com:owner/repo.git\n'
-      end
-      if cmd == 'git branch --show-current' then
-        return 'main\n'
-      end
-      return ''
-    end
-    vim.system = function(cmd, _, cb)
-      local result = {
-        code = 0,
-        stdout = '',
-        stderr = '',
-      }
-      local key = table.concat(cmd, ' ')
-      local fail = {
-        ['git config branch.main.pushRemote'] = true,
-        ['git config remote.pushDefault'] = true,
-        ['git remote get-url upstream'] = true,
-        ['git diff --quiet origin/main..HEAD'] = true,
-      }
-      table.insert(captured.systems, key)
-      if fail[key] then
-        result.code = 1
-      end
-      if key == 'pr-for-branch main' then
-        result.stdout = '\n'
-      elseif key == 'default-branch' then
-        result.stdout = 'main\n'
-      elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
-        result.stdout = 'origin/main\n'
-      elseif key == 'git remote' then
-        result.stdout = 'origin\nupstream\n'
-      elseif key == 'git remote get-url origin' then
-        result.stdout = 'git@github.com:owner/repo.git\n'
-      end
-      if cb then
-        cb(result)
-      end
-      return {
-        wait = function()
-          return result
-        end,
-      }
-    end
+    use_branch_context('main')
+    use_system_responses({
+      ['git config branch.main.pushRemote'] = helpers.command_result('', 1),
+      ['git config remote.pushDefault'] = helpers.command_result('', 1),
+      ['git remote get-url upstream'] = helpers.command_result('', 1),
+      ['git diff --quiet origin/main..HEAD'] = helpers.command_result('', 1),
+      ['pr-for-branch main'] = helpers.command_result('\n'),
+      ['default-branch'] = helpers.command_result('main\n'),
+      ['git rev-parse --abbrev-ref main@{upstream}'] = helpers.command_result('origin/main\n'),
+      ['git remote'] = helpers.command_result('origin\nupstream\n'),
+      ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/repo.git\n'),
+    })
 
     require('forge').create_pr({ web = true })
 
@@ -341,68 +311,22 @@ describe('create_pr', function()
   end)
 
   it('allows web PR creation when the branch matches the base name in a different repo', function()
-    vim.fn.system = function(cmd)
-      if cmd == 'git rev-parse --show-toplevel' then
-        return '/repo\n'
-      end
-      if cmd == 'git remote get-url origin' then
-        return 'git@github.com:owner/fork.git\n'
-      end
-      if cmd == 'git branch --show-current' then
-        return 'main\n'
-      end
-      return ''
-    end
-    vim.system = function(cmd, _, cb)
-      local result = {
-        code = 0,
-        stdout = '',
-        stderr = '',
-      }
-      local key = table.concat(cmd, ' ')
-      local fail = {
-        ['git config branch.main.pushRemote'] = true,
-        ['git config remote.pushDefault'] = true,
-        ['git diff --quiet upstream/main..HEAD'] = true,
-      }
-      table.insert(captured.systems, key)
-      if fail[key] then
-        result.code = 1
-      end
-      if key == 'pr-for-branch main' then
-        result.stdout = '\n'
-      elseif key == 'default-branch' then
-        result.stdout = 'main\n'
-      elseif key == 'git rev-parse --abbrev-ref main@{upstream}' then
-        result.stdout = 'origin/main\n'
-      elseif key == 'git remote' then
-        result.stdout = 'origin\nupstream\n'
-      elseif key == 'git remote get-url origin' then
-        result.stdout = 'git@github.com:owner/fork.git\n'
-      elseif key == 'git remote get-url upstream' then
-        result.stdout = 'git@github.com:owner/repo.git\n'
-      end
-      if cb then
-        cb(result)
-      end
-      return {
-        wait = function()
-          return result
-        end,
-      }
-    end
+    use_branch_context('main', 'git@github.com:owner/fork.git\n')
+    use_system_responses({
+      ['git config branch.main.pushRemote'] = helpers.command_result('', 1),
+      ['git config remote.pushDefault'] = helpers.command_result('', 1),
+      ['git diff --quiet upstream/main..HEAD'] = helpers.command_result('', 1),
+      ['pr-for-branch main'] = helpers.command_result('\n'),
+      ['default-branch'] = helpers.command_result('main\n'),
+      ['git rev-parse --abbrev-ref main@{upstream}'] = helpers.command_result('origin/main\n'),
+      ['git remote'] = helpers.command_result('origin\nupstream\n'),
+      ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['git remote get-url upstream'] = helpers.command_result('git@github.com:owner/repo.git\n'),
+    })
 
     require('forge').create_pr({
       web = true,
-      scope = {
-        kind = 'github',
-        host = 'github.com',
-        owner = 'owner',
-        repo = 'repo',
-        slug = 'owner/repo',
-        repo_arg = 'owner/repo',
-        web_url = 'https://github.com/owner/repo',
-      },
+      scope = repo_scope('repo'),
     })
 
     vim.wait(100, function()
@@ -416,30 +340,11 @@ describe('create_pr', function()
   end)
 
   it('blocks web PR creation when there are no changes from the base branch', function()
-    vim.system = function(cmd, _, cb)
-      local result = {
-        code = 0,
-        stdout = '',
-        stderr = '',
-      }
-      local key = table.concat(cmd, ' ')
-      table.insert(captured.systems, key)
-      if key == 'pr-for-branch feature' then
-        result.stdout = '\n'
-      elseif key == 'default-branch' then
-        result.stdout = 'main\n'
-      elseif key == 'git diff --quiet origin/main..HEAD' then
-        result.code = 0
-      end
-      if cb then
-        cb(result)
-      end
-      return {
-        wait = function()
-          return result
-        end,
-      }
-    end
+    use_system_responses({
+      ['pr-for-branch feature'] = helpers.command_result('\n'),
+      ['default-branch'] = helpers.command_result('main\n'),
+      ['git diff --quiet origin/main..HEAD'] = helpers.command_result(),
+    })
 
     require('forge').create_pr({ web = true })
 
@@ -467,61 +372,20 @@ describe('create_pr', function()
   end)
 
   it('uses explicit head and base overrides for web PR creation', function()
-    vim.system = function(cmd, _, cb)
-      local result = {
-        code = 0,
-        stdout = '',
-        stderr = '',
-      }
-      local key = table.concat(cmd, ' ')
-      local fail = {
-        ['git diff --quiet upstream/stable..topic'] = true,
-      }
-      table.insert(captured.systems, key)
-      if fail[key] then
-        result.code = 1
-      end
-      if key == 'pr-for-branch topic' then
-        result.stdout = '\n'
-      elseif key == 'git remote' then
-        result.stdout = 'origin\nupstream\n'
-      elseif key == 'git remote get-url origin' then
-        result.stdout = 'git@github.com:owner/fork.git\n'
-      elseif key == 'git remote get-url upstream' then
-        result.stdout = 'git@github.com:owner/repo.git\n'
-      end
-      if cb then
-        cb(result)
-      end
-      return {
-        wait = function()
-          return result
-        end,
-      }
-    end
+    use_system_responses({
+      ['git diff --quiet upstream/stable..topic'] = helpers.command_result('', 1),
+      ['pr-for-branch topic'] = helpers.command_result('\n'),
+      ['git remote'] = helpers.command_result('origin\nupstream\n'),
+      ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['git remote get-url upstream'] = helpers.command_result('git@github.com:owner/repo.git\n'),
+    })
 
     require('forge').create_pr({
       web = true,
       head_branch = 'topic',
-      head_scope = {
-        kind = 'github',
-        host = 'github.com',
-        owner = 'owner',
-        repo = 'fork',
-        slug = 'owner/fork',
-        repo_arg = 'owner/fork',
-        web_url = 'https://github.com/owner/fork',
-      },
+      head_scope = repo_scope('fork'),
       base_branch = 'stable',
-      base_scope = {
-        kind = 'github',
-        host = 'github.com',
-        owner = 'owner',
-        repo = 'repo',
-        slug = 'owner/repo',
-        repo_arg = 'owner/repo',
-        web_url = 'https://github.com/owner/repo',
-      },
+      base_scope = repo_scope('repo'),
     })
 
     vim.wait(100, function()
@@ -537,33 +401,12 @@ describe('create_pr', function()
   end)
 
   it('reports an error when the web PR command fails', function()
-    vim.system = function(cmd, _, cb)
-      local result = {
-        code = 0,
-        stdout = '',
-        stderr = '',
-      }
-      local key = table.concat(cmd, ' ')
-      table.insert(captured.systems, key)
-      if key == 'pr-for-branch feature' then
-        result.stdout = '\n'
-      elseif key == 'default-branch' then
-        result.stdout = 'main\n'
-      elseif key == 'git diff --quiet origin/main..HEAD' then
-        result.code = 1
-      elseif key == 'create-pr-web' then
-        result.code = 1
-        result.stderr = 'web failed'
-      end
-      if cb then
-        cb(result)
-      end
-      return {
-        wait = function()
-          return result
-        end,
-      }
-    end
+    use_system_responses({
+      ['pr-for-branch feature'] = helpers.command_result('\n'),
+      ['default-branch'] = helpers.command_result('main\n'),
+      ['git diff --quiet origin/main..HEAD'] = helpers.command_result('', 1),
+      ['create-pr-web'] = helpers.command_result('', 1, 'web failed'),
+    })
 
     require('forge').create_pr({ web = true })
 

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1,0 +1,83 @@
+local M = {}
+
+function M.capture_preload(names)
+  local captured = {}
+  for _, name in ipairs(names) do
+    captured[#captured + 1] = {
+      name = name,
+      loader = package.preload[name],
+    }
+  end
+  return captured
+end
+
+function M.restore_preload(captured)
+  for _, entry in ipairs(captured) do
+    package.preload[entry.name] = entry.loader
+  end
+end
+
+function M.clear_loaded(names)
+  for _, name in ipairs(names) do
+    package.loaded[name] = nil
+  end
+end
+
+function M.action_by_name(actions, name)
+  for _, def in ipairs(actions or {}) do
+    if def.name == name then
+      return def
+    end
+  end
+end
+
+function M.action_labels(actions)
+  local labels = {}
+  for _, def in ipairs(actions or {}) do
+    labels[def.name] = def.label
+  end
+  return labels
+end
+
+function M.command_result(stdout, code, stderr)
+  return {
+    code = code or 0,
+    stdout = stdout or '',
+    stderr = stderr or '',
+  }
+end
+
+function M.system_router(opts)
+  local responses = opts.responses or {}
+  local default = vim.deepcopy(opts.default or M.command_result())
+  local calls = opts.calls
+
+  return function(cmd, _, cb)
+    local key = table.concat(cmd, ' ')
+    if calls then
+      table.insert(calls, key)
+    end
+
+    local response = responses[key]
+    local result
+    if type(response) == 'function' then
+      result = response(key, cmd)
+    elseif response ~= nil then
+      result = vim.deepcopy(response)
+    else
+      result = vim.deepcopy(default)
+    end
+
+    if cb then
+      cb(result)
+    end
+
+    return {
+      wait = function()
+        return result
+      end,
+    }
+  end
+end
+
+return M

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -306,79 +306,67 @@ describe('format_issue', function()
 end)
 
 describe('format_check', function()
-  it('maps pass bucket', function()
-    local result = flatten(forge.format_check({ name = 'lint', bucket = 'pass' }))
-    assert.truthy(result:find('p'))
-    assert.truthy(result:find('lint'))
-  end)
-
-  it('maps fail bucket', function()
-    local result = flatten(forge.format_check({ name = 'build', bucket = 'fail' }))
-    assert.truthy(result:find('f'))
-  end)
-
-  it('maps pending bucket', function()
-    local result = flatten(forge.format_check({ name = 'test', bucket = 'pending' }))
-    assert.truthy(result:find('~'))
-  end)
-
-  it('maps skipping bucket', function()
-    local result = flatten(forge.format_check({ name = 'optional', bucket = 'skipping' }))
-    assert.truthy(result:find('s'))
-  end)
-
-  it('maps cancel bucket', function()
-    local result = flatten(forge.format_check({ name = 'cancelled', bucket = 'cancel' }))
-    assert.truthy(result:find('s'))
-  end)
-
-  it('maps unknown bucket', function()
-    local result = flatten(forge.format_check({ name = 'mystery', bucket = 'something_else' }))
-    assert.truthy(result:find('%?'))
-  end)
-
-  it('defaults to pending when bucket is nil', function()
-    local result = flatten(forge.format_check({ name = 'none' }))
-    assert.truthy(result:find('~'))
-  end)
+  for _, case in ipairs({
+    { name = 'maps pass bucket', check = { name = 'lint', bucket = 'pass' }, icon = 'p' },
+    { name = 'maps fail bucket', check = { name = 'build', bucket = 'fail' }, icon = 'f' },
+    { name = 'maps pending bucket', check = { name = 'test', bucket = 'pending' }, icon = '~' },
+    {
+      name = 'maps skipping bucket',
+      check = { name = 'optional', bucket = 'skipping' },
+      icon = 's',
+    },
+    { name = 'maps cancel bucket', check = { name = 'cancelled', bucket = 'cancel' }, icon = 's' },
+    {
+      name = 'maps unknown bucket',
+      check = { name = 'mystery', bucket = 'something_else' },
+      icon = '%?',
+    },
+    { name = 'defaults to pending when bucket is nil', check = { name = 'none' }, icon = '~' },
+  }) do
+    it(case.name, function()
+      local result = flatten(forge.format_check(case.check))
+      assert.truthy(result:find(case.icon))
+      assert.truthy(result:find(case.check.name, 1, true))
+    end)
+  end
 end)
 
 describe('format_run', function()
-  it('formats successful run with branch', function()
-    local run =
-      { name = 'CI', branch = 'main', status = 'success', event = 'push', created_at = '' }
-    local result = flatten(forge.format_run(run))
-    assert.truthy(result:find('p'))
-    assert.truthy(result:find('CI'))
-    assert.truthy(result:find('main'))
-    assert.truthy(result:find('push'))
-  end)
-
-  it('formats failed run without branch', function()
-    local run = {
-      name = 'Deploy',
-      branch = '',
-      status = 'failure',
-      event = 'workflow_dispatch',
-      created_at = '',
-    }
-    local result = flatten(forge.format_run(run))
-    assert.truthy(result:find('f'))
-    assert.truthy(result:find('manual'))
-  end)
-
-  it('maps in_progress status', function()
-    local run =
-      { name = 'Test', branch = '', status = 'in_progress', event = 'push', created_at = '' }
-    local result = flatten(forge.format_run(run))
-    assert.truthy(result:find('~'))
-  end)
-
-  it('maps cancelled status', function()
-    local run = { name = 'Old', branch = '', status = 'cancelled', event = 'push', created_at = '' }
-    local result = flatten(forge.format_run(run))
-    assert.truthy(result:find('s'))
-  end)
+  for _, case in ipairs({
+    {
+      name = 'formats successful run with branch',
+      run = { name = 'CI', branch = 'main', status = 'success', event = 'push', created_at = '' },
+      expected = { 'p', 'CI', 'main', 'push' },
+    },
+    {
+      name = 'formats failed run without branch',
+      run = {
+        name = 'Deploy',
+        branch = '',
+        status = 'failure',
+        event = 'workflow_dispatch',
+        created_at = '',
+      },
+      expected = { 'f', 'manual' },
+    },
+    {
+      name = 'maps in_progress status',
+      run = { name = 'Test', branch = '', status = 'in_progress', event = 'push', created_at = '' },
+      expected = { '~' },
+    },
+    {
+      name = 'maps cancelled status',
+      run = { name = 'Old', branch = '', status = 'cancelled', event = 'push', created_at = '' },
+      expected = { 's' },
+    },
+  }) do
+    it(case.name, function()
+      local result = flatten(forge.format_run(case.run))
+      for _, expected in ipairs(case.expected) do
+        assert.truthy(result:find(expected, 1, true))
+      end
+    end)
+  end
 end)
 
 describe('format_runs', function()
@@ -705,68 +693,36 @@ describe('config validation', function()
     vim.g.forge = nil
   end)
 
-  it('rejects non-table sources', function()
-    vim.g.forge = { sources = 'bad' }
-    assert.has_error(function()
-      forge.config()
+  for _, case in ipairs({
+    { name = 'rejects non-table sources', config = { sources = 'bad' } },
+    { name = 'rejects non-table display', config = { display = 42 } },
+    { name = 'rejects non-number ci.lines', config = { ci = { lines = 'many' } } },
+    { name = 'rejects non-string icon', config = { display = { icons = { open = 123 } } } },
+    { name = 'rejects non-number width', config = { display = { widths = { title = 'wide' } } } },
+    { name = 'rejects non-number limit', config = { display = { limits = { pulls = true } } } },
+    { name = 'rejects non-string key binding', config = { keys = { pr = { edit = 42 } } } },
+    { name = 'rejects non-table targets', config = { targets = 'bad' } },
+    {
+      name = 'rejects invalid target alias values',
+      config = { targets = { aliases = { upstream = false } } },
+    },
+    { name = 'rejects keys as a string', config = { keys = 'none' } },
+    { name = 'rejects non-table source hosts', config = { sources = { custom = { hosts = 99 } } } },
+    { name = 'rejects invalid split value', config = { split = 'diagonal' } },
+    { name = 'rejects invalid ci.split', config = { ci = { split = 'bad' } } },
+    { name = 'rejects non-number ci.refresh', config = { ci = { refresh = 'fast' } } },
+    {
+      name = 'rejects invalid delete confirmation config',
+      config = { confirm = { branch_delete = 'nope' } },
+    },
+  }) do
+    it(case.name, function()
+      vim.g.forge = case.config
+      assert.has_error(function()
+        forge.config()
+      end)
     end)
-  end)
-
-  it('rejects non-table display', function()
-    vim.g.forge = { display = 42 }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects non-number ci.lines', function()
-    vim.g.forge = { ci = { lines = 'many' } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects non-string icon', function()
-    vim.g.forge = { display = { icons = { open = 123 } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects non-number width', function()
-    vim.g.forge = { display = { widths = { title = 'wide' } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects non-number limit', function()
-    vim.g.forge = { display = { limits = { pulls = true } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects non-string key binding', function()
-    vim.g.forge = { keys = { pr = { edit = 42 } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects non-table targets', function()
-    vim.g.forge = { targets = 'bad' }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects invalid target alias values', function()
-    vim.g.forge = { targets = { aliases = { upstream = false } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
+  end
 
   it('accepts target alias and collaboration defaults', function()
     vim.g.forge = {
@@ -788,40 +744,29 @@ describe('config validation', function()
     assert.is_false(cfg.keys.pr.edit)
   end)
 
-  it('rejects keys as a string', function()
-    vim.g.forge = { keys = 'none' }
-    assert.has_error(function()
-      forge.config()
+  for _, case in ipairs({
+    {
+      name = 'accepts horizontal split',
+      config = { split = 'horizontal' },
+      assert_cfg = function(cfg)
+        assert.equals('horizontal', cfg.split)
+        assert.is_true(cfg.confirm.branch_delete)
+        assert.is_true(cfg.confirm.worktree_delete)
+      end,
+    },
+    {
+      name = 'accepts vertical split',
+      config = { split = 'vertical' },
+      assert_cfg = function(cfg)
+        assert.equals('vertical', cfg.split)
+      end,
+    },
+  }) do
+    it(case.name, function()
+      vim.g.forge = case.config
+      case.assert_cfg(forge.config())
     end)
-  end)
-
-  it('rejects non-table source hosts', function()
-    vim.g.forge = { sources = { custom = { hosts = 99 } } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects invalid split value', function()
-    vim.g.forge = { split = 'diagonal' }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('accepts horizontal split', function()
-    vim.g.forge = { split = 'horizontal' }
-    local cfg = forge.config()
-    assert.equals('horizontal', cfg.split)
-    assert.is_true(cfg.confirm.branch_delete)
-    assert.is_true(cfg.confirm.worktree_delete)
-  end)
-
-  it('accepts vertical split', function()
-    vim.g.forge = { split = 'vertical' }
-    local cfg = forge.config()
-    assert.equals('vertical', cfg.split)
-  end)
+  end
 
   it('accepts ci.split override', function()
     vim.g.forge = { split = 'horizontal', ci = { split = 'vertical' } }
@@ -849,19 +794,5 @@ describe('config validation', function()
     vim.g.forge = { ci = { refresh = 0 } }
     local cfg = forge.config()
     assert.equals(0, cfg.ci.refresh)
-  end)
-
-  it('rejects non-number ci.refresh', function()
-    vim.g.forge = { ci = { refresh = 'fast' } }
-    assert.has_error(function()
-      forge.config()
-    end)
-  end)
-
-  it('rejects invalid delete confirmation config', function()
-    vim.g.forge = { confirm = { branch_delete = 'nope' } }
-    assert.has_error(function()
-      forge.config()
-    end)
   end)
 end)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1,5 +1,7 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
 local captured
 local cache
 local issue_create_calls
@@ -9,6 +11,22 @@ local op_calls
 local pr_create_calls
 local pr_create_opts
 local default_system
+local preload_modules = {
+  'fzf-lua.utils',
+  'forge',
+  'forge.logger',
+  'forge.ops',
+  'forge.picker',
+}
+local loaded_modules = {
+  'forge',
+  'forge.config',
+  'forge.logger',
+  'forge.ops',
+  'forge.picker',
+  'forge.picker.session',
+  'forge.pickers',
+}
 
 local function fake_forge()
   return {
@@ -116,11 +134,7 @@ local function fake_release_forge()
 end
 
 local function action_by_name(name)
-  for _, def in ipairs(captured.actions) do
-    if def.name == name then
-      return def
-    end
-  end
+  return helpers.action_by_name(captured.actions, name)
 end
 
 describe('pickers', function()
@@ -155,13 +169,7 @@ describe('pickers', function()
         { number = 42, title = 'Fix api drift', state = 'OPEN', author = 'alice', created_at = '' },
       },
     }
-    old_preload = {
-      ['fzf-lua.utils'] = package.preload['fzf-lua.utils'],
-      ['forge'] = package.preload['forge'],
-      ['forge.logger'] = package.preload['forge.logger'],
-      ['forge.ops'] = package.preload['forge.ops'],
-      ['forge.picker'] = package.preload['forge.picker'],
-    }
+    old_preload = helpers.capture_preload(preload_modules)
     package.preload['fzf-lua.utils'] = function()
       return {
         ansi_from_hl = function(_, text)
@@ -390,30 +398,14 @@ describe('pickers', function()
         edit_pr = function() end,
       }
     end
-    package.loaded['forge'] = nil
-    package.loaded['forge.config'] = nil
-    package.loaded['forge.logger'] = nil
-    package.loaded['forge.ops'] = nil
-    package.loaded['forge.picker'] = nil
-    package.loaded['forge.picker.session'] = nil
-    package.loaded['forge.pickers'] = nil
+    helpers.clear_loaded(loaded_modules)
     vim.g.forge = nil
   end)
 
   after_each(function()
     vim.system = default_system
-    package.preload['fzf-lua.utils'] = old_preload['fzf-lua.utils']
-    package.preload['forge'] = old_preload['forge']
-    package.preload['forge.logger'] = old_preload['forge.logger']
-    package.preload['forge.ops'] = old_preload['forge.ops']
-    package.preload['forge.picker'] = old_preload['forge.picker']
-    package.loaded['forge'] = nil
-    package.loaded['forge.config'] = nil
-    package.loaded['forge.logger'] = nil
-    package.loaded['forge.ops'] = nil
-    package.loaded['forge.picker'] = nil
-    package.loaded['forge.picker.session'] = nil
-    package.loaded['forge.pickers'] = nil
+    helpers.restore_preload(old_preload)
+    helpers.clear_loaded(loaded_modules)
   end)
 
   it('uses more as the default PR action without a separate default key binding', function()
@@ -431,10 +423,7 @@ describe('pickers', function()
 
     assert.is_not_nil(captured)
     assert.equals('Open PRs (1)> ', captured.prompt)
-    local labels = {}
-    for _, def in ipairs(captured.actions) do
-      labels[def.name] = def.label
-    end
+    local labels = helpers.action_labels(captured.actions)
     assert.equals('checkout', labels.default)
     assert.equals('worktree', labels.worktree)
     assert.equals('edit', labels.edit)
@@ -454,10 +443,19 @@ describe('pickers', function()
 
     assert.is_not_nil(captured)
     assert.equals('checkout', action_by_name('default').label)
-    assert.is_false(rawget(action_by_name('browse'), 'close'))
-    assert.is_false(rawget(action_by_name('worktree'), 'close'))
-    assert.is_nil(rawget(action_by_name('approve'), 'close'))
-    assert.is_nil(rawget(action_by_name('merge'), 'close'))
+    for _, case in ipairs({
+      { name = 'browse', close = false },
+      { name = 'worktree', close = false },
+      { name = 'approve', close = nil },
+      { name = 'merge', close = nil },
+    }) do
+      local close = rawget(action_by_name(case.name), 'close')
+      if case.close == nil then
+        assert.is_nil(close)
+      else
+        assert.equals(case.close, close)
+      end
+    end
   end)
 
   it('dispatches flattened PR actions directly from the root picker', function()


### PR DESCRIPTION
## Problem

The test suite had a lot of repeated preload setup, module reset logic, and inline `vim.system` routing, which made the larger specs harder to maintain and reason about.

## Solution

Add a shared spec helper module for preload and system stubbing, convert the most repetitive mapping and validation cases to tables, and reuse small helpers in the picker, command, and create PR specs so the suite stays isolated while expressing the same coverage more compactly. The full `busted` suite passes with these changes.