### PR TITLE
refactor(plug): define public mapping surface

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -545,10 +545,13 @@ PLUG MAPPINGS                                                     *forge-plug*
 
 forge.nvim exposes stateless |<Plug>| mappings for root launchers, exact
 routes, and configurable section aliases. They are intended
-for user-defined mappings and do not add any additional Ex commands.
+for user-defined mappings and do not add any additional Ex commands. The
+public `<Plug>` surface contains only the root launcher, one plug per
+configurable section alias, and one plug per exact no-argument route.
 
 Examples: >lua
     vim.keymap.set('n', '<leader>gf', '<Plug>(forge)')
+    vim.keymap.set('n', '<leader>gp', '<Plug>(forge-prs)')
     vim.keymap.set('n', '<leader>gP', '<Plug>(forge-prs-open)')
     vim.keymap.set({'n', 'x'}, '<leader>gb', '<Plug>(forge-browse-contextual)')
 <
@@ -557,18 +560,22 @@ Equivalent Lua bindings: >lua
     vim.keymap.set('n', '<leader>gf', function()
       require('forge').open()
     end)
-    vim.keymap.set('n', '<leader>gP', function()
+    vim.keymap.set('n', '<leader>gp', function()
       require('forge').open('prs')
     end)
+    vim.keymap.set('n', '<leader>gP', function()
+      require('forge').open('prs.open')
+    end)
     vim.keymap.set({'n', 'x'}, '<leader>gb', function()
-      require('forge').open('browse')
+      require('forge').open('browse.contextual')
     end)
 <
 
 Alias plugs call `require('forge').open()` with the section name (`"prs"`,
 `"issues"`, etc.), so they respect `vim.g.forge.routes`. Exact route plugs
 call `require('forge').open()` with the full route name and ignore route
-aliases.
+aliases. Exact-route plug names follow the route name with `.` replaced by
+`-`.
 
 `<Plug>(forge-browse)` and `<Plug>(forge-browse-contextual)` are available in
 normal and visual mode. When invoked in visual mode, contextual browse targets

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -8,9 +8,18 @@ local function open_route(route)
   end
 end
 
-set_plug('n', 'forge', open_route(nil))
+local section_plugs = {
+  { 'n', 'forge-prs', 'prs' },
+  { 'n', 'forge-issues', 'issues' },
+  { 'n', 'forge-ci', 'ci' },
+  { { 'n', 'x' }, 'forge-browse', 'browse' },
+  { 'n', 'forge-releases', 'releases' },
+  { 'n', 'forge-branches', 'branches' },
+  { 'n', 'forge-commits', 'commits' },
+  { 'n', 'forge-worktrees', 'worktrees' },
+}
 
-for _, spec in ipairs({
+local exact_route_plugs = {
   { 'n', 'forge-prs-open', 'prs.open' },
   { 'n', 'forge-prs-closed', 'prs.closed' },
   { 'n', 'forge-prs-all', 'prs.all' },
@@ -28,15 +37,15 @@ for _, spec in ipairs({
   { 'n', 'forge-branches-local', 'branches.local' },
   { 'n', 'forge-commits-current-branch', 'commits.current_branch' },
   { 'n', 'forge-worktrees-list', 'worktrees.list' },
-  { 'n', 'forge-prs', 'prs' },
-  { 'n', 'forge-issues', 'issues' },
-  { 'n', 'forge-ci', 'ci' },
-  { { 'n', 'x' }, 'forge-browse', 'browse' },
-  { 'n', 'forge-releases', 'releases' },
-  { 'n', 'forge-branches', 'branches' },
-  { 'n', 'forge-commits', 'commits' },
-  { 'n', 'forge-worktrees', 'worktrees' },
-}) do
+}
+
+set_plug('n', 'forge', open_route(nil))
+
+for _, spec in ipairs(section_plugs) do
+  set_plug(spec[1], spec[2], open_route(spec[3]))
+end
+
+for _, spec in ipairs(exact_route_plugs) do
   set_plug(spec[1], spec[2], open_route(spec[3]))
 end
 

--- a/spec/plug_mappings_spec.lua
+++ b/spec/plug_mappings_spec.lua
@@ -8,9 +8,53 @@ local function mapping(lhs, mode)
   return vim.fn.maparg(lhs, mode, false, true)
 end
 
+local function listed_plugs(mode)
+  local names = {}
+
+  for _, map in ipairs(vim.api.nvim_get_keymap(mode)) do
+    if map.lhs:match('^<Plug>%(') and map.lhs:match('^<Plug>%(forge') then
+      names[#names + 1] = map.lhs
+    end
+  end
+
+  table.sort(names)
+  return names
+end
+
 describe('<Plug> mappings', function()
   local captured
   local old_preload
+
+  local exact_route_plugs = {
+    { '<Plug>(forge-prs-open)', 'prs.open' },
+    { '<Plug>(forge-prs-closed)', 'prs.closed' },
+    { '<Plug>(forge-prs-all)', 'prs.all' },
+    { '<Plug>(forge-issues-open)', 'issues.open' },
+    { '<Plug>(forge-issues-closed)', 'issues.closed' },
+    { '<Plug>(forge-issues-all)', 'issues.all' },
+    { '<Plug>(forge-ci-current-branch)', 'ci.current_branch' },
+    { '<Plug>(forge-ci-all)', 'ci.all' },
+    { '<Plug>(forge-browse-contextual)', 'browse.contextual' },
+    { '<Plug>(forge-browse-branch)', 'browse.branch' },
+    { '<Plug>(forge-browse-commit)', 'browse.commit' },
+    { '<Plug>(forge-releases-all)', 'releases.all' },
+    { '<Plug>(forge-releases-draft)', 'releases.draft' },
+    { '<Plug>(forge-releases-prerelease)', 'releases.prerelease' },
+    { '<Plug>(forge-branches-local)', 'branches.local' },
+    { '<Plug>(forge-commits-current-branch)', 'commits.current_branch' },
+    { '<Plug>(forge-worktrees-list)', 'worktrees.list' },
+  }
+
+  local section_plugs = {
+    { '<Plug>(forge-prs)', 'prs' },
+    { '<Plug>(forge-issues)', 'issues' },
+    { '<Plug>(forge-ci)', 'ci' },
+    { '<Plug>(forge-browse)', 'browse' },
+    { '<Plug>(forge-releases)', 'releases' },
+    { '<Plug>(forge-branches)', 'branches' },
+    { '<Plug>(forge-commits)', 'commits' },
+    { '<Plug>(forge-worktrees)', 'worktrees' },
+  }
 
   local function stub_forge()
     package.preload['forge'] = function()
@@ -49,24 +93,11 @@ describe('<Plug> mappings', function()
 
     local expected = {
       { '<Plug>(forge)', vim.NIL },
-      { '<Plug>(forge-prs-open)', 'prs.open' },
-      { '<Plug>(forge-prs-closed)', 'prs.closed' },
-      { '<Plug>(forge-prs-all)', 'prs.all' },
-      { '<Plug>(forge-issues-open)', 'issues.open' },
-      { '<Plug>(forge-issues-closed)', 'issues.closed' },
-      { '<Plug>(forge-issues-all)', 'issues.all' },
-      { '<Plug>(forge-ci-current-branch)', 'ci.current_branch' },
-      { '<Plug>(forge-ci-all)', 'ci.all' },
-      { '<Plug>(forge-browse-contextual)', 'browse.contextual' },
-      { '<Plug>(forge-browse-branch)', 'browse.branch' },
-      { '<Plug>(forge-browse-commit)', 'browse.commit' },
-      { '<Plug>(forge-releases-all)', 'releases.all' },
-      { '<Plug>(forge-releases-draft)', 'releases.draft' },
-      { '<Plug>(forge-releases-prerelease)', 'releases.prerelease' },
-      { '<Plug>(forge-branches-local)', 'branches.local' },
-      { '<Plug>(forge-commits-current-branch)', 'commits.current_branch' },
-      { '<Plug>(forge-worktrees-list)', 'worktrees.list' },
     }
+
+    for _, item in ipairs(exact_route_plugs) do
+      expected[#expected + 1] = item
+    end
 
     for _, item in ipairs(expected) do
       local map = mapping(item[1], 'n')
@@ -83,16 +114,7 @@ describe('<Plug> mappings', function()
   it('defines section alias plugs in normal mode', function()
     stub_forge()
 
-    local expected = {
-      { '<Plug>(forge-prs)', 'prs' },
-      { '<Plug>(forge-issues)', 'issues' },
-      { '<Plug>(forge-ci)', 'ci' },
-      { '<Plug>(forge-browse)', 'browse' },
-      { '<Plug>(forge-releases)', 'releases' },
-      { '<Plug>(forge-branches)', 'branches' },
-      { '<Plug>(forge-commits)', 'commits' },
-      { '<Plug>(forge-worktrees)', 'worktrees' },
-    }
+    local expected = vim.deepcopy(section_plugs)
 
     for _, item in ipairs(expected) do
       local map = mapping(item[1], 'n')
@@ -131,5 +153,27 @@ describe('<Plug> mappings', function()
     assert.equals('V', captured.calls[2].mode)
     assert.equals(1, captured.calls[2].line_v)
     assert.equals(2, captured.calls[2].line)
+  end)
+
+  it('exposes only root, section alias, and exact-route forge plugs', function()
+    local normal_expected = { '<Plug>(forge)' }
+    local visual_expected = {
+      '<Plug>(forge-browse)',
+      '<Plug>(forge-browse-contextual)',
+    }
+
+    for _, item in ipairs(section_plugs) do
+      normal_expected[#normal_expected + 1] = item[1]
+    end
+
+    for _, item in ipairs(exact_route_plugs) do
+      normal_expected[#normal_expected + 1] = item[1]
+    end
+
+    table.sort(normal_expected)
+    table.sort(visual_expected)
+
+    assert.same(normal_expected, listed_plugs('n'))
+    assert.same(visual_expected, listed_plugs('x'))
   end)
 end)


### PR DESCRIPTION
## Problem

forge.nvim exposed useful `<Plug>` mappings, but the public surface was not explicitly defined as a policy. That made it easier for ad hoc mappings or mismatched docs examples to creep in, especially between section-alias plugs and exact-route plugs.

## Solution

Define the `<Plug>` API around the interactive picker surface only: the root launcher, one plug per configurable section alias, and one plug per exact no-argument route. Restructure the implementation and specs around those categories, and update vimdoc examples so alias plugs and exact-route plugs map to the correct `require('forge').open(...)` targets.