### PR TITLE
refactor(issue): simplify compose editing surface

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -814,21 +814,15 @@ Layout: ~
   Line 1      Issue title
   Line 2      Empty separator
   Lines 3+    Issue body (from discovered issue template, or empty)
-  `<!--`        Metadata comment block (forge, labels, assignees).
+  `<!--`        Informational comment block (forge, submit/discard hints).
   `-->`         End of metadata
 
 Write (`:w`) to create the issue. An empty title aborts creation. The
 issue URL is copied to the `+` register on success.
 
-Metadata fields: ~
-  `Labels:`          Comma or space separated label names.
-  `Assignees:`       Comma or space separated usernames.
-  `Milestone:`       Milestone name.
-
 Editing an issue opens a compose buffer at `forge://issue/{num}/edit` with
-the same title/body layout and metadata fields as issue creation. Write
-(`:w`) to update the issue. An empty title aborts editing. Empty bodies are
-allowed.
+the same title/body layout as issue creation. Write (`:w`) to update the
+issue. An empty title aborts editing. Empty bodies are allowed.
 
 Template discovery: ~
   forge.nvim searches forge-specific template paths. If a template
@@ -871,7 +865,6 @@ Compose buffer: ~
   `ForgeComposeAdded`        `Added`            Addition indicators (+)
   `ForgeComposeRemoved`      `Removed`          Deletion indicators (-)
   `ForgeComposeHeader`       `PreProc`          Section headers
-  `ForgeComposeLabel`        `Label`            Metadata labels (Labels:, etc.)
 
 Picker lines: ~
 
@@ -935,9 +928,6 @@ support for features that vary:
   CI runs (repo-wide)          yes       yes       yes
   Issue create                   yes       yes       yes
   Issue edit                    yes       yes       yes
-  Issue create (labels)        yes       yes       yes
-  Issue create (assignees)     yes       yes       yes
-  Issue create (milestone)     yes       yes       yes
   Issues                       yes       yes       yes
   Branches                     yes       yes       yes
   Commits                      yes       yes       yes

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -46,32 +46,6 @@ local function repo_arg(ref)
   return forge.scope_repo_arg(current) or ''
 end
 
-local function diff_values(before, after)
-  local before_set = {}
-  for _, value in ipairs(before or {}) do
-    before_set[value] = true
-  end
-  local after_set = {}
-  for _, value in ipairs(after or {}) do
-    after_set[value] = true
-  end
-  local added = {}
-  for _, value in ipairs(after or {}) do
-    if not before_set[value] then
-      table.insert(added, value)
-      before_set[value] = true
-    end
-  end
-  local removed = {}
-  for _, value in ipairs(before or {}) do
-    if not after_set[value] then
-      table.insert(removed, value)
-      after_set[value] = true
-    end
-  end
-  return added, removed
-end
-
 ---@param state string
 ---@param limit integer?
 ---@return string[]
@@ -365,7 +339,7 @@ function M:update_pr_cmd(num, title, body, ref)
   }
 end
 
