### PR TITLE
docs: clarify optional picker workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,18 @@ without leaving your editor.
 
 - Neovim 0.10.0+
 - tree-sitter `yaml` parser for YAML issue form templates
-- [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive picker
-  workflows
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
+
+Optional:
+
+- [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive picker
+  workflows
+
+Direct `:Forge` action commands work without `fzf-lua`. Install it if you want
+the interactive picker UI opened by mappings such as `<Plug>(forge)` or
+`require('forge').open()`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ luarocks install forge.nvim
 ## Optional picker bindings
 
 Picker-style workflows are separate from the action-oriented `:Forge` command
-surface. For modern Neovim config, bind them with `require('forge').open()`
-or the provided `<Plug>` mappings:
+surface. For modern Neovim config, bind them with `require('forge').open()` or
+the provided `<Plug>` mappings:
 
 ```lua
 vim.keymap.set('n', '<leader>gg', function()

--- a/README.md
+++ b/README.md
@@ -41,6 +41,37 @@ Install with your package manager of choice or via
 luarocks install forge.nvim
 ```
 
+## Optional picker bindings
+
+Picker-style workflows are separate from the action-oriented `:Forge` command
+surface. For modern Neovim config, bind them with `require('forge').open()`
+or the provided `<Plug>` mappings:
+
+```lua
+vim.keymap.set('n', '<leader>gg', function()
+  require('forge').open()
+end, { desc = 'forge' })
+
+vim.keymap.set('n', '<leader>gp', function()
+  require('forge').open('prs')
+end, { desc = 'forge prs' })
+
+vim.keymap.set('n', '<leader>gi', function()
+  require('forge').open('issues')
+end, { desc = 'forge issues' })
+
+vim.keymap.set('n', '<leader>gc', function()
+  require('forge').open('ci')
+end, { desc = 'forge ci' })
+
+vim.keymap.set({ 'n', 'x' }, '<leader>gB', function()
+  require('forge').open('browse')
+end, { desc = 'forge browse' })
+```
+
+Use `:Forge` itself for direct action commands such as `:Forge pr create`,
+`:Forge pr checkout 123`, or `:Forge ci log 456`.
+
 ## Documentation
 
 ```vim

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -64,15 +64,15 @@ remote and delegates to the appropriate CLI (`gh`, `glab`, or `tea`).
 
 Requirements: ~
 - Neovim 0.10.0+
-- fzf-lua for interactive picker workflows
 - tree-sitter `yaml` parser
 - One or more forge CLIs:
   - `gh` for GitHub
   - `glab` for GitLab
   - `tea` for Codeberg/Gitea/Forgejo
+- Optional: `fzf-lua` for interactive picker workflows
 
-Direct `:Forge` action commands work without `fzf-lua`. The interactive picker
-surface requires it.
+Direct `:Forge` action commands work without `fzf-lua`. The built-in
+interactive picker surface requires it.
 
 Run |:checkhealth| forge to verify CLIs and dependencies.
 
@@ -1068,11 +1068,13 @@ Optional methods: ~
 
   Method                              Fallback ~
   `list_runs_json_cmd(branch?)`        `string[]` JSON CI list cmd.
-                                        If absent, `list_runs_cmd` is used
-                                        as a raw fzf-lua command source.
+                                        If absent, Forge reports that
+                                        structured CI data is unavailable
+                                        for that source.
   `checks_json_cmd(num)`               `string[]` JSON checks cmd.
-                                        If absent, `checks_cmd` string is
-                                        used as a raw fzf-lua command.
+                                        If absent, Forge reports that
+                                        structured checks are unavailable
+                                        for that source.
   `create_pr_web_cmd()`                `string[]?` cmd to open web PR
                                         creation. Return `nil` to no-op.
   `create_issue_web_cmd()`             `string[]?` cmd to open web issue

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -190,7 +190,8 @@ Top-level keys: ~
 
 `sections`                                             *forge-config-sections*
   `table<string, boolean>`  (default shown below)
-    Toggle root picker sections. Enabled sections appear in `:Forge`.
+    Toggle root picker sections. Enabled sections appear in the interactive
+    root picker opened by `require('forge').open()` or `<Plug>(forge)`.
 
   Defaults: >lua
       sections = {
@@ -552,6 +553,18 @@ Examples: >lua
     vim.keymap.set({'n', 'x'}, '<leader>gb', '<Plug>(forge-browse-contextual)')
 <
 
+Equivalent Lua bindings: >lua
+    vim.keymap.set('n', '<leader>gf', function()
+      require('forge').open()
+    end)
+    vim.keymap.set('n', '<leader>gP', function()
+      require('forge').open('prs')
+    end)
+    vim.keymap.set({'n', 'x'}, '<leader>gb', function()
+      require('forge').open('browse')
+    end)
+<
+
 Alias plugs call `require('forge').open()` with the section name (`"prs"`,
 `"issues"`, etc.), so they respect `vim.g.forge.routes`. Exact route plugs
 call `require('forge').open()` with the full route name and ignore route
@@ -564,7 +577,7 @@ include the selected line range just like |:Forge-browse|.
 Alias plugs: ~
                                                             *forge-plug-alias*
   Mapping                          Modes      Action ~
-  `<Plug>(forge)`                    `n`        Open the root picker
+  `<Plug>(forge)`                    `n`        Open the root workflow surface
   `<Plug>(forge-prs)`                `n`        Open the configured `prs`
                                               section route
   `<Plug>(forge-issues)`             `n`        Open the configured `issues`
@@ -729,19 +742,17 @@ prerelease badges are shown for forges that support them (GitHub, Codeberg).
 ==============================================================================
 WORKFLOW SURFACE                                              *forge-workflow*
 
-`:Forge` is a workflow surface, not just a route list. The root picker uses
-label-only entries so the top level stays compact, while the nested pickers
-and help docs carry the workflow detail.
+The interactive workflow surface is separate from the action-oriented `:Forge`
+command interface. Open it with `<Plug>(forge)` or
+`require('forge').open()`. The root picker uses label-only entries so the top
+level stays compact, while nested pickers and help docs carry the workflow
+detail.
 
 Architecture: ~
 - Interactive root entries go through `require('forge.client').open_root()`.
 - Nested pickers go through `require('forge.picker').pick()`.
 - `require('forge.client').register()` can replace the root workflow surface.
 - Nested pickers use the built-in `fzf-lua` adapter.
-
-The interactive workflow surface is separate from `:Forge`. Use mappings such
-as `<Plug>(forge)` or Lua entrypoints such as `require('forge').open()` to
-launch it.
 
 Default root route inventory: ~
   `PRs` -> `prs.open`


### PR DESCRIPTION
## Problem

The docs still mixed together the action-oriented `:Forge` command surface and the optional interactive picker entrypoints. That left stale wording in vimdoc and README examples that no longer matched the `require('forge').open(...)` / `<Plug>` workflow after `:Forge` became action-only.

## Solution

Clarify that `fzf-lua` is optional for direct `:Forge` action commands but required for the interactive picker surface, add modern picker-binding examples using `require('forge').open(...)`, and update the vimdoc workflow-surface language so it consistently points users to the picker entrypoints instead of `:Forge`.