### PR TITLE
fix(fzf): let picker selection highlight win over metadata

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -4,12 +4,6 @@ local fzf_args = (vim.env.FZF_DEFAULT_OPTS or '')
   :gsub('%-%-bind=[^%s]+', '')
   :gsub('%-%-color=[^%s]+', '')
 
-local no_bg_highlights = {
-  ForgeBranch = true,
-  ForgeBranchCurrent = true,
-  ForgeMerged = true,
-}
-
 local special_keys = {
   ['<cr>'] = { fzf = 'enter', header = '<cr>' },
   ['<tab>'] = { fzf = 'tab', header = '<tab>' },
@@ -54,9 +48,7 @@ local function render(segments)
   for _, seg in ipairs(segments) do
     if seg[2] then
       local text = utils.ansi_from_hl(seg[2], seg[1])
-      if no_bg_highlights[seg[2]] then
-        text = strip_bg_ansi(text)
-      end
+      text = strip_bg_ansi(text)
       table.insert(parts, text)
     else
       table.insert(parts, seg[1])

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -820,4 +820,58 @@ describe('fzf picker', function()
     assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3mfeature/test\27%[0m'))
     assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m main\27%[0m'))
   end)
+
+  it('strips author and metadata background ANSI so the selected row highlight can win across pickers', function()
+    local utils = require('fzf-lua.utils')
+    local old_ansi_from_hl = utils.ansi_from_hl
+    utils.ansi_from_hl = function(group, text)
+      if group == 'FzfLuaHeaderBind' or group == 'FzfLuaHeaderText' then
+        return ('[%s:%s]'):format(group, text)
+      end
+      if group then
+        return ('\27[48;2;255;255;255m\27[38;2;1;2;3m%s\27[0m'):format(text)
+      end
+      return text
+    end
+
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Issues> ',
+      entries = {
+        {
+          display = {
+            { '#7', 'ForgeNumber' },
+            { ' Cursorline bug ' },
+            { 'alice', 'ForgeAuthor' },
+            { ' 1h', 'ForgeTime' },
+          },
+          value = '7',
+        },
+        {
+          display = {
+            { 'abc1234', 'ForgeCommitHash' },
+            { ' fix selection ' },
+            { 'bob', 'ForgeCommitAuthor' },
+            { ' /repo-feature', 'Directory' },
+            { ' detached', 'ForgeDim' },
+          },
+          value = 'abc1234',
+        },
+      },
+      actions = {},
+      picker_name = 'issue',
+    })
+
+    utils.ansi_from_hl = old_ansi_from_hl
+
+    assert.is_not_nil(captured)
+    assert.same(2, #captured.lines)
+    assert.is_nil(captured.lines[1]:match('\27%[48;'))
+    assert.is_nil(captured.lines[2]:match('\27%[48;'))
+    assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3malice\27%[0m'))
+    assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m 1h\27%[0m'))
+    assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3mbob\27%[0m'))
+    assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3m /repo%-feature\27%[0m'))
+    assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3m detached\27%[0m'))
+  end)
 end)


### PR DESCRIPTION
## Problem

Highlighted picker segments can carry their own background ANSI through `ansi_from_hl()`, which lets row metadata like issue authors override the selected-row background in fzf-lua. The current renderer only strips backgrounds for a small branch-specific allowlist, so the same cursorline bug still shows up on usernames and other metadata segments.

## Solution

Strip background ANSI from all highlighted entry segments in the shared fzf picker renderer so the selected row highlight wins consistently across issue, PR, commit, worktree, CI, and related picker rows. Add a regression spec that covers author and metadata segments in addition to the existing branch-focused case.