### PR TITLE
fix(compose): restore readonly metadata extraction

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -358,18 +358,50 @@ end
 ---@param json table
 ---@return forge.PRDetails
 function M:parse_pr_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, l.name or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.login or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
   return {
     title = json.title or '',
     body = json.body or '',
+    draft = false,
     head_branch = type(json.head) == 'table' and (json.head.ref or '') or json.head or '',
     base_branch = type(json.base) == 'table' and (json.base.ref or '') or json.base or '',
+    labels = labels,
+    assignees = assignees,
+    reviewers = {},
+    milestone = milestone,
   }
 end
 
 function M:parse_issue_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, l.name or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.login or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
   return {
     title = json.title or '',
     body = json.body or '',
+    labels = labels,
+    assignees = assignees,
+    milestone = milestone,
   }
 end
 
@@ -416,8 +448,6 @@ end
 ---@param title string
 ---@param body string
 ---@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
 function M:create_issue_cmd(title, body, labels, ref)
   local cmd =

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -79,17 +79,89 @@ local function set_clipboard(text)
   end
 end
 
+local function is_comment_opener(line)
+  return vim.trim(line or '') == '<!--'
+end
+
+local function is_comment_closer(line)
+  return vim.trim(line or '') == '-->'
+end
+
 ---@param buf_lines string[]
 ---@return string[] content_lines
 local function extract_content(buf_lines)
   local content_lines = {}
   for _, l in ipairs(buf_lines) do
-    if l:match('^<!--') then
+    if is_comment_opener(l) then
       break
     end
     table.insert(content_lines, l)
   end
   return content_lines
