### PR TITLE
fix(compose): honor forge-specific submission semantics

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -1,4 +1,5 @@
 local forge = require('forge')
+local submission = require('forge.submission')
 
 ---@class forge.Codeberg: forge.Forge
 local M = {
@@ -16,6 +17,16 @@ local M = {
     draft = false,
     per_pr_checks = true,
     ci_json = true,
+  },
+  submission = {
+    issue = {
+      create = { labels = true, assignees = true, milestone = true },
+      update = { labels = true, assignees = false, milestone = true },
+    },
+    pr = {
+      create = { draft = false, reviewers = false, labels = true, assignees = true, milestone = true },
+      update = { draft = false, reviewers = true, labels = true, assignees = false, milestone = true },
+    },
   },
   pr_fields = {
     number = 'index',
@@ -44,6 +55,13 @@ local M = {
 local function repo_arg(ref)
   local current = ref or forge.current_scope(M.name)
   return forge.scope_repo_arg(current) or ''
+end
+
+local function append_csv(cmd, flag, values)
+  if values and #values > 0 then
+    table.insert(cmd, flag)
+    table.insert(cmd, table.concat(values, ','))
+  end
 end
 
 ---@param state string
@@ -324,8 +342,8 @@ end
 ---@param title string
 ---@param body string
 ---@return string[]
-function M:update_pr_cmd(num, title, body, ref)
-  return {
+function M:update_pr_cmd(num, title, body, ref, metadata, previous)
+  local cmd = {
     'tea',
     'pr',
     'edit',
@@ -337,9 +355,22 @@ function M:update_pr_cmd(num, title, body, ref)
     '--repo',
     repo_arg(ref),
   }
+  local current = submission.filter(self, 'pr', 'update', metadata)
+  local before = previous or { labels = {}, reviewers = {}, milestone = '' }
+  local add_labels, remove_labels = submission.diff(before.labels, current.labels)
+  local add_reviewers, remove_reviewers = submission.diff(before.reviewers, current.reviewers)
+  append_csv(cmd, '--add-labels', add_labels)
+  append_csv(cmd, '--remove-labels', remove_labels)
+  append_csv(cmd, '--add-reviewers', add_reviewers)
+  append_csv(cmd, '--remove-reviewers', remove_reviewers)
+  if current.milestone ~= (before.milestone or '') then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
+  end
+  return cmd
 end
 
-function M:update_issue_cmd(num, title, body, ref)
+function M:update_issue_cmd(num, title, body, ref, metadata, previous)
   local cmd = {
     'tea',
     'issues',
@@ -352,6 +383,15 @@ function M:update_issue_cmd(num, title, body, ref)
     '--repo',
     repo_arg(ref),
   }
+  local current = submission.filter(self, 'issue', 'update', metadata)
+  local before = previous or { labels = {}, milestone = '' }
+  local add_labels, remove_labels = submission.diff(before.labels, current.labels)
+  append_csv(cmd, '--add-labels', add_labels)
+  append_csv(cmd, '--remove-labels', remove_labels)
+  if current.milestone ~= (before.milestone or '') then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
+  end
   return cmd
 end
 
@@ -373,12 +413,18 @@ function M:parse_pr_details(json)
   return {
     title = json.title or '',
     body = json.body or '',
-    draft = false,
+    draft = json.draft == true,
     head_branch = type(json.head) == 'table' and (json.head.ref or '') or json.head or '',
     base_branch = type(json.base) == 'table' and (json.base.ref or '') or json.base or '',
     labels = labels,
     assignees = assignees,
-    reviewers = {},
+    reviewers = (function()
+      local reviewers = {}
+      for _, reviewer in ipairs(json.requested_reviewers or json.reviewers or {}) do
+        table.insert(reviewers, reviewer.login or reviewer.username or '')
+      end
+      return reviewers
+    end)(),
     milestone = milestone,
   }
 end
@@ -410,7 +456,7 @@ end
 ---@param base string
 ---@param _draft boolean
 ---@return string[]
-function M:create_pr_cmd(title, body, base, _draft, ref)
+function M:create_pr_cmd(title, body, base, _draft, ref, metadata)
   local cmd = {
     'tea',
     'pr',
@@ -424,6 +470,13 @@ function M:create_pr_cmd(title, body, base, _draft, ref)
     '--repo',
     repo_arg(ref),
   }
+  local current = metadata and submission.filter(self, 'pr', 'create', metadata) or nil
+  append_csv(cmd, '--labels', current and current.labels or {})
+  append_csv(cmd, '--assignees', current and current.assignees or {})
+  if current and current.milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
+  end
   return cmd
 end
 
@@ -449,12 +502,16 @@ end
 ---@param body string
 ---@param labels string[]?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, ref)
+function M:create_issue_cmd(title, body, labels, ref, metadata)
   local cmd =
     { 'tea', 'issues', 'create', '--title', title, '--description', body, '--repo', repo_arg(ref) }
-  if labels and #labels > 0 then
-    table.insert(cmd, '--labels')
-    table.insert(cmd, table.concat(labels, ','))
+  local current = metadata and submission.filter(self, 'issue', 'create', metadata) or nil
+  local effective_labels = current and current.labels or labels or {}
+  append_csv(cmd, '--labels', effective_labels)
+  append_csv(cmd, '--assignees', current and current.assignees or {})
+  if current and current.milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
   end
   return cmd
 end

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local template = require('forge.template')
+local submission = require('forge.submission')
 
 local compose_ns = vim.api.nvim_create_namespace('forge_compose')
 
@@ -164,6 +165,25 @@ local function add_metadata_line(builder, label, value, value_hl)
   return ln
 end
 
+local function add_metadata_fields(builder, forge, kind, operation, metadata)
+  local fields = submission.fields(forge, kind, operation)
+  for _, field in ipairs(fields) do
+    if field == 'draft' then
+      local draft = metadata.draft == true
+      local value_hl = draft and 'ForgeComposeDraft' or 'ForgeDim'
+      add_metadata_line(builder, 'Draft', draft and 'true' or 'false', value_hl)
+    elseif field == 'reviewers' then
+      add_metadata_line(builder, 'Reviewers', table.concat(metadata.reviewers or {}, ', '))
+    elseif field == 'labels' then
+      add_metadata_line(builder, 'Labels', table.concat(metadata.labels or {}, ', '))
+    elseif field == 'assignees' then
+      add_metadata_line(builder, 'Assignees', table.concat(metadata.assignees or {}, ', '))
+    elseif field == 'milestone' then
+      add_metadata_line(builder, 'Milestone', metadata.milestone or '')
+    end
+  end
+end
+
 ---@param f forge.Forge
 ---@param branch string
 ---@param title string
@@ -268,10 +288,10 @@ local function submit_issue(f, title, body, labels, buf, ref, metadata)
   )
 end
 
-local function update_issue(f, num, title, body, buf, ref, metadata)
+local function update_issue(f, num, title, body, buf, ref, metadata, previous)
   local log = require('forge.logger')
   log.info('updating issue #' .. num .. '...')
-  vim.system(f:update_issue_cmd(num, title, body, ref, metadata), { text = true }, function(result)
+  vim.system(f:update_issue_cmd(num, title, body, ref, metadata, previous), { text = true }, function(result)
     vim.schedule(function()
       if result.code == 0 then
         log.info(('updated issue #%s'):format(num))
@@ -304,7 +324,15 @@ function M.open_issue(f, result, ref)
   local template_title = result and result.title or ''
   local title_prefix = '# ' .. template_title
   local template_labels = result and result.labels or {}
+  local template_assignees = result and result.assignees or {}
   local body = result and result.body or ''
+  local template_metadata = {
+    labels = template_labels,
+    assignees = template_assignees,
+    milestone = '',
+    draft = false,
+    reviewers = {},
+  }
 
   local b = ComposeBuilder.new()
   b.lines = { title_prefix, '' }
@@ -326,9 +354,7 @@ function M.open_issue(f, result, ref)
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
-  add_metadata_line(b, 'Labels', table.concat(template_labels, ', '))
-  add_metadata_line(b, 'Assignees', '')
-  add_metadata_line(b, 'Milestone', '')
+  add_metadata_fields(b, f, 'issue', 'create', template_metadata)
   b:add_line('')
   add_discard_hints(b)
   b:add_line('  An empty title aborts creation.')
@@ -340,8 +366,8 @@ function M.open_issue(f, result, ref)
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local submission = extract_submission(buf_lines)
-      local issue_title = submission.title
+      local submission_data = extract_submission(buf_lines)
+      local issue_title = submission_data.title
 
       local log = require('forge.logger')
       if
@@ -353,7 +379,7 @@ function M.open_issue(f, result, ref)
         vim.api.nvim_buf_delete(buf, { force = true })
         return
       end
-      local issue_body = submission.body
+      local issue_body = submission_data.body
       if body ~= '' and template.normalize_body(issue_body) == template.normalize_body(body) then
         log.warn('aborting: body unchanged from template')
         vim.bo[buf].modified = false
@@ -361,7 +387,7 @@ function M.open_issue(f, result, ref)
         return
       end
 
-      submit_issue(f, issue_title, issue_body, template_labels, buf, ref, submission.metadata)
+      submit_issue(f, issue_title, issue_body, template_labels, buf, ref, submission_data.metadata)
     end,
   })
 
@@ -394,9 +420,7 @@ function M.open_issue_edit(f, num, details, ref)
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
-  add_metadata_line(b, 'Labels', table.concat(details.labels or {}, ', '))
-  add_metadata_line(b, 'Assignees', table.concat(details.assignees or {}, ', '))
-  add_metadata_line(b, 'Milestone', details.milestone or '')
+  add_metadata_fields(b, f, 'issue', 'update', submission.issue_metadata(details))
   b:add_line('')
   add_discard_hints(b)
   b:add_line('  An empty title aborts editing.')
@@ -408,8 +432,8 @@ function M.open_issue_edit(f, num, details, ref)
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local submission = extract_submission(buf_lines)
-      local issue_title = submission.title
+      local submission_data = extract_submission(buf_lines)
+      local issue_title = submission_data.title
 
       local log = require('forge.logger')
       if issue_title == '' then
@@ -419,7 +443,16 @@ function M.open_issue_edit(f, num, details, ref)
         return
       end
 
-      update_issue(f, num, issue_title, submission.body, buf, ref, submission.metadata)
+      update_issue(
+        f,
+        num,
+        issue_title,
+        submission_data.body,
+        buf,
+        ref,
+        submission_data.metadata,
+        submission.issue_metadata(details)
+      )
     end,
   })
 
@@ -442,6 +475,13 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   head_ref = head_ref or 'HEAD'
   local title, commit_body = template.fill_from_commits(branch, base_ref, head_ref)
   local body = (tmpl and tmpl.body) or commit_body
+  local draft_metadata = {
+    labels = {},
+    assignees = {},
+    milestone = '',
+    draft = draft == true,
+    reviewers = {},
+  }
 
   local buf = create_compose_buf('forge://pr/new')
   vim.b[buf].forge_scope = ref
@@ -477,16 +517,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
-  if f.capabilities and f.capabilities.draft then
-    local draft_val = draft and 'true' or 'false'
-    add_metadata_line(b, 'Draft', draft_val, draft and 'ForgeComposeDraft' or 'ForgeDim')
-  end
-  if f.capabilities and f.capabilities.reviewers then
-    add_metadata_line(b, 'Reviewers', '')
-  end
-  add_metadata_line(b, 'Labels', '')
-  add_metadata_line(b, 'Assignees', '')
-  add_metadata_line(b, 'Milestone', '')
+  add_metadata_fields(b, f, 'pr', 'create', draft_metadata)
 
   local stat_start, stat_end
   if diff_stat ~= '' then
@@ -541,8 +572,8 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local submission = extract_submission(buf_lines)
-      local pr_title = submission.title
+      local submission_data = extract_submission(buf_lines)
+      local pr_title = submission_data.title
 
       local log = require('forge.logger')
       if pr_title == '' then
@@ -551,7 +582,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
         vim.api.nvim_buf_delete(buf, { force = true })
         return
       end
-      local pr_body = submission.body
+      local pr_body = submission_data.body
       if pr_body == '' then
         log.warn('aborting: empty body')
         vim.bo[buf].modified = false
@@ -575,7 +606,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
         buf,
         ref,
         push_target,
-        submission.metadata
+        submission_data.metadata
       )
     end,
   })