-function M:update_issue_cmd(num, title, body, labels, assignees, milestone, original, ref)
+function M:update_issue_cmd(num, title, body, ref)
   local cmd = {
     'tea',
     'issues',
@@ -378,27 +352,6 @@ function M:update_issue_cmd(num, title, body, labels, assignees, milestone, orig
     '--repo',
     repo_arg(ref),
   }
-  local added_labels, removed_labels = diff_values(original and original.labels or {}, labels)
-  if #added_labels > 0 then
-    table.insert(cmd, '--add-labels')
-    table.insert(cmd, table.concat(added_labels, ','))
-  end
-  if #removed_labels > 0 then
-    table.insert(cmd, '--remove-labels')
-    table.insert(cmd, table.concat(removed_labels, ','))
-  end
-  local added_assignees = select(1, diff_values(original and original.assignees or {}, assignees))
-  if #added_assignees > 0 then
-    table.insert(cmd, '--add-assignees')
-    table.insert(cmd, table.concat(added_assignees, ','))
-  end
-  if
-    milestone ~= nil
-    and (milestone ~= '' or (original and original.milestone and original.milestone ~= ''))
-  then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
-  end
   return cmd
 end
 
@@ -414,51 +367,22 @@ function M:parse_pr_details(json)
 end
 
 function M:parse_issue_details(json)
-  local labels = {}
-  for _, l in ipairs(json.labels or {}) do
-    table.insert(labels, l.name or '')
-  end
-  local assignees = {}
-  for _, a in ipairs(json.assignees or {}) do
-    table.insert(assignees, a.login or '')
-  end
-  local milestone = ''
-  if type(json.milestone) == 'table' and json.milestone.title then
-    milestone = json.milestone.title
-  end
   return {
     title = json.title or '',
     body = json.body or '',
-    labels = labels,
-    assignees = assignees,
-    milestone = milestone,
   }
 end
 
 ---@param field string
 ---@return string[]?
 function M:completion_cmd(field, ref)
-  if field == 'labels' then
-    return {
-      'sh',
-      '-c',
-      'tea api --repo ' .. repo_arg(ref) .. " '/repos/{owner}/{repo}/labels' | jq -r '.[].name'",
-    }
-  elseif field == 'assignees' or field == 'mentions' then
+  if field == 'mentions' then
     return {
       'sh',
       '-c',
       'tea api --repo '
         .. repo_arg(ref)
         .. " '/repos/{owner}/{repo}/collaborators' | jq -r '.[].login'",
-    }
-  elseif field == 'milestone' then
-    return {
-      'sh',
-      '-c',
-      'tea api --repo '
-        .. repo_arg(ref)
-        .. " '/repos/{owner}/{repo}/milestones?state=open' | jq -r '.[].title'",
     }
   elseif field == 'issues' then
     return {
@@ -521,20 +445,12 @@ end
 ---@param assignees string[]?
 ---@param milestone string?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, assignees, milestone, ref)
+function M:create_issue_cmd(title, body, labels, ref)
   local cmd =
     { 'tea', 'issues', 'create', '--title', title, '--description', body, '--repo', repo_arg(ref) }
   if labels and #labels > 0 then
     table.insert(cmd, '--labels')
     table.insert(cmd, table.concat(labels, ','))
-  end
-  if assignees and #assignees > 0 then
-    table.insert(cmd, '--assignees')
-    table.insert(cmd, table.concat(assignees, ','))
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
   end
   return cmd
 end

--- a/lua/forge/completion.lua
+++ b/lua/forge/completion.lua
@@ -10,32 +10,6 @@ local last_context
 
 ---@param line string
 ---@return string?
-local function detect_field(line)
-  if line:match('^%s*Labels:') then
-    return 'labels'
-  elseif line:match('^%s*Assignees:') then
-    return 'assignees'
-  elseif line:match('^%s*Milestone:') then
-    return 'milestone'
-  end
-  return nil
-end
-
----@return boolean
-local function in_comment_block()
-  local buf_lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-  local cur = vim.fn.line('.')
-  local inside = false
-  for i = 1, cur do
-    if buf_lines[i]:match('^<!--') then
-      inside = true
-    elseif buf_lines[i]:match('^%-%->') then
-      inside = false
-    end
-  end
-  return inside
-end
-
 ---@param line string
 ---@param col integer
 ---@return string? trigger
@@ -96,18 +70,6 @@ function M.omnifunc(findstart, base)
   local col = vim.fn.col('.')
 
   if findstart == 1 then
-    if in_comment_block() then
-      local field = detect_field(line)
-      if field then
-        last_context = 'field:' .. field
-        local i = col - 1
-        while i > 0 and line:sub(i, i):match('[^,%s]') do
-          i = i - 1
-        end
-        return i
-      end
-    end
-
     local trigger, tpos = detect_trigger(line, col)
     if trigger and tpos then
       last_context = 'trigger:' .. trigger
@@ -129,18 +91,6 @@ function M.omnifunc(findstart, base)
   local scope = vim.b.forge_scope
 
   local kind, value = last_context:match('^(%w+):(.+)$')
-
-  if kind == 'field' then
-    local candidates = fetch(value, f, scope)
-    local items = {}
-    local lower_base = base:lower()
-    for _, word in ipairs(candidates) do
-      if word:lower():find(lower_base, 1, true) then
-        table.insert(items, { word = word, menu = '[Forge]' })
-      end
-    end
-    return items
-  end
 
   if kind == 'trigger' then
     if value == '#' then

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -93,43 +93,6 @@ local function extract_content(buf_lines)
   return content_lines
 end
 
----@class forge.CommentMetadata
----@field labels string[]
----@field assignees string[]
----@field milestone string
-
----@param buf_lines string[]
----@return forge.CommentMetadata
-local function parse_comment_metadata(buf_lines)
-  local in_comment = false
-  local meta = { labels = {}, assignees = {}, milestone = '' }
-  for _, l in ipairs(buf_lines) do
-    if l:match('^<!--') then
-      in_comment = true
-    elseif l:match('^%-%->') then
-      break
-    elseif in_comment then
-      local lv = l:match('^%s*Labels:%s*(.*)$')
-      if lv then
-        for label in vim.trim(lv):gmatch('[^,%s]+') do
-          table.insert(meta.labels, label)
-        end
-      end
-      local av = l:match('^%s*Assignees:%s*(.*)$')
-      if av then
-        for assignee in vim.trim(av):gmatch('[^,%s]+') do
-          table.insert(meta.assignees, assignee)
-        end
-      end
-      local mv = l:match('^%s*Milestone:%s*(.*)$')
-      if mv then
-        meta.milestone = vim.trim(mv)
-      end
-    end
-  end
-  return meta
-end
-
 ---@param f forge.Forge
 ---@param branch string
 ---@param title string
@@ -189,68 +152,60 @@ local function push_and_create(f, branch, title, body, pr_base, pr_draft, buf, r
   )
 end
 
-local function submit_issue(f, title, body, labels, assignees, milestone, buf, ref)
+local function submit_issue(f, title, body, labels, buf, ref)
   local log = require('forge.logger')
   log.info('creating issue...')
-  vim.system(
-    f:create_issue_cmd(title, body, labels, assignees, milestone, ref),
-    { text = true },
-    function(result)
-      vim.schedule(function()
-        if result.code == 0 then
-          local url = vim.trim(result.stdout or '')
-          if url ~= '' then
-            set_clipboard(url)
-          end
-          log.info(('created issue -> %s'):format(url))
-          require('forge').clear_list()
-          if buf and vim.api.nvim_buf_is_valid(buf) then
-            vim.bo[buf].modified = false
-            vim.api.nvim_buf_delete(buf, { force = true })
-          end
-        else
-          local msg = vim.trim(result.stderr or '')
-          if msg == '' then
-            msg = vim.trim(result.stdout or '')
-          end
-          if msg == '' then
-            msg = 'creation failed'
-          end
-          log.error(msg)
+  vim.system(f:create_issue_cmd(title, body, labels, ref), { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        local url = vim.trim(result.stdout or '')
+        if url ~= '' then
+          set_clipboard(url)
         end
-      end)
-    end
-  )
+        log.info(('created issue -> %s'):format(url))
+        require('forge').clear_list()
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          vim.bo[buf].modified = false
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      else
+        local msg = vim.trim(result.stderr or '')
+        if msg == '' then
+          msg = vim.trim(result.stdout or '')
+        end
+        if msg == '' then
+          msg = 'creation failed'
+        end
+        log.error(msg)
+      end
+    end)
+  end)
 end
 
-local function update_issue(f, num, title, body, labels, assignees, milestone, original, buf, ref)
+local function update_issue(f, num, title, body, buf, ref)
   local log = require('forge.logger')
   log.info('updating issue #' .. num .. '...')
-  vim.system(
-    f:update_issue_cmd(num, title, body, labels, assignees, milestone, original, ref),
-    { text = true },
-    function(result)
-      vim.schedule(function()
-        if result.code == 0 then
-          log.info(('updated issue #%s'):format(num))
-          require('forge').clear_list()
-          if buf and vim.api.nvim_buf_is_valid(buf) then
-            vim.bo[buf].modified = false
-            vim.api.nvim_buf_delete(buf, { force = true })
-          end
-        else
-          local msg = vim.trim(result.stderr or '')
-          if msg == '' then
-            msg = vim.trim(result.stdout or '')
-          end
-          if msg == '' then
-            msg = 'update failed'
-          end
-          log.error(msg)
+  vim.system(f:update_issue_cmd(num, title, body, ref), { text = true }, function(result)
+    vim.schedule(function()
+      if result.code == 0 then
+        log.info(('updated issue #%s'):format(num))
+        require('forge').clear_list()
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          vim.bo[buf].modified = false
+          vim.api.nvim_buf_delete(buf, { force = true })
         end
-      end)
-    end
-  )
+      else
+        local msg = vim.trim(result.stderr or '')
+        if msg == '' then
+          msg = vim.trim(result.stdout or '')
+        end
+        if msg == '' then
+          msg = 'update failed'
+        end
+        log.error(msg)
+      end
+    end)
+  end)
 end
 
 ---@param f forge.Forge
@@ -285,17 +240,6 @@ function M.open_issue(f, result, ref)
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
-  local labels_prefix = '  Labels: '
-  local labels_val = #template_labels > 0 and table.concat(template_labels, ', ') or ''
-  b:add_line('%s%s', labels_prefix, labels_val)
-
-  local assignees_prefix = '  Assignees: '
-  b:add_line('%s', assignees_prefix)
-
-  local milestone_prefix = '  Milestone: '
-  b:add_line('%s', milestone_prefix)
-
-  b:add_line('')
   add_discard_hints(b)
   b:add_line('  An empty title aborts creation.')
   b:add_line('-->')
@@ -327,17 +271,7 @@ function M.open_issue(f, result, ref)
         return
       end
 
-      local meta = parse_comment_metadata(buf_lines)
-      submit_issue(
-        f,
-        issue_title,
-        issue_body,
-        meta.labels,
-        meta.assignees,
-        meta.milestone,
-        buf,
-        ref
-      )
+      submit_issue(f, issue_title, issue_body, template_labels, buf, ref)
     end,
   })
 