+end
+
+local function parse_comment_metadata(buf_lines)
+  local in_comment = false
+  local meta = { labels = {}, assignees = {}, milestone = '', draft = false, reviewers = {} }
+  for _, l in ipairs(buf_lines) do
+    if is_comment_opener(l) then
+      in_comment = true
+    elseif is_comment_closer(l) then
+      break
+    elseif in_comment then
+      local draft = l:match('^%s*Draft:%s*(.*)$')
+      if draft then
+        draft = vim.trim(draft):lower()
+        meta.draft = draft == 'yes' or draft == 'true'
+      end
+
+      local reviewers = l:match('^%s*Reviewers:%s*(.*)$')
+      if reviewers then
+        for reviewer in vim.trim(reviewers):gmatch('[^,%s]+') do
+          table.insert(meta.reviewers, reviewer)
+        end
+      end
+
+      local labels = l:match('^%s*Labels:%s*(.*)$')
+      if labels then
+        for label in vim.trim(labels):gmatch('[^,%s]+') do
+          table.insert(meta.labels, label)
+        end
+      end
+
+      local assignees = l:match('^%s*Assignees:%s*(.*)$')
+      if assignees then
+        for assignee in vim.trim(assignees):gmatch('[^,%s]+') do
+          table.insert(meta.assignees, assignee)
+        end
+      end
+
+      local milestone = l:match('^%s*Milestone:%s*(.*)$')
+      if milestone then
+        meta.milestone = vim.trim(milestone)
+      end
+    end
+  end
+  return meta
+end
+
+local function extract_submission(buf_lines)
+  local content_lines = extract_content(buf_lines)
+  return {
+    title = vim.trim((content_lines[1] or ''):gsub('^#+ *', '')),
+    body = vim.trim(table.concat(content_lines, '\n', 3)),
+    metadata = parse_comment_metadata(buf_lines),
+  }
+end
+
+local function add_metadata_line(builder, label, value, value_hl)
+  local prefix = '  ' .. label .. ': '
+  local ln = builder:add_line('%s%s', prefix, value or '')
+  builder:mark(ln, 2, #label, 'ForgeComposeLabel')
+  if value_hl and value and value ~= '' then
+    builder:mark(ln, #prefix, #value, value_hl)
+  end
+  return ln
 end
 
 ---@param f forge.Forge
@@ -101,7 +173,18 @@ end
 ---@param buf integer?
 ---@param ref? forge.Scope
 ---@param push_target string?
-local function push_and_create(f, branch, title, body, pr_base, pr_draft, buf, ref, push_target)
+local function push_and_create(
+  f,
+  branch,
+  title,
+  body,
+  pr_base,
+  pr_draft,
+  buf,
+  ref,
+  push_target,
+  metadata
+)
   local log = require('forge.logger')
   log.info('pushing and creating ' .. f.labels.pr_one .. '...')
   vim.system(
@@ -119,7 +202,7 @@ local function push_and_create(f, branch, title, body, pr_base, pr_draft, buf, r
         return
       end
       vim.system(
-        f:create_pr_cmd(title, body, pr_base, pr_draft, ref),
+        f:create_pr_cmd(title, body, pr_base, pr_draft, ref, metadata),
         { text = true },
         function(create_result)
           vim.schedule(function()
@@ -151,40 +234,44 @@ local function push_and_create(f, branch, title, body, pr_base, pr_draft, buf, r
   )
 end
 
-local function submit_issue(f, title, body, labels, buf, ref)
+local function submit_issue(f, title, body, labels, buf, ref, metadata)
   local log = require('forge.logger')
   log.info('creating issue...')
-  vim.system(f:create_issue_cmd(title, body, labels, ref), { text = true }, function(result)
-    vim.schedule(function()
-      if result.code == 0 then
-        local url = vim.trim(result.stdout or '')
-        if url ~= '' then
-          set_clipboard(url)
+  vim.system(
+    f:create_issue_cmd(title, body, labels, ref, metadata),
+    { text = true },
+    function(result)
+      vim.schedule(function()
+        if result.code == 0 then
+          local url = vim.trim(result.stdout or '')
+          if url ~= '' then
+            set_clipboard(url)
+          end
+          log.info(('created issue -> %s'):format(url))
+          require('forge').clear_list()
+          if buf and vim.api.nvim_buf_is_valid(buf) then
+            vim.bo[buf].modified = false
+            vim.api.nvim_buf_delete(buf, { force = true })
+          end
+        else
+          local msg = vim.trim(result.stderr or '')
+          if msg == '' then
+            msg = vim.trim(result.stdout or '')
+          end
+          if msg == '' then
+            msg = 'creation failed'
+          end
+          log.error(msg)
         end
-        log.info(('created issue -> %s'):format(url))
-        require('forge').clear_list()
-        if buf and vim.api.nvim_buf_is_valid(buf) then
-          vim.bo[buf].modified = false
-          vim.api.nvim_buf_delete(buf, { force = true })
-        end
-      else
-        local msg = vim.trim(result.stderr or '')
-        if msg == '' then
-          msg = vim.trim(result.stdout or '')
-        end
-        if msg == '' then
-          msg = 'creation failed'
-        end
-        log.error(msg)
-      end
-    end)
-  end)
+      end)
+    end
+  )
 end
 
-local function update_issue(f, num, title, body, buf, ref)
+local function update_issue(f, num, title, body, buf, ref, metadata)
   local log = require('forge.logger')
   log.info('updating issue #' .. num .. '...')
-  vim.system(f:update_issue_cmd(num, title, body, ref), { text = true }, function(result)
+  vim.system(f:update_issue_cmd(num, title, body, ref, metadata), { text = true }, function(result)
     vim.schedule(function()
       if result.code == 0 then
         log.info(('updated issue #%s'):format(num))
@@ -239,6 +326,10 @@ function M.open_issue(f, result, ref)
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
+  add_metadata_line(b, 'Labels', table.concat(template_labels, ', '))
+  add_metadata_line(b, 'Assignees', '')
+  add_metadata_line(b, 'Milestone', '')
+  b:add_line('')
   add_discard_hints(b)
   b:add_line('  An empty title aborts creation.')
   b:add_line('-->')
@@ -249,8 +340,8 @@ function M.open_issue(f, result, ref)
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local content_lines = extract_content(buf_lines)
-      local issue_title = vim.trim((content_lines[1] or ''):gsub('^#+ *', ''))
+      local submission = extract_submission(buf_lines)
+      local issue_title = submission.title
 
       local log = require('forge.logger')
       if
@@ -262,7 +353,7 @@ function M.open_issue(f, result, ref)
         vim.api.nvim_buf_delete(buf, { force = true })
         return
       end
-      local issue_body = vim.trim(table.concat(content_lines, '\n', 3))
+      local issue_body = submission.body
       if body ~= '' and template.normalize_body(issue_body) == template.normalize_body(body) then
         log.warn('aborting: body unchanged from template')
         vim.bo[buf].modified = false
@@ -270,7 +361,7 @@ function M.open_issue(f, result, ref)
         return
       end
 
-      submit_issue(f, issue_title, issue_body, template_labels, buf, ref)
+      submit_issue(f, issue_title, issue_body, template_labels, buf, ref, submission.metadata)
     end,
   })
 
@@ -303,6 +394,10 @@ function M.open_issue_edit(f, num, details, ref)
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
+  add_metadata_line(b, 'Labels', table.concat(details.labels or {}, ', '))
+  add_metadata_line(b, 'Assignees', table.concat(details.assignees or {}, ', '))
+  add_metadata_line(b, 'Milestone', details.milestone or '')
+  b:add_line('')
   add_discard_hints(b)
   b:add_line('  An empty title aborts editing.')
   b:add_line('-->')
@@ -313,8 +408,8 @@ function M.open_issue_edit(f, num, details, ref)
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local content_lines = extract_content(buf_lines)
-      local issue_title = vim.trim((content_lines[1] or ''):gsub('^#+ *', ''))
+      local submission = extract_submission(buf_lines)
+      local issue_title = submission.title
 
       local log = require('forge.logger')
       if issue_title == '' then
@@ -324,8 +419,7 @@ function M.open_issue_edit(f, num, details, ref)
         return
       end
 
-      local issue_body = vim.trim(table.concat(content_lines, '\n', 3))
-      update_issue(f, num, issue_title, issue_body, buf, ref)
+      update_issue(f, num, issue_title, submission.body, buf, ref, submission.metadata)
     end,
   })
 
@@ -382,6 +476,18 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   b:mark(ln, 2, #creating_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
+  b:add_line('')
+  if f.capabilities and f.capabilities.draft then
+    local draft_val = draft and 'true' or 'false'
+    add_metadata_line(b, 'Draft', draft_val, draft and 'ForgeComposeDraft' or 'ForgeDim')
+  end
+  if f.capabilities and f.capabilities.reviewers then
+    add_metadata_line(b, 'Reviewers', '')
+  end
+  add_metadata_line(b, 'Labels', '')
+  add_metadata_line(b, 'Assignees', '')
+  add_metadata_line(b, 'Milestone', '')
+
   local stat_start, stat_end
   if diff_stat ~= '' then
     b:add_line('')
@@ -435,8 +541,8 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local content_lines = extract_content(buf_lines)
-      local pr_title = vim.trim((content_lines[1] or ''):gsub('^#+ *', ''))
+      local submission = extract_submission(buf_lines)
+      local pr_title = submission.title
 
       local log = require('forge.logger')
       if pr_title == '' then
@@ -445,7 +551,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
         vim.api.nvim_buf_delete(buf, { force = true })
         return
       end
-      local pr_body = vim.trim(table.concat(content_lines, '\n', 3))
+      local pr_body = submission.body
       if pr_body == '' then
         log.warn('aborting: empty body')
         vim.bo[buf].modified = false
@@ -459,7 +565,18 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
         return
       end
 
-      push_and_create(f, branch, pr_title, pr_body, base, draft, buf, ref, push_target)
+      push_and_create(
+        f,
+        branch,
+        pr_title,
+        pr_body,
+        base,
+        draft,
+        buf,
+        ref,
+        push_target,
+        submission.metadata
+      )
     end,
   })
 
@@ -467,6 +584,10 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   vim.cmd('normal! v$h')
   vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-G>', true, false, true), 'n', false)
 end
+
+M._extract_content = extract_content
+M._parse_comment_metadata = parse_comment_metadata
+M._extract_submission = extract_submission
 
 M.push_and_create = push_and_create
 
@@ -476,10 +597,10 @@ M.push_and_create = push_and_create
 ---@param body string
 ---@param buf integer?
 ---@param ref? forge.Scope
-local function update_pr(f, num, title, body, buf, ref)
+local function update_pr(f, num, title, body, buf, ref, metadata)
   local log = require('forge.logger')
   log.info('updating ' .. f.labels.pr_one .. ' #' .. num .. '...')
-  vim.system(f:update_pr_cmd(num, title, body, ref), { text = true }, function(result)
+  vim.system(f:update_pr_cmd(num, title, body, ref, metadata), { text = true }, function(result)
     vim.schedule(function()
       if result.code ~= 0 then
         local msg = vim.trim(result.stderr or '')
@@ -545,6 +666,18 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
   b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
+  b:add_line('')
+  if f.capabilities and f.capabilities.draft then
+    local draft_val = details.draft and 'true' or 'false'
+    add_metadata_line(b, 'Draft', draft_val, details.draft and 'ForgeComposeDraft' or 'ForgeDim')
+  end
+  if f.capabilities and f.capabilities.reviewers then
+    add_metadata_line(b, 'Reviewers', table.concat(details.reviewers or {}, ', '))
+  end
+  add_metadata_line(b, 'Labels', table.concat(details.labels or {}, ', '))
+  add_metadata_line(b, 'Assignees', table.concat(details.assignees or {}, ', '))
+  add_metadata_line(b, 'Milestone', details.milestone or '')
+
   local stat_start, stat_end
   if diff_stat ~= '' then
     b:add_line('')
@@ -598,8 +731,8 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local content_lines = extract_content(buf_lines)
-      local pr_title = vim.trim((content_lines[1] or ''):gsub('^#+ *', ''))
+      local submission = extract_submission(buf_lines)
+      local pr_title = submission.title
 
       local log = require('forge.logger')
       if pr_title == '' then
@@ -608,7 +741,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
         vim.api.nvim_buf_delete(buf, { force = true })
         return
       end
-      local pr_body = vim.trim(table.concat(content_lines, '\n', 3))
+      local pr_body = submission.body
       if pr_body == '' then
         log.warn('aborting: empty body')
         vim.bo[buf].modified = false
@@ -616,7 +749,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
         return
       end
 
-      update_pr(f, num, pr_title, pr_body, buf, ref)
+      update_pr(f, num, pr_title, pr_body, buf, ref, submission.metadata)
     end,
   })
 

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -449,7 +449,7 @@ function M:fetch_pr_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,headRefName,baseRefName,url',
+    'title,body,isDraft,headRefName,baseRefName,labels,assignees,reviewRequests,milestone,url',
   }
 end
 
@@ -462,7 +462,7 @@ function M:fetch_issue_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,url',
+    'title,body,labels,assignees,milestone,url',
   }
 end
 
@@ -493,18 +493,54 @@ end
 ---@param json table
 ---@return forge.PRDetails
 function M:parse_pr_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, l.name or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.login or '')
+  end
+  local reviewers = {}
+  for _, r in ipairs(json.reviewRequests or {}) do
+    table.insert(reviewers, r.login or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
   return {
     title = json.title or '',
     body = json.body or '',
+    draft = json.isDraft == true,
     head_branch = json.headRefName or '',
     base_branch = json.baseRefName or '',
+    labels = labels,
+    assignees = assignees,
+    reviewers = reviewers,
+    milestone = milestone,
   }
 end
 
 function M:parse_issue_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, l.name or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.login or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
   return {
     title = json.title or '',
     body = json.body or '',
+    labels = labels,
+    assignees = assignees,
+    milestone = milestone,
   }
 end
 
@@ -561,8 +597,6 @@ end
 ---@param title string
 ---@param body string
 ---@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
 function M:create_issue_cmd(title, body, labels, scope)
   local cmd = { 'gh', 'issue', 'create', '--title', title, '--body', body }

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -401,18 +401,54 @@ end
 ---@param json table
 ---@return forge.PRDetails
 function M:parse_pr_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, type(l) == 'string' and l or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.username or '')
+  end
+  local reviewers = {}
+  for _, r in ipairs(json.reviewers or {}) do
+    table.insert(reviewers, r.username or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
   return {
     title = json.title or '',
     body = json.description or '',
+    draft = json.draft == true,
     head_branch = json.source_branch or '',
     base_branch = json.target_branch or '',
+    labels = labels,
+    assignees = assignees,
+    reviewers = reviewers,
+    milestone = milestone,
   }
 end
 
 function M:parse_issue_details(json)
+  local labels = {}
+  for _, l in ipairs(json.labels or {}) do
+    table.insert(labels, type(l) == 'string' and l or '')
+  end
+  local assignees = {}
+  for _, a in ipairs(json.assignees or {}) do
+    table.insert(assignees, a.username or '')
+  end
+  local milestone = ''
+  if type(json.milestone) == 'table' and json.milestone.title then
+    milestone = json.milestone.title
+  end
   return {
     title = json.title or '',
     body = json.description or '',
+    labels = labels,
+    assignees = assignees,
+    milestone = milestone,
   }
 end
 
@@ -467,8 +503,6 @@ end
 ---@param title string
 ---@param body string
 ---@param labels string[]?
----@param assignees string[]?
----@param milestone string?
 ---@return string[]
 function M:create_issue_cmd(title, body, labels, ref)
   local cmd = {

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -43,12 +43,27 @@
 ---@class forge.PRDetails
 ---@field title string
 ---@field body string
+---@field draft boolean?
 ---@field head_branch string
 ---@field base_branch string
+---@field labels string[]?
+---@field assignees string[]?
+---@field reviewers string[]?
+---@field milestone string?
 
 ---@class forge.IssueDetails
 ---@field title string
 ---@field body string
+---@field labels string[]?
+---@field assignees string[]?
+---@field milestone string?
+
+---@class forge.CommentMetadata
+---@field labels string[]
+---@field assignees string[]
+---@field milestone string
+---@field draft boolean
+---@field reviewers string[]
 
 ---@class forge.CreatePROpts
 ---@field draft boolean?
@@ -102,6 +117,7 @@
 
 ---@class forge.Capabilities
 ---@field draft boolean
+---@field reviewers boolean
 ---@field per_pr_checks boolean
 ---@field ci_json boolean
 
@@ -144,8 +160,8 @@
 ---@field close_issue_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field reopen_issue_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field draft_toggle_cmd fun(self: forge.Forge, num: string, is_draft: boolean, scope?: forge.Scope): string[]?
----@field create_pr_cmd fun(self: forge.Forge, title: string, body: string, base: string, draft: boolean, scope?: forge.Scope): string[]
----@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope): string[]
+---@field create_pr_cmd fun(self: forge.Forge, title: string, body: string, base: string, draft: boolean, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
+---@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
 ---@field fetch_pr_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field parse_pr_details fun(self: forge.Forge, json: table): forge.PRDetails
 ---@field fetch_issue_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
@@ -159,8 +175,8 @@
 ---@field release_fields { tag: string, title: string, is_draft: string?, is_prerelease: string?, is_latest: string?, published_at: string }
 ---@field browse_release fun(self: forge.Forge, tag: string, scope?: forge.Scope)
 ---@field delete_release_cmd fun(self: forge.Forge, tag: string, scope?: forge.Scope): string[]
----@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, scope?: forge.Scope): string[]
----@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope): string[]
+---@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
+---@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
 ---@field issue_template_paths fun(self: forge.Forge): string[]
 ---@field create_issue_web_cmd (fun(self: forge.Forge, scope?: forge.Scope): string[]?)?
 ---@field create_issue_web_url (fun(self: forge.Forge, scope?: forge.Scope): string?)?

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -100,12 +100,13 @@ describe('compose issue create', function()
     local compose = require('forge.compose')
     local f = {
       name = 'github',
-      create_issue_cmd = function(_, title, body, labels, _assignees, _milestone, ref)
+      create_issue_cmd = function(_, title, body, labels, ref, metadata)
         captured.args = {
           title = title,
           body = body,
           labels = labels,
           ref = ref,
+          metadata = metadata,
         }
         return { 'create-issue', title, body }
       end,
@@ -115,9 +116,9 @@ describe('compose issue create', function()
 
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    assert.is_false(vim.tbl_contains(lines, '  Labels: '))
-    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
-    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
+    assert.is_true(vim.tbl_contains(lines, '  Labels: '))
+    assert.is_true(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_true(vim.tbl_contains(lines, '  Milestone: '))
     vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# test issue' })
     vim.cmd('write')
 
@@ -130,6 +131,13 @@ describe('compose issue create', function()
       body = '',
       labels = {},
       ref = nil,
+      metadata = {
+        labels = {},
+        assignees = {},
+        milestone = '',
+        draft = false,
+        reviewers = {},
+      },
     }, captured.args)
     assert.equals(1, captured.cleared)
     assert.same({}, captured.warns)
@@ -140,12 +148,13 @@ describe('compose issue create', function()
     local compose = require('forge.compose')
     local f = {
       name = 'github',
-      create_issue_cmd = function(_, title, body, labels, _assignees, _milestone, ref)
+      create_issue_cmd = function(_, title, body, labels, ref, metadata)
         captured.args = {
           title = title,
           body = body,
           labels = labels,
           ref = ref,
+          metadata = metadata,
         }
         return { 'create-issue', title, body }
       end,
@@ -159,9 +168,7 @@ describe('compose issue create', function()
 
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    assert.is_false(vim.tbl_contains(lines, '  Labels: bug'))
-    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
-    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
+    assert.is_true(vim.tbl_contains(lines, '  Labels: bug'))
     vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# template issue done' })
     vim.cmd('write')
 
@@ -174,6 +181,13 @@ describe('compose issue create', function()
       body = '',
       labels = { 'bug' },
       ref = nil,
+      metadata = {
+        labels = { 'bug' },
+        assignees = {},
+        milestone = '',
+        draft = false,
+        reviewers = {},
+      },
     }, captured.args)
   end)
 
@@ -313,7 +327,7 @@ describe('compose issue edit', function()
     vim.cmd('enew!')
   end)
 
-  it('submits issue edits with an empty body', function()
+  it('extracts issue metadata from the comment block on write', function()
     local compose = require('forge.compose')
     local original = {
       title = 'existing issue',
@@ -324,22 +338,13 @@ describe('compose issue edit', function()
     }
     local f = {
       name = 'github',
-      update_issue_cmd = function(
-        _,
-        num,
-        title,
-        body,
-        _labels,
-        _assignees,
-        _milestone,
-        _details,
-        ref
-      )
+      update_issue_cmd = function(_, num, title, body, ref, metadata)
         captured.args = {
           num = num,
           title = title,
           body = body,
           ref = ref,
+          metadata = metadata,
         }
         return { 'update-issue', num, title, body }
       end,
@@ -349,10 +354,26 @@ describe('compose issue edit', function()
 
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    assert.is_false(vim.tbl_contains(lines, '  Labels: bug'))
-    assert.is_false(vim.tbl_contains(lines, '  Assignees: alice'))
-    assert.is_false(vim.tbl_contains(lines, '  Milestone: v1'))
-    vim.api.nvim_buf_set_lines(buf, 0, 3, false, { '# updated issue', '', '' })
+    assert.is_true(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_true(vim.tbl_contains(lines, '  Assignees: alice'))
+    assert.is_true(vim.tbl_contains(lines, '  Milestone: v1'))
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# updated issue',
+      '',
+      '',
+      '<!--',
+      '  Editing issue #42 via github.',
+      '',
+      '  Labels: bug, docs',
+      '  Assignees: alice, bob',
+      '  Milestone: v2',
+      '',
+      '  Write (:w) submits this buffer.',
+      '  Quit or delete without ! keeps modified-buffer protection.',
+      '  Use :q!, :bd!, or :bwipeout! to discard it.',
+      '  An empty title aborts editing.',
+      '-->',
+    })
     vim.cmd('write')
 
     vim.wait(100, function()
@@ -364,10 +385,127 @@ describe('compose issue edit', function()
       title = 'updated issue',
       body = '',
       ref = nil,
+      metadata = {
+        labels = { 'bug', 'docs' },
+        assignees = { 'alice', 'bob' },
+        milestone = 'v2',
+        draft = false,
+        reviewers = {},
+      },
     }, captured.args)
     assert.equals(1, captured.cleared)
     assert.same({}, captured.warns)
     assert.same({}, captured.errors)
+  end)
+
+  it('treats a broken comment opener as body text on write', function()
+    local compose = require('forge.compose')
+    local f = {
+      name = 'github',
+      update_issue_cmd = function(_, num, title, body, ref, metadata)
+        captured.args = {
+          num = num,
+          title = title,
+          body = body,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'update-issue', num, title, body }
+      end,
+    }
+
+    compose.open_issue_edit(f, '42', {
+      title = 'existing issue',
+      body = '',
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# updated issue',
+      '',
+      '<! --',
+      '  Labels: docs',
+      '  Assignees: bob',
+      '  Milestone: v2',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.args ~= nil and captured.cleared == 1
+    end)
+
+    assert.same({
+      num = '42',
+      title = 'updated issue',
+      body = '<! --\n  Labels: docs\n  Assignees: bob\n  Milestone: v2\n-->',
+      ref = nil,
+      metadata = {
+        labels = {},
+        assignees = {},
+        milestone = '',
+        draft = false,
+        reviewers = {},
+      },
+    }, captured.args)
+  end)
+
+  it('parses metadata to end of buffer when the closer is removed', function()
+    local compose = require('forge.compose')
+    local f = {
+      name = 'github',
+      update_issue_cmd = function(_, num, title, body, ref, metadata)
+        captured.args = {
+          num = num,
+          title = title,
+          body = body,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'update-issue', num, title, body }
+      end,
+    }
+
+    compose.open_issue_edit(f, '42', {
+      title = 'existing issue',
+      body = '',
+      labels = {},
+      assignees = {},
+      milestone = '',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# updated issue',
+      '',
+      '',
+      '<!--',
+      '  Labels: docs',
+      '  Assignees: bob',
+      '  Milestone: v2',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.args ~= nil and captured.cleared == 1
+    end)
+
+    assert.same({
+      num = '42',
+      title = 'updated issue',
+      body = '',
+      ref = nil,
+      metadata = {
+        labels = { 'docs' },
+        assignees = { 'bob' },
+        milestone = 'v2',
+        draft = false,
+        reviewers = {},
+      },
+    }, captured.args)
   end)
 
   it('aborts issue editing when the title is empty', function()
@@ -383,8 +521,6 @@ describe('compose issue edit', function()
       title = 'existing issue',
       body = '',
       labels = {},
-      assignees = {},
-      milestone = '',
     })
 
     local buf = vim.api.nvim_get_current_buf()

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -1,18 +1,92 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 describe('compose pr edit', function()
+  local captured
   local old_fn_system
+  local old_system
   local old_feedkeys
+  local old_preload
 
   before_each(function()
+    captured = {
+      infos = {},
+      warns = {},
+      errors = {},
+      cleared = 0,
+      diff_stat = '',
+    }
+
     old_fn_system = vim.fn.system
+    old_system = vim.system
     old_feedkeys = vim.api.nvim_feedkeys
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.logger'] = package.preload['forge.logger'],
+    }
+
     vim.api.nvim_feedkeys = function() end
+    vim.fn.system = function(cmd)
+      if cmd == 'git diff --stat origin/main..HEAD' then
+        return captured.diff_stat
+      end
+      return ''
+    end
+    vim.system = function(cmd, _, cb)
+      captured.cmd = cmd
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
+        warn = function(msg)
+          table.insert(captured.warns, msg)
+        end,
+        error = function(msg)
+          table.insert(captured.errors, msg)
+        end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.logger'] = nil
   end)
 
   after_each(function()
     vim.fn.system = old_fn_system
+    vim.system = old_system
     vim.api.nvim_feedkeys = old_feedkeys
+
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.logger'] = old_preload['forge.logger']
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.logger'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if
@@ -25,26 +99,25 @@ describe('compose pr edit', function()
     vim.cmd('enew!')
   end)
 
-  it('shows fetched head/base metadata in the header', function()
-    vim.fn.system = function(cmd)
-      if cmd == 'git diff --stat origin/main..HEAD' then
-        return ''
-      end
-      return ''
-    end
-
+  it('shows fetched metadata in the comment header', function()
     local compose = require('forge.compose')
     compose.open_pr_edit(
       {
         labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = true },
         name = 'github',
       },
       '23',
       {
         title = 'PR title',
         body = 'PR body',
+        draft = false,
         head_branch = 'real-pr-head',
         base_branch = 'main',
+        reviewers = { 'bob' },
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
       },
       'other-local-branch'
     )
@@ -52,33 +125,35 @@ describe('compose pr edit', function()
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
     assert.is_truthy(vim.tbl_contains(lines, '  On branch real-pr-head against main.'))
     assert.is_false(vim.tbl_contains(lines, '  On branch other-local-branch against main.'))
-    assert.is_false(vim.tbl_contains(lines, '  Draft: false'))
-    assert.is_false(vim.tbl_contains(lines, '  Reviewers: bob'))
-    assert.is_false(vim.tbl_contains(lines, '  Labels: bug'))
-    assert.is_false(vim.tbl_contains(lines, '  Assignees: alice'))
-    assert.is_false(vim.tbl_contains(lines, '  Milestone: v1'))
+    assert.is_true(vim.tbl_contains(lines, '  Draft: false'))
+    assert.is_true(vim.tbl_contains(lines, '  Reviewers: bob'))
+    assert.is_true(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_true(vim.tbl_contains(lines, '  Assignees: alice'))
+    assert.is_true(vim.tbl_contains(lines, '  Milestone: v1'))
   end)
 
   it('hides the local diff stat when the checked-out branch differs from the PR head', function()
-    vim.fn.system = function(cmd)
-      if cmd == 'git diff --stat origin/main..HEAD' then
-        return ' lua/forge/init.lua | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
-      end
-      return ''
-    end
+    captured.diff_stat =
+      ' lua/forge/init.lua | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
 
     local compose = require('forge.compose')
     compose.open_pr_edit(
       {
         labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = true },
         name = 'github',
       },
       '23',
       {
         title = 'PR title',
         body = 'PR body',
+        draft = false,
         head_branch = 'real-pr-head',
         base_branch = 'main',
+        reviewers = {},
+        labels = {},
+        assignees = {},
+        milestone = '',
       },
       'other-local-branch'
     )
@@ -88,5 +163,73 @@ describe('compose pr edit', function()
       assert.is_false(line == '  Changes not in origin/main:')
       assert.is_false(line == '   lua/forge/init.lua | 2 +-')
     end
+  end)
+
+  it('extracts PR metadata from the comment block on write', function()
+    local compose = require('forge.compose')
+    local f = {
+      labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+      capabilities = { draft = true, reviewers = true },
+      name = 'github',
+      update_pr_cmd = function(_, num, title, body, ref, metadata)
+        captured.args = {
+          num = num,
+          title = title,
+          body = body,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'update-pr', num, title, body }
+      end,
+    }
+
+    compose.open_pr_edit(f, '23', {
+      title = 'PR title',
+      body = 'PR body',
+      draft = false,
+      head_branch = 'real-pr-head',
+      base_branch = 'main',
+      reviewers = { 'bob' },
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    }, 'real-pr-head')
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# updated pr',
+      '',
+      'updated body',
+      '',
+      '<!--',
+      '  Draft: true',
+      '  Reviewers: carol, dave',
+      '  Labels: bug, docs',
+      '  Assignees: alice, bob',
+      '  Milestone: v2',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.args ~= nil and captured.cleared == 1
+    end)
+
+    assert.same({
+      num = '23',
+      title = 'updated pr',
+      body = 'updated body',
+      ref = nil,
+      metadata = {
+        labels = { 'bug', 'docs' },
+        assignees = { 'alice', 'bob' },
+        milestone = 'v2',
+        draft = true,
+        reviewers = { 'carol', 'dave' },
+      },
+    }, captured.args)
+    assert.equals(1, captured.cleared)
+    assert.same({}, captured.warns)
+    assert.same({}, captured.errors)
   end)
 end)

--- a/spec/edit_issue_spec.lua
+++ b/spec/edit_issue_spec.lua
@@ -134,6 +134,9 @@ describe('edit_issue', function()
           return {
             title = json.title,
             body = json.body,
+            labels = { 'bug' },
+            assignees = { 'alice' },
+            milestone = 'v1',
           }
         end,
       }
@@ -209,6 +212,9 @@ describe('edit_issue', function()
       details = {
         title = 'Issue title',
         body = 'Issue body',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
       },
       scope = nil,
     }, captured.opened)

--- a/spec/edit_pr_spec.lua
+++ b/spec/edit_pr_spec.lua
@@ -61,8 +61,21 @@ describe('edit_pr', function()
         result.stdout = vim.json.encode({
           title = 'PR title',
           body = 'PR body',
+          isDraft = false,
           headRefName = 'real-pr-head',
           baseRefName = 'main',
+          labels = {
+            { name = 'bug' },
+          },
+          assignees = {
+            { login = 'alice' },
+          },
+          reviewRequests = {
+            { login = 'bob' },
+          },
+          milestone = {
+            title = 'v1',
+          },
         })
       end
       if cb then
@@ -136,8 +149,13 @@ describe('edit_pr', function()
           return {
             title = json.title,
             body = json.body,
+            draft = json.isDraft == true,
             head_branch = json.headRefName,
             base_branch = json.baseRefName,
+            labels = { 'bug' },
+            assignees = { 'alice' },
+            reviewers = { 'bob' },
+            milestone = 'v1',
           }
         end,
       }
@@ -213,8 +231,13 @@ describe('edit_pr', function()
       details = {
         title = 'PR title',
         body = 'PR body',
+        draft = false,
         head_branch = 'real-pr-head',
         base_branch = 'main',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        reviewers = { 'bob' },
+        milestone = 'v1',
       },
       current_branch = 'other-local-branch',
       scope = nil,

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -59,24 +59,87 @@ describe('github', function()
   end)
 
   it('builds issue detail and simplified issue commands', function()
+    local pr_details = gh:fetch_pr_details_cmd('23', { repo_arg = 'owner/repo' })
+    assert.same({ 'gh', 'pr', 'view', '23' }, vim.list_slice(pr_details, 1, 4))
+    assert.truthy(
+      vim.tbl_contains(
+        pr_details,
+        'title,body,isDraft,headRefName,baseRefName,labels,assignees,reviewRequests,milestone,url'
+      )
+    )
+
     local details = gh:fetch_issue_details_cmd('23', { repo_arg = 'owner/repo' })
     assert.same({ 'gh', 'issue', 'view', '23' }, vim.list_slice(details, 1, 4))
     assert.truthy(vim.tbl_contains(details, '--json'))
+    assert.truthy(vim.tbl_contains(details, 'title,body,labels,assignees,milestone,url'))
 
     local create = gh:create_issue_cmd('title', 'body', { 'bug' }, {
       repo_arg = 'owner/repo',
     })
     assert.truthy(vim.tbl_contains(create, '--label'))
     assert.truthy(vim.tbl_contains(create, 'bug'))
-    assert.falsy(vim.tbl_contains(create, '--assignee'))
-    assert.falsy(vim.tbl_contains(create, '--milestone'))
 
     local cmd = gh:update_issue_cmd('23', 'title', 'body', { repo_arg = 'owner/repo' })
     assert.falsy(vim.tbl_contains(cmd, '--add-label'))
     assert.falsy(vim.tbl_contains(cmd, '--remove-label'))
-    assert.falsy(vim.tbl_contains(cmd, '--add-assignee'))
-    assert.falsy(vim.tbl_contains(cmd, '--remove-assignee'))
-    assert.falsy(vim.tbl_contains(cmd, '--remove-milestone'))
+  end)
+
+  it('parses fetched PR and issue metadata', function()
+    assert.same(
+      {
+        title = 'title',
+        body = 'body',
+        draft = true,
+        head_branch = 'topic',
+        base_branch = 'main',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        reviewers = { 'bob' },
+        milestone = 'v1',
+      },
+      gh:parse_pr_details({
+        title = 'title',
+        body = 'body',
+        isDraft = true,
+        headRefName = 'topic',
+        baseRefName = 'main',
+        labels = {
+          { name = 'bug' },
+        },
+        assignees = {
+          { login = 'alice' },
+        },
+        reviewRequests = {
+          { login = 'bob' },
+        },
+        milestone = {
+          title = 'v1',
+        },
+      })
+    )
+
+    assert.same(
+      {
+        title = 'title',
+        body = 'body',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
+      },
+      gh:parse_issue_details({
+        title = 'title',
+        body = 'body',
+        labels = {
+          { name = 'bug' },
+        },
+        assignees = {
+          { login = 'alice' },
+        },
+        milestone = {
+          title = 'v1',
+        },
+      })
+    )
   end)
 
   it('adds draft flag to create_pr_cmd', function()
@@ -319,14 +382,64 @@ describe('gitlab', function()
     })
     assert.truthy(vim.tbl_contains(create, '--label'))
     assert.truthy(vim.tbl_contains(create, 'bug'))
-    assert.falsy(vim.tbl_contains(create, '--assignee'))
-    assert.falsy(vim.tbl_contains(create, '--milestone'))
 
     local cmd = gl:update_issue_cmd('23', 'title', 'body', { repo_arg = 'group/repo' })
     assert.falsy(vim.tbl_contains(cmd, '--label'))
     assert.falsy(vim.tbl_contains(cmd, '--unlabel'))
-    assert.falsy(vim.tbl_contains(cmd, '--unassign'))
-    assert.falsy(vim.tbl_contains(cmd, '--milestone'))
+  end)
+
+  it('parses fetched MR and issue metadata', function()
+    assert.same(
+      {
+        title = 'title',
+        body = 'body',
+        draft = true,
+        head_branch = 'topic',
+        base_branch = 'main',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        reviewers = { 'bob' },
+        milestone = 'v1',
+      },
+      gl:parse_pr_details({
+        title = 'title',
+        description = 'body',
+        draft = true,
+        source_branch = 'topic',
+        target_branch = 'main',
+        labels = { 'bug' },
+        assignees = {
+          { username = 'alice' },
+        },
+        reviewers = {
+          { username = 'bob' },
+        },
+        milestone = {
+          title = 'v1',
+        },
+      })
+    )
+
+    assert.same(
+      {
+        title = 'title',
+        body = 'body',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
+      },
+      gl:parse_issue_details({
+        title = 'title',
+        description = 'body',
+        labels = { 'bug' },
+        assignees = {
+          { username = 'alice' },
+        },
+        milestone = {
+          title = 'v1',
+        },
+      })
+    )
   end)
 
   it('returns correct pr_json_fields', function()
@@ -429,15 +542,65 @@ describe('codeberg', function()
     assert.same({ 'tea', 'issues', 'create', '--title', 'title' }, vim.list_slice(create, 1, 5))
     assert.truthy(vim.tbl_contains(create, '--labels'))
     assert.truthy(vim.tbl_contains(create, 'bug'))
-    assert.falsy(vim.tbl_contains(create, '--assignees'))
-    assert.falsy(vim.tbl_contains(create, '--milestone'))
 
     local cmd = cb:update_issue_cmd('23', 'title', 'body', { repo_arg = 'forgejo/tea-test' })
     assert.same({ 'tea', 'issues', 'edit', '23' }, vim.list_slice(cmd, 1, 4))
     assert.falsy(vim.tbl_contains(cmd, '--add-labels'))
     assert.falsy(vim.tbl_contains(cmd, '--remove-labels'))
-    assert.falsy(vim.tbl_contains(cmd, '--add-assignees'))
-    assert.falsy(vim.tbl_contains(cmd, '--milestone'))
+  end)
+
+  it('parses fetched PR and issue metadata for tea', function()
+    assert.same(
+      {
+        title = 'title',
+        body = 'body',
+        draft = false,
+        head_branch = 'topic',
+        base_branch = 'main',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        reviewers = {},
+        milestone = 'v1',
+      },
+      cb:parse_pr_details({
+        title = 'title',
+        body = 'body',
+        head = { ref = 'topic' },
+        base = { ref = 'main' },
+        labels = {
+          { name = 'bug' },
+        },
+        assignees = {
+          { login = 'alice' },
+        },
+        milestone = {
+          title = 'v1',
+        },
+      })
+    )
+
+    assert.same(
+      {
+        title = 'title',
+        body = 'body',
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
+      },
+      cb:parse_issue_details({
+        title = 'title',
+        body = 'body',
+        labels = {
+          { name = 'bug' },
+        },
+        assignees = {
+          { login = 'alice' },
+        },
+        milestone = {
+          title = 'v1',
+        },
+      })
+    )
   end)
 
   it('uses tea releases commands for release list and delete', function()


### PR DESCRIPTION
## Problem
Compose and edit buffers no longer show the fetched or template metadata users need for context, and the save path no longer exposes what the compose parser extracted from the commented block. That made the restored metadata direction untestable and left altered comment-block behavior undefined in specs.

## Solution
Restore fetched and template metadata rendering in compose/edit buffers, request and parse the known forge fields again on the backend detail fetchers, and thread the parsed metadata through the save callbacks as an extra payload for tests and future per-forge handling. Add focused specs for metadata display, save-time extraction, and the agreed comment-block behavior when the opener is kept, removed, or the closer is missing.