@@ -597,10 +628,10 @@ M.push_and_create = push_and_create
 ---@param body string
 ---@param buf integer?
 ---@param ref? forge.Scope
-local function update_pr(f, num, title, body, buf, ref, metadata)
+local function update_pr(f, num, title, body, buf, ref, metadata, previous)
   local log = require('forge.logger')
   log.info('updating ' .. f.labels.pr_one .. ' #' .. num .. '...')
-  vim.system(f:update_pr_cmd(num, title, body, ref, metadata), { text = true }, function(result)
+  vim.system(f:update_pr_cmd(num, title, body, ref, metadata, previous), { text = true }, function(result)
     vim.schedule(function()
       if result.code ~= 0 then
         local msg = vim.trim(result.stderr or '')
@@ -612,6 +643,30 @@ local function update_pr(f, num, title, body, buf, ref, metadata)
         end
         log.error(msg)
         return
+      end
+      if
+        submission.supports(f, 'pr', 'update', 'draft')
+        and previous
+        and previous.draft ~= metadata.draft
+        and f.draft_toggle_cmd
+      then
+        local draft_cmd = f:draft_toggle_cmd(num, previous.draft, ref)
+        if draft_cmd then
+          vim.system(draft_cmd, { text = true }, function(draft_result)
+            vim.schedule(function()
+              if draft_result.code ~= 0 then
+                local msg = vim.trim(draft_result.stderr or '')
+                if msg == '' then
+                  msg = vim.trim(draft_result.stdout or '')
+                end
+                if msg == '' then
+                  msg = 'draft toggle failed'
+                end
+                log.error(msg)
+              end
+            end)
+          end)
+        end
       end
       log.info(('updated %s #%s'):format(f.labels.pr_one, num))
       require('forge').clear_list()
@@ -667,16 +722,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
   b:add_line('')
-  if f.capabilities and f.capabilities.draft then
-    local draft_val = details.draft and 'true' or 'false'
-    add_metadata_line(b, 'Draft', draft_val, details.draft and 'ForgeComposeDraft' or 'ForgeDim')
-  end
-  if f.capabilities and f.capabilities.reviewers then
-    add_metadata_line(b, 'Reviewers', table.concat(details.reviewers or {}, ', '))
-  end
-  add_metadata_line(b, 'Labels', table.concat(details.labels or {}, ', '))
-  add_metadata_line(b, 'Assignees', table.concat(details.assignees or {}, ', '))
-  add_metadata_line(b, 'Milestone', details.milestone or '')
+  add_metadata_fields(b, f, 'pr', 'update', submission.pr_metadata(details))
 
   local stat_start, stat_end
   if diff_stat ~= '' then
@@ -731,8 +777,8 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
     buffer = buf,
     callback = function()
       local buf_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-      local submission = extract_submission(buf_lines)
-      local pr_title = submission.title
+      local submission_data = extract_submission(buf_lines)
+      local pr_title = submission_data.title
 
       local log = require('forge.logger')
       if pr_title == '' then
@@ -741,7 +787,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
         vim.api.nvim_buf_delete(buf, { force = true })
         return
       end
-      local pr_body = submission.body
+      local pr_body = submission_data.body
       if pr_body == '' then
         log.warn('aborting: empty body')
         vim.bo[buf].modified = false
@@ -749,7 +795,16 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
         return
       end
 
-      update_pr(f, num, pr_title, pr_body, buf, ref, submission.metadata)
+      update_pr(
+        f,
+        num,
+        pr_title,
+        pr_body,
+        buf,
+        ref,
+        submission_data.metadata,
+        submission.pr_metadata(details)
+      )
     end,
   })
 

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -1,5 +1,6 @@
 local forge = require('forge')
 local log = require('forge.logger')
+local submission = require('forge.submission')
 
 ---@class forge.GitHub: forge.Forge
 local M = {
@@ -15,8 +16,19 @@ local M = {
   },
   capabilities = {
     draft = true,
+    reviewers = true,
     per_pr_checks = true,
     ci_json = true,
+  },
+  submission = {
+    issue = {
+      create = { labels = true, assignees = true, milestone = true },
+      update = { labels = true, assignees = true, milestone = true },
+    },
+    pr = {
+      create = { draft = true, reviewers = true, labels = true, assignees = true, milestone = true },
+      update = { draft = true, reviewers = true, labels = true, assignees = true, milestone = true },
+    },
   },
   pr_fields = {
     number = 'number',
@@ -65,6 +77,13 @@ local function open_browse_url(cmd)
       end
     end)
   end)
+end
+
+local function append_csv(cmd, flag, values)
+  if values and #values > 0 then
+    table.insert(cmd, flag)
+    table.insert(cmd, table.concat(values, ','))
+  end
 end
 
 ---@param state string
@@ -470,8 +489,27 @@ end
 ---@param title string
 ---@param body string
 ---@return string[]
-function M:update_pr_cmd(num, title, body, scope)
+function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   local cmd = { 'gh', 'pr', 'edit', num, '--title', title, '--body', body }
+  local current = submission.filter(self, 'pr', 'update', metadata)
+  local before = previous or { labels = {}, assignees = {}, reviewers = {}, milestone = '' }
+  local add_labels, remove_labels = submission.diff(before.labels, current.labels)
+  local add_assignees, remove_assignees = submission.diff(before.assignees, current.assignees)
+  local add_reviewers, remove_reviewers = submission.diff(before.reviewers, current.reviewers)
+  append_csv(cmd, '--add-label', add_labels)
+  append_csv(cmd, '--remove-label', remove_labels)
+  append_csv(cmd, '--add-assignee', add_assignees)
+  append_csv(cmd, '--remove-assignee', remove_assignees)
+  append_csv(cmd, '--add-reviewer', add_reviewers)
+  append_csv(cmd, '--remove-reviewer', remove_reviewers)
+  if current.milestone ~= (before.milestone or '') then
+    if current.milestone == '' then
+      table.insert(cmd, '--remove-milestone')
+    else
+      table.insert(cmd, '--milestone')
+      table.insert(cmd, current.milestone)
+    end
+  end
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
@@ -480,8 +518,24 @@ function M:update_pr_cmd(num, title, body, scope)
   return cmd
 end
 
-function M:update_issue_cmd(num, title, body, scope)
+function M:update_issue_cmd(num, title, body, scope, metadata, previous)
   local cmd = { 'gh', 'issue', 'edit', num, '--title', title, '--body', body }
+  local current = submission.filter(self, 'issue', 'update', metadata)
+  local before = previous or { labels = {}, assignees = {}, milestone = '' }
+  local add_labels, remove_labels = submission.diff(before.labels, current.labels)
+  local add_assignees, remove_assignees = submission.diff(before.assignees, current.assignees)
+  append_csv(cmd, '--add-label', add_labels)
+  append_csv(cmd, '--remove-label', remove_labels)
+  append_csv(cmd, '--add-assignee', add_assignees)
+  append_csv(cmd, '--remove-assignee', remove_assignees)
+  if current.milestone ~= (before.milestone or '') then
+    if current.milestone == '' then
+      table.insert(cmd, '--remove-milestone')
+    else
+      table.insert(cmd, '--milestone')
+      table.insert(cmd, current.milestone)
+    end
+  end
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
@@ -549,15 +603,23 @@ end
 ---@param base string
 ---@param draft boolean
 ---@return string[]
-function M:create_pr_cmd(title, body, base, draft, scope)
+function M:create_pr_cmd(title, body, base, draft, scope, metadata)
   local cmd = { 'gh', 'pr', 'create', '--title', title, '--body', body, '--base', base }
+  local current = metadata and submission.filter(self, 'pr', 'create', metadata) or nil
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
   end
-  if draft then
+  if (current and current.draft) or (not current and draft) then
     table.insert(cmd, '--draft')
+  end
+  append_csv(cmd, '--label', current and current.labels or {})
+  append_csv(cmd, '--assignee', current and current.assignees or {})
+  append_csv(cmd, '--reviewer', current and current.reviewers or {})
+  if current and current.milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
   end
   return cmd
 end
@@ -598,16 +660,20 @@ end
 ---@param body string
 ---@param labels string[]?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, scope)