@@ -370,19 +304,6 @@ function M.open_issue_edit(f, num, details, ref)
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
-  local labels_prefix = '  Labels: '
-  ln = b:add_line('%s%s', labels_prefix, table.concat(details.labels, ', '))
-  b:mark(ln, 2, 7, 'ForgeComposeLabel')
-
-  local assignees_prefix = '  Assignees: '
-  ln = b:add_line('%s%s', assignees_prefix, table.concat(details.assignees, ', '))
-  b:mark(ln, 2, 10, 'ForgeComposeLabel')
-
-  local milestone_prefix = '  Milestone: '
-  ln = b:add_line('%s%s', milestone_prefix, details.milestone)
-  b:mark(ln, 2, 10, 'ForgeComposeLabel')
-
-  b:add_line('')
   add_discard_hints(b)
   b:add_line('  An empty title aborts editing.')
   b:add_line('-->')
@@ -405,19 +326,7 @@ function M.open_issue_edit(f, num, details, ref)
       end
 
       local issue_body = vim.trim(table.concat(content_lines, '\n', 3))
-      local meta = parse_comment_metadata(buf_lines)
-      update_issue(
-        f,
-        num,
-        issue_title,
-        issue_body,
-        meta.labels,
-        meta.assignees,
-        meta.milestone,
-        details,
-        buf,
-        ref
-      )
+      update_issue(f, num, issue_title, issue_body, buf, ref)
     end,
   })
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -256,7 +256,6 @@ local hl_defaults = {
   ForgeComposeAdded = 'Added',
   ForgeComposeRemoved = 'Removed',
   ForgeComposeHeader = 'PreProc',
-  ForgeComposeLabel = 'Label',
   ForgeNumber = 'Number',
   ForgeOpen = 'DiagnosticOk',
   ForgeMerged = 'Special',

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -67,32 +67,6 @@ local function open_browse_url(cmd)
   end)
 end
 
