### PR TITLE
docs: clarify optional fzf-lua support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ without leaving your editor.
 
 - Neovim 0.10.0+
 - tree-sitter `yaml` parser for YAML issue form templates
-- [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive picker
-  workflows
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
+
+Optional:
+
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive picker
+  workflows
+
+Direct `:Forge` action commands work without `fzf-lua`. Install it if you want
+the interactive picker UI opened by mappings such as `<Plug>(forge)` or
+`require('forge').open()`.
 
 ## Installation
 

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -64,15 +64,15 @@ remote and delegates to the appropriate CLI (`gh`, `glab`, or `tea`).
 
 Requirements: ~
 - Neovim 0.10.0+
-- fzf-lua for interactive picker workflows
 - tree-sitter `yaml` parser
 - One or more forge CLIs:
   - `gh` for GitHub
   - `glab` for GitLab
   - `tea` for Codeberg/Gitea/Forgejo
+- Optional: `fzf-lua` for interactive picker workflows
 
-Direct `:Forge` action commands work without `fzf-lua`. The interactive picker
-surface requires it.
+Direct `:Forge` action commands work without `fzf-lua`. The built-in
+interactive picker surface requires it.
 
 Run |:checkhealth| forge to verify CLIs and dependencies.
 
@@ -1068,11 +1068,13 @@ Optional methods: ~
 
   Method                              Fallback ~
   `list_runs_json_cmd(branch?)`        `string[]` JSON CI list cmd.
-                                        If absent, `list_runs_cmd` is used
-                                        as a raw fzf-lua command source.
+                                        If absent, Forge reports that
+                                        structured CI data is unavailable
+                                        for that source.
   `checks_json_cmd(num)`               `string[]` JSON checks cmd.
-                                        If absent, `checks_cmd` string is
-                                        used as a raw fzf-lua command.
+                                        If absent, Forge reports that
+                                        structured checks are unavailable
+                                        for that source.
   `create_pr_web_cmd()`                `string[]?` cmd to open web PR
                                         creation. Return `nil` to no-op.
   `create_issue_web_cmd()`             `string[]?` cmd to open web issue


### PR DESCRIPTION
## Problem

The recent picker refactor made direct `:Forge` action commands work without `fzf-lua`, but the README and vimdoc still read as if `fzf-lua` is always required. The vimdoc API section also still described old raw `fzf-lua` fallbacks for CI runs and checks that the current picker implementation no longer uses.

## Solution

Update the README and help text to describe `fzf-lua` as optional for direct command usage while keeping the interactive picker requirement explicit. Also refresh the vimdoc API fallback descriptions so they match the current structured-data behavior.