+function M:create_issue_cmd(title, body, labels, scope, metadata)
   local cmd = { 'gh', 'issue', 'create', '--title', title, '--body', body }
+  local current = metadata and submission.filter(self, 'issue', 'create', metadata) or nil
   local repo = nwo(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
   end
-  for _, l in ipairs(labels or {}) do
-    table.insert(cmd, '--label')
-    table.insert(cmd, l)
+  local effective_labels = current and current.labels or (labels or {})
+  append_csv(cmd, '--label', effective_labels)
+  append_csv(cmd, '--assignee', current and current.assignees or {})
+  if current and current.milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
   end
   return cmd
 end

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -1,5 +1,6 @@
 local forge = require('forge')
 local scope = require('forge.scope')
+local submission = require('forge.submission')
 
 ---@class forge.GitLab: forge.Forge
 local M = {
@@ -15,8 +16,19 @@ local M = {
   },
   capabilities = {
     draft = true,
+    reviewers = true,
     per_pr_checks = true,
     ci_json = true,
+  },
+  submission = {
+    issue = {
+      create = { labels = true, assignees = true, milestone = true },
+      update = { labels = true, assignees = true, milestone = true },
+    },
+    pr = {
+      create = { draft = true, reviewers = true, labels = true, assignees = true, milestone = true },
+      update = { draft = true, reviewers = true, labels = true, assignees = true, milestone = true },
+    },
   },
   pr_fields = {
     number = 'iid',
@@ -52,6 +64,13 @@ end
 local function hostname(ref)
   local current = ref or forge.current_scope(M.name)
   return current and current.host or nil
+end
+
+local function append_csv(cmd, flag, values)
+  if values and #values > 0 then
+    table.insert(cmd, flag)
+    table.insert(cmd, table.concat(values, ','))
+  end
 end
 
 ---@param state string
@@ -376,13 +395,40 @@ end
 ---@param title string
 ---@param body string
 ---@return string[]
-function M:update_pr_cmd(num, title, body, ref)
+function M:update_pr_cmd(num, title, body, ref, metadata, previous)
   local cmd =
     { 'glab', 'mr', 'update', num, '--title', title, '--description', body, '-R', repo_arg(ref) }
+  local current = submission.filter(self, 'pr', 'update', metadata)
+  local before = previous or { labels = {}, assignees = {}, reviewers = {}, milestone = '' }
+  local add_labels, remove_labels = submission.diff(before.labels, current.labels)
+  append_csv(cmd, '--label', add_labels)
+  append_csv(cmd, '--unlabel', remove_labels)
+  if current.assignees ~= nil and vim.deep_equal(current.assignees, before.assignees or {}) == false then
+    if #current.assignees == 0 then
+      table.insert(cmd, '--unassign')
+    else
+      append_csv(cmd, '--assignee', current.assignees)
+    end
+  end
+  if current.reviewers ~= nil and vim.deep_equal(current.reviewers, before.reviewers or {}) == false then
+    if #current.reviewers == 0 then
+      local removed = {}
+      for _, reviewer in ipairs(before.reviewers or {}) do
+        table.insert(removed, '-' .. reviewer)
+      end
+      append_csv(cmd, '--reviewer', removed)
+    else
+      append_csv(cmd, '--reviewer', current.reviewers)
+    end
+  end
+  if current.milestone ~= (before.milestone or '') then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone ~= '' and current.milestone or '0')
+  end
   return cmd
 end
 
-function M:update_issue_cmd(num, title, body, ref)
+function M:update_issue_cmd(num, title, body, ref, metadata, previous)
   local cmd = {
     'glab',
     'issue',
@@ -395,6 +441,22 @@ function M:update_issue_cmd(num, title, body, ref)
     '-R',
     repo_arg(ref),
   }
+  local current = submission.filter(self, 'issue', 'update', metadata)
+  local before = previous or { labels = {}, assignees = {}, milestone = '' }
+  local add_labels, remove_labels = submission.diff(before.labels, current.labels)
+  append_csv(cmd, '--label', add_labels)
+  append_csv(cmd, '--unlabel', remove_labels)
+  if current.assignees ~= nil and vim.deep_equal(current.assignees, before.assignees or {}) == false then
+    if #current.assignees == 0 then
+      table.insert(cmd, '--unassign')
+    else
+      append_csv(cmd, '--assignee', current.assignees)
+    end
+  end
+  if current.milestone ~= (before.milestone or '') then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone ~= '' and current.milestone or '0')
+  end
   return cmd
 end
 
@@ -457,7 +519,7 @@ end
 ---@param base string
 ---@param draft boolean
 ---@return string[]
-function M:create_pr_cmd(title, body, base, draft, ref)
+function M:create_pr_cmd(title, body, base, draft, ref, metadata)
   local cmd = {
     'glab',
     'mr',
@@ -472,8 +534,16 @@ function M:create_pr_cmd(title, body, base, draft, ref)
     '-R',
     repo_arg(ref),
   }
-  if draft then
+  local current = metadata and submission.filter(self, 'pr', 'create', metadata) or nil
+  if (current and current.draft) or (not current and draft) then
     table.insert(cmd, '--draft')
+  end
+  append_csv(cmd, '--label', current and current.labels or {})
+  append_csv(cmd, '--assignee', current and current.assignees or {})
+  append_csv(cmd, '--reviewer', current and current.reviewers or {})
+  if current and current.milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
   end
   return cmd
 end
@@ -504,7 +574,7 @@ end
 ---@param body string
 ---@param labels string[]?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, ref)