-local function diff_values(before, after)
-  local before_set = {}
-  for _, value in ipairs(before or {}) do
-    before_set[value] = true
-  end
-  local after_set = {}
-  for _, value in ipairs(after or {}) do
-    after_set[value] = true
-  end
-  local added = {}
-  for _, value in ipairs(after or {}) do
-    if not before_set[value] then
-      table.insert(added, value)
-      before_set[value] = true
-    end
-  end
-  local removed = {}
-  for _, value in ipairs(before or {}) do
-    if not after_set[value] then
-      table.insert(removed, value)
-      after_set[value] = true
-    end
-  end
-  return added, removed
-end
-
 ---@param state string
 ---@param limit integer?
 ---@return string[]
@@ -488,7 +462,7 @@ function M:fetch_issue_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,labels,assignees,milestone,url',
+    'title,body,url',
   }
 end
 
@@ -506,37 +480,12 @@ function M:update_pr_cmd(num, title, body, scope)
   return cmd
 end
 
-function M:update_issue_cmd(num, title, body, labels, assignees, milestone, original, scope)
+function M:update_issue_cmd(num, title, body, scope)
   local cmd = { 'gh', 'issue', 'edit', num, '--title', title, '--body', body }
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
-  end
-  local added_labels, removed_labels = diff_values(original and original.labels or {}, labels)
-  for _, label in ipairs(added_labels) do
-    table.insert(cmd, '--add-label')
-    table.insert(cmd, label)
-  end
-  for _, label in ipairs(removed_labels) do
-    table.insert(cmd, '--remove-label')
-    table.insert(cmd, label)
-  end
-  local added_assignees, removed_assignees =
-    diff_values(original and original.assignees or {}, assignees)
-  for _, assignee in ipairs(added_assignees) do
-    table.insert(cmd, '--add-assignee')
-    table.insert(cmd, assignee)
-  end
-  for _, assignee in ipairs(removed_assignees) do
-    table.insert(cmd, '--remove-assignee')
-    table.insert(cmd, assignee)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
-  elseif original and original.milestone and original.milestone ~= '' then
-    table.insert(cmd, '--remove-milestone')
   end
   return cmd
 end
@@ -553,36 +502,17 @@ function M:parse_pr_details(json)
 end
 
 function M:parse_issue_details(json)
-  local labels = {}
-  for _, l in ipairs(json.labels or {}) do
-    table.insert(labels, l.name or '')
-  end
-  local assignees = {}
-  for _, a in ipairs(json.assignees or {}) do
-    table.insert(assignees, a.login or '')
-  end
-  local milestone = ''
-  if type(json.milestone) == 'table' and json.milestone.title then
-    milestone = json.milestone.title
-  end
   return {
     title = json.title or '',
     body = json.body or '',
-    labels = labels,
-    assignees = assignees,
-    milestone = milestone,
   }
 end
 
 ---@param field string
 ---@return string[]?
 function M:completion_cmd(field, scope)