+function M:create_issue_cmd(title, body, labels, ref, metadata)
   local cmd = {
     'glab',
     'issue',
@@ -517,9 +587,13 @@ function M:create_issue_cmd(title, body, labels, ref)
     '-R',
     repo_arg(ref),
   }
-  if labels and #labels > 0 then
-    table.insert(cmd, '--label')
-    table.insert(cmd, table.concat(labels, ','))
+  local current = metadata and submission.filter(self, 'issue', 'create', metadata) or nil
+  local effective_labels = current and current.labels or labels or {}
+  append_csv(cmd, '--label', effective_labels)
+  append_csv(cmd, '--assignee', current and current.assignees or {})
+  if current and current.milestone ~= '' then
+    table.insert(cmd, '--milestone')
+    table.insert(cmd, current.milestone)
   end
   return cmd
 end

--- a/lua/forge/submission.lua
+++ b/lua/forge/submission.lua
@@ -1,0 +1,110 @@
+local M = {}
+
+local ordered_fields = {
+  issue = { 'labels', 'assignees', 'milestone' },
+  pr = { 'draft', 'reviewers', 'labels', 'assignees', 'milestone' },
+}
+
+local function trim(value)
+  return vim.trim(value or '')
+end
+
+local function normalize_list(values)
+  local items = {}
+  local seen = {}
+  for _, value in ipairs(values or {}) do
+    local item = trim(value)
+    if item ~= '' and not seen[item] then
+      seen[item] = true
+      table.insert(items, item)
+    end
+  end
+  return items
+end
+
+function M.supports(forge, kind, operation, field)
+  local ops = (((forge or {}).submission or {})[kind] or {})[operation] or {}
+  if ops[field] ~= nil then
+    return ops[field]
+  end
+  if field == 'draft' then
+    return (forge.capabilities or {}).draft == true
+  end
+  if field == 'reviewers' then
+    return (forge.capabilities or {}).reviewers == true
+  end
+  return true
+end
+
+function M.filter(forge, kind, operation, metadata)
+  metadata = metadata or {}
+  return {
+    labels = M.supports(forge, kind, operation, 'labels') and normalize_list(metadata.labels) or {},
+    assignees = M.supports(forge, kind, operation, 'assignees') and normalize_list(metadata.assignees)
+      or {},
+    milestone = M.supports(forge, kind, operation, 'milestone') and trim(metadata.milestone) or '',
+    draft = M.supports(forge, kind, operation, 'draft') and metadata.draft == true or false,
+    reviewers = M.supports(forge, kind, operation, 'reviewers') and normalize_list(metadata.reviewers)
+      or {},
+  }
+end
+
+function M.fields(forge, kind, operation)
+  local fields = {}
+  for _, field in ipairs(ordered_fields[kind] or {}) do
+    if M.supports(forge, kind, operation, field) then
+      table.insert(fields, field)
+    end
+  end
+  return fields
+end
+
+function M.issue_metadata(details)
+  details = details or {}
+  return {
+    labels = normalize_list(details.labels),
+    assignees = normalize_list(details.assignees),
+    milestone = trim(details.milestone),
+    draft = false,
+    reviewers = {},
+  }
+end
+
+function M.pr_metadata(details)
+  details = details or {}
+  return {
+    labels = normalize_list(details.labels),
+    assignees = normalize_list(details.assignees),
+    milestone = trim(details.milestone),
+    draft = details.draft == true,
+    reviewers = normalize_list(details.reviewers),
+  }
+end
+
+function M.diff(previous, current)
+  local before = normalize_list(previous)
+  local after = normalize_list(current)
+  local before_set = {}
+  local after_set = {}
+  local added = {}
+  local removed = {}
+
+  for _, item in ipairs(before) do
+    before_set[item] = true
+  end
+  for _, item in ipairs(after) do
+    after_set[item] = true
+    if not before_set[item] then
+      table.insert(added, item)
+    end
+  end
+  for _, item in ipairs(before) do
+    if not after_set[item] then
+      table.insert(removed, item)
+    end
+  end
+
+  return added, removed
+end
+
+return M

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -65,6 +65,21 @@
 ---@field draft boolean
 ---@field reviewers string[]
 
+---@class forge.SubmissionFields
+---@field labels boolean?
+---@field assignees boolean?
+---@field milestone boolean?
+---@field draft boolean?
+---@field reviewers boolean?
+
+---@class forge.SubmissionOps
+---@field create forge.SubmissionFields?
+---@field update forge.SubmissionFields?
+
+---@class forge.Submission
+---@field issue forge.SubmissionOps?
+---@field pr forge.SubmissionOps?
+
 ---@class forge.CreatePROpts
 ---@field draft boolean?
 ---@field instant boolean?
@@ -127,6 +142,7 @@
 ---@field kinds { issue: string, pr: string }
 ---@field labels { issue: string, pr: string, pr_one: string, pr_full: string, ci: string }
 ---@field capabilities forge.Capabilities
+---@field submission forge.Submission?
 ---@field list_pr_json_cmd fun(self: forge.Forge, state: string, limit?: integer, scope?: forge.Scope): string[]
 ---@field list_issue_json_cmd fun(self: forge.Forge, state: string, limit?: integer, scope?: forge.Scope): string[]
 ---@field pr_fields { number: string, title: string, branch: string, state: string, author: string, created_at: string }
@@ -161,7 +177,7 @@
 ---@field reopen_issue_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field draft_toggle_cmd fun(self: forge.Forge, num: string, is_draft: boolean, scope?: forge.Scope): string[]?
 ---@field create_pr_cmd fun(self: forge.Forge, title: string, body: string, base: string, draft: boolean, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
----@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
+---@field update_pr_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope, metadata?: forge.CommentMetadata, previous?: forge.CommentMetadata): string[]
 ---@field fetch_pr_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field parse_pr_details fun(self: forge.Forge, json: table): forge.PRDetails
 ---@field fetch_issue_details_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
@@ -176,7 +192,7 @@
 ---@field browse_release fun(self: forge.Forge, tag: string, scope?: forge.Scope)
 ---@field delete_release_cmd fun(self: forge.Forge, tag: string, scope?: forge.Scope): string[]
 ---@field create_issue_cmd fun(self: forge.Forge, title: string, body: string, labels: string[]?, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
----@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope, metadata?: forge.CommentMetadata): string[]
+---@field update_issue_cmd fun(self: forge.Forge, num: string, title: string, body: string, scope?: forge.Scope, metadata?: forge.CommentMetadata, previous?: forge.CommentMetadata): string[]
 ---@field issue_template_paths fun(self: forge.Forge): string[]
 ---@field create_issue_web_cmd (fun(self: forge.Forge, scope?: forge.Scope): string[]?)?
 ---@field create_issue_web_url (fun(self: forge.Forge, scope?: forge.Scope): string?)?

--- a/lua/forge/yaml.lua
+++ b/lua/forge/yaml.lua
@@ -191,6 +191,7 @@ end
 ---@field body string
 ---@field title string?
 ---@field labels string[]?
+---@field assignees string[]?
 
 ---@param doc table
 ---@return forge.TemplateResult
@@ -211,10 +212,15 @@ function M.render(doc)
   if type(labels) == 'string' then
     labels = { labels }
   end
+  local assignees = doc.assignees
+  if type(assignees) == 'string' then
+    assignees = { assignees }
+  end
   return {
     body = table.concat(parts, '\n'),
     title = doc.title or nil,
     labels = labels,
+    assignees = assignees,
   }
 end
 

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -191,6 +191,54 @@ describe('compose issue create', function()
     }, captured.args)
   end)
 