-  if field == 'labels' then
-    return { 'gh', 'label', 'list', '-R', nwo(scope), '--json', 'name', '--jq', '.[].name' }
-  elseif field == 'assignees' or field == 'mentions' then
+  if field == 'mentions' then
     return { 'gh', 'api', 'repos/' .. nwo(scope) .. '/collaborators', '--jq', '.[].login' }
-  elseif field == 'milestone' then
-    return { 'gh', 'api', 'repos/' .. nwo(scope) .. '/milestones', '--jq', '.[].title' }
   elseif field == 'issues' then
     return {
       'sh',
@@ -654,7 +584,7 @@ end
 ---@param assignees string[]?
 ---@param milestone string?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, assignees, milestone, scope)
+function M:create_issue_cmd(title, body, labels, scope)
   local cmd = { 'gh', 'issue', 'create', '--title', title, '--body', body }
   local repo = nwo(scope)
   if repo ~= '' then
@@ -664,14 +594,6 @@ function M:create_issue_cmd(title, body, labels, assignees, milestone, scope)
   for _, l in ipairs(labels or {}) do
     table.insert(cmd, '--label')
     table.insert(cmd, l)
-  end
-  for _, a in ipairs(assignees or {}) do
-    table.insert(cmd, '--assignee')
-    table.insert(cmd, a)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
   end
   return cmd
 end

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -54,32 +54,6 @@ local function hostname(ref)
   return current and current.host or nil
 end
 
-local function diff_values(before, after)
-  local before_set = {}
-  for _, value in ipairs(before or {}) do
-    before_set[value] = true
-  end
-  local after_set = {}
-  for _, value in ipairs(after or {}) do
-    after_set[value] = true
-  end
-  local added = {}
-  for _, value in ipairs(after or {}) do
-    if not before_set[value] then
-      table.insert(added, value)
-      before_set[value] = true
-    end
-  end
-  local removed = {}
-  for _, value in ipairs(before or {}) do
-    if not after_set[value] then
-      table.insert(removed, value)
-      after_set[value] = true
-    end
-  end
-  return added, removed
-end
-
 ---@param state string
 ---@param limit integer?
 ---@return string[]
@@ -408,7 +382,7 @@ function M:update_pr_cmd(num, title, body, ref)
   return cmd
 end
 
-function M:update_issue_cmd(num, title, body, labels, assignees, milestone, original, ref)
+function M:update_issue_cmd(num, title, body, ref)
   local cmd = {
     'glab',
     'issue',
@@ -421,28 +395,6 @@ function M:update_issue_cmd(num, title, body, labels, assignees, milestone, orig
     '-R',
     repo_arg(ref),
   }
-  local added_labels, removed_labels = diff_values(original and original.labels or {}, labels)
-  if #added_labels > 0 then
-    table.insert(cmd, '--label')
-    table.insert(cmd, table.concat(added_labels, ','))
-  end
-  if #removed_labels > 0 then
-    table.insert(cmd, '--unlabel')
-    table.insert(cmd, table.concat(removed_labels, ','))
-  end
-  if assignees and #assignees > 0 then
-    table.insert(cmd, '--assignee')
-    table.insert(cmd, table.concat(assignees, ','))
-  elseif original and original.assignees and #original.assignees > 0 then
-    table.insert(cmd, '--unassign')
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
-  elseif original and original.milestone and original.milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, '')
-  end
   return cmd
 end
 
@@ -458,33 +410,16 @@ function M:parse_pr_details(json)
 end
 
 function M:parse_issue_details(json)
-  local labels = {}
-  for _, l in ipairs(json.labels or {}) do
-    table.insert(labels, type(l) == 'string' and l or '')
-  end
-  local assignees = {}
-  for _, a in ipairs(json.assignees or {}) do
-    table.insert(assignees, a.username or '')
-  end
-  local milestone = ''
-  if type(json.milestone) == 'table' and json.milestone.title then
-    milestone = json.milestone.title
-  end
   return {
     title = json.title or '',
     body = json.description or '',
-    labels = labels,
-    assignees = assignees,
-    milestone = milestone,
   }
 end
 
 ---@param field string
 ---@return string[]?
 function M:completion_cmd(field, ref)
-  if field == 'labels' then
-    return { 'sh', '-c', "glab label list -F json -R '" .. repo_arg(ref) .. "' | jq -r '.[].name'" }
-  elseif field == 'assignees' or field == 'mentions' then
+  if field == 'mentions' then
     return {
       'sh',
       '-c',
@@ -493,16 +428,6 @@ function M:completion_cmd(field, ref)
         .. " 'projects/"
         .. project(ref)
         .. "/members/all?per_page=100' | jq -r '.[].username'",
-    }
-  elseif field == 'milestone' then
-    return {
-      'sh',
-      '-c',
-      'glab api --hostname '
-        .. (hostname(ref) or 'gitlab.com')
-        .. " 'projects/"
-        .. project(ref)
-        .. "/milestones?state=active' | jq -r '.[].title'",
     }
   elseif field == 'issues' then
     return {
@@ -573,7 +498,7 @@ end
 ---@param assignees string[]?
 ---@param milestone string?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, assignees, milestone, ref)