+  it('renders template assignees into the metadata block and extracts them on write', function()
+    local compose = require('forge.compose')
+    local f = {
+      name = 'github',
+      create_issue_cmd = function(_, title, body, labels, ref, metadata)
+        captured.args = {
+          title = title,
+          body = body,
+          labels = labels,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'create-issue', title, body }
+      end,
+    }
+
+    compose.open_issue(f, {
+      title = 'template issue',
+      body = '',
+      labels = { 'bug' },
+      assignees = { 'alice' },
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    assert.is_true(vim.tbl_contains(lines, '  Assignees: alice'))
+    vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# template issue done' })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.args ~= nil and captured.cleared == 1
+    end)
+
+    assert.same({
+      title = 'template issue done',
+      body = '',
+      labels = { 'bug' },
+      ref = nil,
+      metadata = {
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = '',
+        draft = false,
+        reviewers = {},
+      },
+    }, captured.args)
+  end)
+
   it('submits issues when the clipboard register is unavailable', function()
     local old_setreg = vim.fn.setreg
     vim.fn.setreg = function()

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -232,4 +232,46 @@ describe('compose pr edit', function()
     assert.same({}, captured.warns)
     assert.same({}, captured.errors)
   end)
+
+  it('uses submission semantics to hide unsupported draft edits while keeping reviewers', function()
+    local compose = require('forge.compose')
+    compose.open_pr_edit(
+      {
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = false, reviewers = false },
+        submission = {
+          pr = {
+            update = {
+              draft = false,
+              reviewers = true,
+              labels = true,
+              assignees = false,
+              milestone = true,
+            },
+          },
+        },
+        name = 'codeberg',
+      },
+      '23',
+      {
+        title = 'PR title',
+        body = 'PR body',
+        draft = true,
+        head_branch = 'real-pr-head',
+        base_branch = 'main',
+        reviewers = { 'bob' },
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
+      },
+      'real-pr-head'
+    )
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    assert.is_false(vim.tbl_contains(lines, '  Draft: true'))
+    assert.is_true(vim.tbl_contains(lines, '  Reviewers: bob'))
+    assert.is_true(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: alice'))
+    assert.is_true(vim.tbl_contains(lines, '  Milestone: v1'))
+  end)
 end)

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -52,10 +52,24 @@ describe('github', function()
   end)
 
   it('builds create_pr_cmd', function()
-    local cmd = gh:create_pr_cmd('title', 'body', 'main', false)
+    local cmd = gh:create_pr_cmd('title', 'body', 'main', false, nil, {
+      draft = true,
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      reviewers = { 'bob' },
+      milestone = 'v1',
+    })
     assert.truthy(vim.tbl_contains(cmd, '--title'))
     assert.truthy(vim.tbl_contains(cmd, '--base'))
-    assert.falsy(vim.tbl_contains(cmd, '--draft'))
+    assert.truthy(vim.tbl_contains(cmd, '--draft'))
+    assert.truthy(vim.tbl_contains(cmd, '--label'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'alice'))
+    assert.truthy(vim.tbl_contains(cmd, '--reviewer'))
+    assert.truthy(vim.tbl_contains(cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, 'v1'))
   end)
 
   it('builds issue detail and simplified issue commands', function()
@@ -73,15 +87,36 @@ describe('github', function()
     assert.truthy(vim.tbl_contains(details, '--json'))
     assert.truthy(vim.tbl_contains(details, 'title,body,labels,assignees,milestone,url'))
 
-    local create = gh:create_issue_cmd('title', 'body', { 'bug' }, {
-      repo_arg = 'owner/repo',
+    local create = gh:create_issue_cmd('title', 'body', { 'bug' }, { repo_arg = 'owner/repo' }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
     })
     assert.truthy(vim.tbl_contains(create, '--label'))
     assert.truthy(vim.tbl_contains(create, 'bug'))
+    assert.truthy(vim.tbl_contains(create, '--assignee'))
+    assert.truthy(vim.tbl_contains(create, 'alice'))
+    assert.truthy(vim.tbl_contains(create, '--milestone'))
+    assert.truthy(vim.tbl_contains(create, 'v1'))
 
-    local cmd = gh:update_issue_cmd('23', 'title', 'body', { repo_arg = 'owner/repo' })
-    assert.falsy(vim.tbl_contains(cmd, '--add-label'))
-    assert.falsy(vim.tbl_contains(cmd, '--remove-label'))
+    local cmd = gh:update_issue_cmd('23', 'title', 'body', { repo_arg = 'owner/repo' }, {
+      labels = { 'docs' },
+      assignees = { 'bob' },
+      milestone = '',
+    }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    })
+    assert.truthy(vim.tbl_contains(cmd, '--add-label'))
+    assert.truthy(vim.tbl_contains(cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-label'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--add-assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'alice'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-milestone'))
   end)
 
   it('parses fetched PR and issue metadata', function()
@@ -144,6 +179,36 @@ describe('github', function()
 
   it('adds draft flag to create_pr_cmd', function()
     assert.truthy(vim.tbl_contains(gh:create_pr_cmd('t', 'b', 'main', true), '--draft'))
+  end)
+
+  it('builds update_pr_cmd metadata deltas', function()
+    local cmd = gh:update_pr_cmd('23', 'title', 'body', { repo_arg = 'owner/repo' }, {
+      labels = { 'docs' },
+      assignees = { 'bob' },
+      reviewers = { 'carol' },
+      milestone = '',
+      draft = true,
+    }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      reviewers = { 'dave' },
+      milestone = 'v1',
+      draft = false,
+    })
+
+    assert.truthy(vim.tbl_contains(cmd, '--add-label'))
+    assert.truthy(vim.tbl_contains(cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-label'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--add-assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'alice'))
+    assert.truthy(vim.tbl_contains(cmd, '--add-reviewer'))
+    assert.truthy(vim.tbl_contains(cmd, 'carol'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-reviewer'))
+    assert.truthy(vim.tbl_contains(cmd, 'dave'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-milestone'))
   end)
 
   it('builds checkout_cmd', function()
@@ -364,10 +429,25 @@ describe('gitlab', function()
   end)
 
   it('builds create_pr_cmd with --description and --target-branch', function()
-    local cmd = gl:create_pr_cmd('title', 'desc', 'develop', false)
+    local cmd = gl:create_pr_cmd('title', 'desc', 'develop', false, nil, {
+      draft = true,
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      reviewers = { 'bob' },
+      milestone = 'v1',
+    })
     assert.truthy(vim.tbl_contains(cmd, '--description'))
     assert.truthy(vim.tbl_contains(cmd, '--target-branch'))
     assert.truthy(vim.tbl_contains(cmd, '--yes'))
+    assert.truthy(vim.tbl_contains(cmd, '--draft'))
+    assert.truthy(vim.tbl_contains(cmd, '--label'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'alice'))
+    assert.truthy(vim.tbl_contains(cmd, '--reviewer'))
+    assert.truthy(vim.tbl_contains(cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, 'v1'))
   end)
 
   it('builds issue detail and simplified issue commands', function()
@@ -377,15 +457,62 @@ describe('gitlab', function()
       vim.list_slice(details, 1, 6)
     )
 
-    local create = gl:create_issue_cmd('title', 'body', { 'bug' }, {
-      repo_arg = 'group/repo',
+    local create = gl:create_issue_cmd('title', 'body', { 'bug' }, { repo_arg = 'group/repo' }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
     })
     assert.truthy(vim.tbl_contains(create, '--label'))
     assert.truthy(vim.tbl_contains(create, 'bug'))
+    assert.truthy(vim.tbl_contains(create, '--assignee'))
+    assert.truthy(vim.tbl_contains(create, 'alice'))
+    assert.truthy(vim.tbl_contains(create, '--milestone'))
+    assert.truthy(vim.tbl_contains(create, 'v1'))
 
-    local cmd = gl:update_issue_cmd('23', 'title', 'body', { repo_arg = 'group/repo' })
-    assert.falsy(vim.tbl_contains(cmd, '--label'))
-    assert.falsy(vim.tbl_contains(cmd, '--unlabel'))
+    local cmd = gl:update_issue_cmd('23', 'title', 'body', { repo_arg = 'group/repo' }, {
+      labels = { 'docs' },
+      assignees = { 'bob' },
+      milestone = '',
+    }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    })
+    assert.truthy(vim.tbl_contains(cmd, '--label'))
+    assert.truthy(vim.tbl_contains(cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--unlabel'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, '0'))
+  end)
+
+  it('builds update_pr_cmd reviewer and label changes', function()
+    local cmd = gl:update_pr_cmd('23', 'title', 'body', { repo_arg = 'group/repo' }, {
+      labels = { 'docs' },
+      assignees = { 'bob' },
+      reviewers = {},
+      milestone = '',
+      draft = true,
+    }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      reviewers = { 'carol' },
+      milestone = 'v1',
+      draft = false,
+    })
+
+    assert.truthy(vim.tbl_contains(cmd, '--label'))
+    assert.truthy(vim.tbl_contains(cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--unlabel'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(cmd, '--reviewer'))
+    assert.truthy(vim.tbl_contains(cmd, '-carol'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, '0'))
   end)
 
   it('parses fetched MR and issue metadata', function()
@@ -503,9 +630,22 @@ describe('codeberg', function()
   end)
 
   it('ignores draft in create_pr_cmd', function()
-    local cmd = cb:create_pr_cmd('title', 'body', 'main', true)
+    local cmd = cb:create_pr_cmd('title', 'body', 'main', true, nil, {
+      draft = true,
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      reviewers = { 'bob' },
+      milestone = 'v1',
+    })
     assert.falsy(vim.tbl_contains(cmd, '--draft'))
     assert.truthy(vim.tbl_contains(cmd, '--base'))
+    assert.truthy(vim.tbl_contains(cmd, '--labels'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--assignees'))
+    assert.truthy(vim.tbl_contains(cmd, 'alice'))
+    assert.falsy(vim.tbl_contains(cmd, '--add-reviewers'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, 'v1'))
   end)
 
   it('returns correct pr_json_fields', function()
@@ -536,17 +676,35 @@ describe('codeberg', function()
   end)
 
   it('builds simplified issue commands for tea', function()
-    local create = cb:create_issue_cmd('title', 'body', { 'bug' }, {
-      repo_arg = 'forgejo/tea-test',
+    local create = cb:create_issue_cmd('title', 'body', { 'bug' }, { repo_arg = 'forgejo/tea-test' }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
     })
     assert.same({ 'tea', 'issues', 'create', '--title', 'title' }, vim.list_slice(create, 1, 5))
     assert.truthy(vim.tbl_contains(create, '--labels'))
     assert.truthy(vim.tbl_contains(create, 'bug'))
+    assert.truthy(vim.tbl_contains(create, '--assignees'))
+    assert.truthy(vim.tbl_contains(create, 'alice'))
+    assert.truthy(vim.tbl_contains(create, '--milestone'))
+    assert.truthy(vim.tbl_contains(create, 'v1'))
 
-    local cmd = cb:update_issue_cmd('23', 'title', 'body', { repo_arg = 'forgejo/tea-test' })
+    local cmd = cb:update_issue_cmd('23', 'title', 'body', { repo_arg = 'forgejo/tea-test' }, {
+      labels = { 'docs' },
+      assignees = { 'bob' },
+      milestone = '',
+    }, {
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    })
     assert.same({ 'tea', 'issues', 'edit', '23' }, vim.list_slice(cmd, 1, 4))
-    assert.falsy(vim.tbl_contains(cmd, '--add-labels'))
-    assert.falsy(vim.tbl_contains(cmd, '--remove-labels'))
+    assert.truthy(vim.tbl_contains(cmd, '--add-labels'))
+    assert.truthy(vim.tbl_contains(cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-labels'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, ''))
   end)
 
   it('parses fetched PR and issue metadata for tea', function()
@@ -554,17 +712,18 @@ describe('codeberg', function()
       {
         title = 'title',
         body = 'body',
-        draft = false,
+        draft = true,
         head_branch = 'topic',
         base_branch = 'main',
         labels = { 'bug' },
         assignees = { 'alice' },
-        reviewers = {},
+        reviewers = { 'bob' },
         milestone = 'v1',
       },
       cb:parse_pr_details({
         title = 'title',
         body = 'body',
+        draft = true,
         head = { ref = 'topic' },
         base = { ref = 'main' },
         labels = {
@@ -572,6 +731,9 @@ describe('codeberg', function()
         },
         assignees = {
           { login = 'alice' },
+        },
+        requested_reviewers = {
+          { login = 'bob' },
         },
         milestone = {
           title = 'v1',

--- a/spec/submission_integration_spec.lua
+++ b/spec/submission_integration_spec.lua
@@ -1,0 +1,280 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('submission integration', function()
+  local captured
+  local old_fn_system
+  local old_system
+  local old_feedkeys
+  local old_preload
+
+  before_each(function()
+    captured = {
+      calls = {},
+      infos = {},
+      warns = {},
+      errors = {},
+      cleared = 0,
+    }
+
+    old_fn_system = vim.fn.system
+    old_system = vim.system
+    old_feedkeys = vim.api.nvim_feedkeys
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.template'] = package.preload['forge.template'],
+    }
+
+    vim.fn.system = function(cmd)
+      if cmd:match('^git diff %-%-stat ') then
+        return ''
+      end
+      return ''
+    end
+
+    vim.api.nvim_feedkeys = function() end
+
+    vim.system = function(cmd, _, cb)
+      table.insert(captured.calls, cmd)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
+        end,
+        scope_repo_arg = function(scope)
+          return scope and scope.repo_arg or ''
+        end,
+        remote_web_url = function()
+          return ''
+        end,
+        scope_key = function(scope)
+          return scope and scope.repo_arg or ''
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
+        warn = function(msg)
+          table.insert(captured.warns, msg)
+        end,
+        error = function(msg)
+          table.insert(captured.errors, msg)
+        end,
+      }
+    end
+
+    package.preload['forge.template'] = function()
+      return {
+        normalize_body = function(s)
+          return vim.trim(s):gsub('%s+', ' ')
+        end,
+        fill_from_commits = function()
+          return 'title', 'body'
+        end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.codeberg'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.github'] = nil
+    package.loaded['forge.gitlab'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.submission'] = nil
+    package.loaded['forge.template'] = nil
+  end)
+
+  after_each(function()
+    vim.fn.system = old_fn_system
+    vim.system = old_system
+    vim.api.nvim_feedkeys = old_feedkeys
+
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.template'] = old_preload['forge.template']
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.codeberg'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.github'] = nil
+    package.loaded['forge.gitlab'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.submission'] = nil
+    package.loaded['forge.template'] = nil
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        local name = vim.api.nvim_buf_get_name(buf)
+        if name:match('^forge://') then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end
+    vim.cmd('enew!')
+  end)
+
+  it('submits GitHub issue metadata through compose into the real adapter', function()
+    local compose = require('forge.compose')
+    local gh = require('forge.github')
+
+    compose.open_issue(gh, {
+      title = 'bug: ',
+      body = '',
+      labels = { 'bug' },
+      assignees = { 'alice' },
+    }, { repo_arg = 'owner/repo' })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# fixed issue',
+      '',
+      'body',
+      '',
+      '<!--',
+      '  Labels: bug, docs',
+      '  Assignees: alice',
+      '  Milestone: v1',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return #captured.calls > 0
+    end)
+
+    local cmd = captured.calls[1]
+    assert.same({ 'gh', 'issue', 'create' }, vim.list_slice(cmd, 1, 3))
+    assert.truthy(vim.tbl_contains(cmd, '--label'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug,docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--assignee'))
+    assert.truthy(vim.tbl_contains(cmd, 'alice'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(cmd, 'v1'))
+  end)
+
+  it('submits GitLab PR updates and draft toggle through compose into the real adapter', function()
+    local compose = require('forge.compose')
+    local gl = require('forge.gitlab')
+
+    compose.open_pr_edit(gl, '23', {
+      title = 'PR title',
+      body = 'PR body',
+      draft = false,
+      head_branch = 'topic',
+      base_branch = 'main',
+      reviewers = { 'carol' },
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    }, 'topic', { repo_arg = 'group/repo' })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# updated pr',
+      '',
+      'updated body',
+      '',
+      '<!--',
+      '  Draft: true',
+      '  Reviewers: bob',
+      '  Labels: docs',
+      '  Assignees: bob',
+      '  Milestone: ',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return #captured.calls >= 2
+    end)
+
+    local update_cmd = captured.calls[1]
+    local draft_cmd = captured.calls[2]
+    assert.same({ 'glab', 'mr', 'update', '23' }, vim.list_slice(update_cmd, 1, 4))
+    assert.truthy(vim.tbl_contains(update_cmd, '--label'))
+    assert.truthy(vim.tbl_contains(update_cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(update_cmd, '--unlabel'))
+    assert.truthy(vim.tbl_contains(update_cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(update_cmd, '--assignee'))
+    assert.truthy(vim.tbl_contains(update_cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(update_cmd, '--reviewer'))
+    assert.truthy(vim.tbl_contains(update_cmd, 'bob'))
+    assert.truthy(vim.tbl_contains(update_cmd, '--milestone'))
+    assert.truthy(vim.tbl_contains(update_cmd, '0'))
+    assert.same({ 'glab', 'mr', 'update', '23', '--draft', '-R', 'group/repo' }, draft_cmd)
+  end)
+
+  it('submits Codeberg PR updates through compose using only supported metadata fields', function()
+    local compose = require('forge.compose')
+    local cb = require('forge.codeberg')
+
+    compose.open_pr_edit(cb, '23', {
+      title = 'PR title',
+      body = 'PR body',
+      draft = true,
+      head_branch = 'topic',
+      base_branch = 'main',
+      reviewers = { 'carol' },
+      labels = { 'bug' },
+      assignees = { 'alice' },
+      milestone = 'v1',
+    }, 'topic', { repo_arg = 'forgejo/tea-test' })
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    assert.is_false(vim.tbl_contains(lines, '  Draft: true'))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: alice'))
+    assert.is_true(vim.tbl_contains(lines, '  Reviewers: carol'))
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# updated pr',
+      '',
+      'updated body',
+      '',
+      '<!--',
+      '  Reviewers: dave',
+      '  Labels: docs',
+      '  Assignees: bob',
+      '  Milestone: ',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return #captured.calls > 0
+    end)
+
+    local cmd = captured.calls[1]
+    assert.same({ 'tea', 'pr', 'edit', '23' }, vim.list_slice(cmd, 1, 4))
+    assert.truthy(vim.tbl_contains(cmd, '--add-labels'))
+    assert.truthy(vim.tbl_contains(cmd, 'docs'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-labels'))
+    assert.truthy(vim.tbl_contains(cmd, 'bug'))
+    assert.truthy(vim.tbl_contains(cmd, '--add-reviewers'))
+    assert.truthy(vim.tbl_contains(cmd, 'dave'))
+    assert.truthy(vim.tbl_contains(cmd, '--remove-reviewers'))
+    assert.truthy(vim.tbl_contains(cmd, 'carol'))
+    assert.truthy(vim.tbl_contains(cmd, '--milestone'))
+    assert.falsy(vim.tbl_contains(cmd, '--add-assignees'))
+  end)
+end)

--- a/spec/yaml_spec.lua
+++ b/spec/yaml_spec.lua
@@ -219,8 +219,17 @@ describe('render', function()
     assert.same({ 'bug' }, result.labels)
   end)
 
+  it('returns assignees', function()
+    local result = yaml.render({ assignees = { 'alice', 'bob' }, body = {} })
+    assert.same({ 'alice', 'bob' }, result.assignees)
+  end)
+
   it('wraps string labels into table', function()
     assert.same({ 'bug' }, yaml.render({ labels = 'bug', body = {} }).labels)
+  end)
+
+  it('wraps string assignees into table', function()
+    assert.same({ 'alice' }, yaml.render({ assignees = 'alice', body = {} }).assignees)
   end)
 
   describe('bug_report.yaml end-to-end', function()


### PR DESCRIPTION
## Problem

Compose metadata rendering and submission were drifting across forges because each adapter encoded support ad hoc. That left template defaults, compose comment fields, and create/update command construction out of sync, especially once the same field was fetchable on one forge, creatable on another, or only partially mutable during edit flows.

## Solution

Add a shared internal submission-semantics layer and have compose plus each forge adapter use that same source of truth for create and update behavior. This makes template defaults flow through the compose metadata block, applies only forge-supported metadata on save, restores Codeberg's fetched draft and reviewer parsing without exposing unsupported edits, and adds integration coverage that drives the real adapters through compose to verify the end-to-end command construction.