+function M:create_issue_cmd(title, body, labels, ref)
   local cmd = {
     'glab',
     'issue',
@@ -589,14 +514,6 @@ function M:create_issue_cmd(title, body, labels, assignees, milestone, ref)
   if labels and #labels > 0 then
     table.insert(cmd, '--label')
     table.insert(cmd, table.concat(labels, ','))
-  end
-  for _, a in ipairs(assignees or {}) do
-    table.insert(cmd, '--assignee')
-    table.insert(cmd, a)
-  end
-  if milestone and milestone ~= '' then
-    table.insert(cmd, '--milestone')
-    table.insert(cmd, milestone)
   end
   return cmd
 end

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -49,9 +49,6 @@
 ---@class forge.IssueDetails
 ---@field title string
 ---@field body string
----@field labels string[]
----@field assignees string[]
----@field milestone string
 
 ---@class forge.CreatePROpts
 ---@field draft boolean?
@@ -163,8 +160,8 @@
 ---@field release_fields { tag: string, title: string, is_draft: string?, is_prerelease: string?, is_latest: string?, published_at: string }
 ---@field browse_release fun(self: forge.Forge, tag: string, scope?: forge.Scope)
 ---@field delete_release_cmd fun(self: forge.Forge, tag: string, scope?: forge.Scope): string[]
----@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, assignees: string[]?, milestone: string?, scope?: forge.Scope): string[]
----@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, labels: string[]?, assignees: string[]?, milestone: string?, original: forge.IssueDetails, scope?: forge.Scope): string[]
+---@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, scope?: forge.Scope): string[]
+---@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope): string[]
 ---@field issue_template_paths fun(self: forge.Forge): string[]
 ---@field create_issue_web_cmd (fun(self: forge.Forge, scope?: forge.Scope): string[]?)?
 ---@field create_issue_web_url (fun(self: forge.Forge, scope?: forge.Scope): string?)?

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -100,13 +100,11 @@ describe('compose issue create', function()
     local compose = require('forge.compose')
     local f = {
       name = 'github',
-      create_issue_cmd = function(_, title, body, labels, assignees, milestone, ref)
+      create_issue_cmd = function(_, title, body, labels, _assignees, _milestone, ref)
         captured.args = {
           title = title,
           body = body,
           labels = labels,
-          assignees = assignees,
-          milestone = milestone,
           ref = ref,
         }
         return { 'create-issue', title, body }
@@ -116,6 +114,10 @@ describe('compose issue create', function()
     compose.open_issue(f)
 
     local buf = vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    assert.is_false(vim.tbl_contains(lines, '  Labels: '))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
     vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# test issue' })
     vim.cmd('write')
 
@@ -127,13 +129,52 @@ describe('compose issue create', function()
       title = 'test issue',
       body = '',
       labels = {},
-      assignees = {},
-      milestone = '',
       ref = nil,
     }, captured.args)
     assert.equals(1, captured.cleared)
     assert.same({}, captured.warns)
     assert.same({}, captured.errors)
+  end)
+
+  it('keeps template labels without rendering editable metadata', function()
+    local compose = require('forge.compose')
+    local f = {
+      name = 'github',
+      create_issue_cmd = function(_, title, body, labels, _assignees, _milestone, ref)
+        captured.args = {
+          title = title,
+          body = body,
+          labels = labels,
+          ref = ref,
+        }
+        return { 'create-issue', title, body }
+      end,
+    }
+
+    compose.open_issue(f, {
+      title = 'template issue',
+      body = '',
+      labels = { 'bug' },
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    assert.is_false(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# template issue done' })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.args ~= nil and captured.cleared == 1
+    end)
+
+    assert.same({
+      title = 'template issue done',
+      body = '',
+      labels = { 'bug' },
+      ref = nil,
+    }, captured.args)
   end)
 
   it('submits issues when the clipboard register is unavailable', function()
@@ -272,7 +313,7 @@ describe('compose issue edit', function()
     vim.cmd('enew!')
   end)
 
-  it('submits issue edits with updated metadata and an empty body', function()
+  it('submits issue edits with an empty body', function()
     local compose = require('forge.compose')
     local original = {
       title = 'existing issue',
@@ -283,15 +324,21 @@ describe('compose issue edit', function()
     }
     local f = {
       name = 'github',
-      update_issue_cmd = function(_, num, title, body, labels, assignees, milestone, details, ref)
+      update_issue_cmd = function(
+        _,
+        num,
+        title,
+        body,
+        _labels,
+        _assignees,
+        _milestone,
+        _details,
+        ref
+      )
         captured.args = {
           num = num,
           title = title,
           body = body,
-          labels = labels,
-          assignees = assignees,
-          milestone = milestone,
-          details = details,
           ref = ref,
         }
         return { 'update-issue', num, title, body }
@@ -301,20 +348,11 @@ describe('compose issue edit', function()
     compose.open_issue_edit(f, '42', original)
 
     local buf = vim.api.nvim_get_current_buf()
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
-      '# updated issue',
-      '',
-      '',
-      '<!--',
-      '  Editing issue #42 via github.',
-      '',
-      '  Labels: bug, docs',
-      '  Assignees: alice, bob',
-      '  Milestone: v2',
-      '',
-      '  An empty title aborts editing.',
-      '-->',
-    })
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    assert.is_false(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: alice'))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: v1'))
+    vim.api.nvim_buf_set_lines(buf, 0, 3, false, { '# updated issue', '', '' })
     vim.cmd('write')
 
     vim.wait(100, function()
@@ -325,10 +363,6 @@ describe('compose issue edit', function()
       num = '42',
       title = 'updated issue',
       body = '',
-      labels = { 'bug', 'docs' },
-      assignees = { 'alice', 'bob' },
-      milestone = 'v2',
-      details = original,
       ref = nil,
     }, captured.args)
     assert.equals(1, captured.cleared)

--- a/spec/edit_issue_spec.lua
+++ b/spec/edit_issue_spec.lua
@@ -134,9 +134,6 @@ describe('edit_issue', function()
           return {
             title = json.title,
             body = json.body,
-            labels = { 'bug' },
-            assignees = { 'alice' },
-            milestone = 'v1',
           }
         end,
       }
@@ -212,9 +209,6 @@ describe('edit_issue', function()
       details = {
         title = 'Issue title',
         body = 'Issue body',
-        labels = { 'bug' },
-        assignees = { 'alice' },
-        milestone = 'v1',
       },
       scope = nil,
     }, captured.opened)

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -58,25 +58,25 @@ describe('github', function()
     assert.falsy(vim.tbl_contains(cmd, '--draft'))
   end)
 
-  it('builds issue detail and update commands with metadata diffs', function()
+  it('builds issue detail and simplified issue commands', function()
     local details = gh:fetch_issue_details_cmd('23', { repo_arg = 'owner/repo' })
     assert.same({ 'gh', 'issue', 'view', '23' }, vim.list_slice(details, 1, 4))
     assert.truthy(vim.tbl_contains(details, '--json'))
 
-    local cmd = gh:update_issue_cmd('23', 'title', 'body', { 'bug', 'docs' }, { 'alice' }, '', {
-      labels = { 'bug', 'help wanted' },
-      assignees = { 'bob' },
-      milestone = 'v1',
-    }, { repo_arg = 'owner/repo' })
-    assert.truthy(vim.tbl_contains(cmd, '--add-label'))
-    assert.truthy(vim.tbl_contains(cmd, 'docs'))
-    assert.truthy(vim.tbl_contains(cmd, '--remove-label'))
-    assert.truthy(vim.tbl_contains(cmd, 'help wanted'))
-    assert.truthy(vim.tbl_contains(cmd, '--add-assignee'))
-    assert.truthy(vim.tbl_contains(cmd, 'alice'))
-    assert.truthy(vim.tbl_contains(cmd, '--remove-assignee'))
-    assert.truthy(vim.tbl_contains(cmd, 'bob'))
-    assert.truthy(vim.tbl_contains(cmd, '--remove-milestone'))
+    local create = gh:create_issue_cmd('title', 'body', { 'bug' }, {
+      repo_arg = 'owner/repo',
+    })
+    assert.truthy(vim.tbl_contains(create, '--label'))
+    assert.truthy(vim.tbl_contains(create, 'bug'))
+    assert.falsy(vim.tbl_contains(create, '--assignee'))
+    assert.falsy(vim.tbl_contains(create, '--milestone'))
+
+    local cmd = gh:update_issue_cmd('23', 'title', 'body', { repo_arg = 'owner/repo' })
+    assert.falsy(vim.tbl_contains(cmd, '--add-label'))
+    assert.falsy(vim.tbl_contains(cmd, '--remove-label'))
+    assert.falsy(vim.tbl_contains(cmd, '--add-assignee'))
+    assert.falsy(vim.tbl_contains(cmd, '--remove-assignee'))
+    assert.falsy(vim.tbl_contains(cmd, '--remove-milestone'))
   end)
 
   it('adds draft flag to create_pr_cmd', function()
@@ -307,24 +307,26 @@ describe('gitlab', function()
     assert.truthy(vim.tbl_contains(cmd, '--yes'))
   end)
 
-  it('builds issue detail and update commands', function()
+  it('builds issue detail and simplified issue commands', function()
     local details = gl:fetch_issue_details_cmd('23', { repo_arg = 'group/repo' })
     assert.same(
       { 'glab', 'issue', 'view', '23', '--output', 'json' },
       vim.list_slice(details, 1, 6)
     )
 
-    local cmd = gl:update_issue_cmd('23', 'title', 'body', { 'bug', 'docs' }, {}, '', {
-      labels = { 'bug', 'help wanted' },
-      assignees = { 'bob' },
-      milestone = 'v1',
-    }, { repo_arg = 'group/repo' })
-    assert.truthy(vim.tbl_contains(cmd, '--label'))
-    assert.truthy(vim.tbl_contains(cmd, 'docs'))
-    assert.truthy(vim.tbl_contains(cmd, '--unlabel'))
-    assert.truthy(vim.tbl_contains(cmd, 'help wanted'))
-    assert.truthy(vim.tbl_contains(cmd, '--unassign'))
-    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    local create = gl:create_issue_cmd('title', 'body', { 'bug' }, {
+      repo_arg = 'group/repo',
+    })
+    assert.truthy(vim.tbl_contains(create, '--label'))
+    assert.truthy(vim.tbl_contains(create, 'bug'))
+    assert.falsy(vim.tbl_contains(create, '--assignee'))
+    assert.falsy(vim.tbl_contains(create, '--milestone'))
+
+    local cmd = gl:update_issue_cmd('23', 'title', 'body', { repo_arg = 'group/repo' })
+    assert.falsy(vim.tbl_contains(cmd, '--label'))
+    assert.falsy(vim.tbl_contains(cmd, '--unlabel'))
+    assert.falsy(vim.tbl_contains(cmd, '--unassign'))
+    assert.falsy(vim.tbl_contains(cmd, '--milestone'))
   end)
 
   it('returns correct pr_json_fields', function()
@@ -420,20 +422,22 @@ describe('codeberg', function()
     assert.truthy(default_cmd[3]:find('/repos/{owner}/{repo}', 1, true))
   end)
 
-  it('builds issue update commands for tea', function()
-    local cmd = cb:update_issue_cmd('23', 'title', 'body', { 'bug', 'docs' }, { 'alice' }, '', {
-      labels = { 'bug', 'help wanted' },
-      assignees = {},
-      milestone = 'v1',
-    }, { repo_arg = 'forgejo/tea-test' })
+  it('builds simplified issue commands for tea', function()
+    local create = cb:create_issue_cmd('title', 'body', { 'bug' }, {
+      repo_arg = 'forgejo/tea-test',
+    })
+    assert.same({ 'tea', 'issues', 'create', '--title', 'title' }, vim.list_slice(create, 1, 5))
+    assert.truthy(vim.tbl_contains(create, '--labels'))
+    assert.truthy(vim.tbl_contains(create, 'bug'))
+    assert.falsy(vim.tbl_contains(create, '--assignees'))
+    assert.falsy(vim.tbl_contains(create, '--milestone'))
+
+    local cmd = cb:update_issue_cmd('23', 'title', 'body', { repo_arg = 'forgejo/tea-test' })
     assert.same({ 'tea', 'issues', 'edit', '23' }, vim.list_slice(cmd, 1, 4))
-    assert.truthy(vim.tbl_contains(cmd, '--add-labels'))
-    assert.truthy(vim.tbl_contains(cmd, 'docs'))
-    assert.truthy(vim.tbl_contains(cmd, '--remove-labels'))
-    assert.truthy(vim.tbl_contains(cmd, 'help wanted'))
-    assert.truthy(vim.tbl_contains(cmd, '--add-assignees'))
-    assert.truthy(vim.tbl_contains(cmd, 'alice'))
-    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.falsy(vim.tbl_contains(cmd, '--add-labels'))
+    assert.falsy(vim.tbl_contains(cmd, '--remove-labels'))
+    assert.falsy(vim.tbl_contains(cmd, '--add-assignees'))
+    assert.falsy(vim.tbl_contains(cmd, '--milestone'))
   end)
 
   it('uses tea releases commands for release list and delete', function()


### PR DESCRIPTION
## Problem
Issue compose/edit still exposed labels, assignees, and milestone as inline comment metadata even after PR compose was simplified. That kept the compose buffer acting like a partial metadata form, with extra parsing, completion, backend plumbing, and documentation that were out of proportion to the value.

## Solution
This removes inline issue metadata editing from compose and edit buffers so they stay focused on title/body authoring. Template labels still flow through issue creation internally, while the issue update path, compose completion path, backend issue metadata plumbing, and related docs/tests are simplified to match the narrower scope.