### PR TITLE
fix(compose): omit empty metadata lines

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -173,13 +173,25 @@ local function add_metadata_fields(builder, forge, kind, operation, metadata)
       local value_hl = draft and 'ForgeComposeDraft' or 'ForgeDim'
       add_metadata_line(builder, 'Draft', draft and 'true' or 'false', value_hl)
     elseif field == 'reviewers' then
-      add_metadata_line(builder, 'Reviewers', table.concat(metadata.reviewers or {}, ', '))
+      local reviewers = table.concat(metadata.reviewers or {}, ', ')
+      if reviewers ~= '' then
+        add_metadata_line(builder, 'Reviewers', reviewers)
+      end
     elseif field == 'labels' then
-      add_metadata_line(builder, 'Labels', table.concat(metadata.labels or {}, ', '))
+      local labels = table.concat(metadata.labels or {}, ', ')
+      if labels ~= '' then
+        add_metadata_line(builder, 'Labels', labels)
+      end
     elseif field == 'assignees' then
-      add_metadata_line(builder, 'Assignees', table.concat(metadata.assignees or {}, ', '))
+      local assignees = table.concat(metadata.assignees or {}, ', ')
+      if assignees ~= '' then
+        add_metadata_line(builder, 'Assignees', assignees)
+      end
     elseif field == 'milestone' then
-      add_metadata_line(builder, 'Milestone', metadata.milestone or '')
+      local milestone = metadata.milestone or ''
+      if milestone ~= '' then
+        add_metadata_line(builder, 'Milestone', milestone)
+      end
     end
   end
 end

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -116,9 +116,9 @@ describe('compose issue create', function()
 
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-    assert.is_true(vim.tbl_contains(lines, '  Labels: '))
-    assert.is_true(vim.tbl_contains(lines, '  Assignees: '))
-    assert.is_true(vim.tbl_contains(lines, '  Milestone: '))
+    assert.is_false(vim.tbl_contains(lines, '  Labels: '))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
     vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# test issue' })
     vim.cmd('write')
 
@@ -169,6 +169,8 @@ describe('compose issue create', function()
     local buf = vim.api.nvim_get_current_buf()
     local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
     assert.is_true(vim.tbl_contains(lines, '  Labels: bug'))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
     vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# template issue done' })
     vim.cmd('write')
 
@@ -444,6 +446,36 @@ describe('compose issue edit', function()
     assert.equals(1, captured.cleared)
     assert.same({}, captured.warns)
     assert.same({}, captured.errors)
+  end)
+
+  it('omits empty issue metadata lines in the comment block', function()
+    local compose = require('forge.compose')
+    local f = {
+      name = 'github',
+      update_issue_cmd = function(_, num, title, body, ref, metadata)
+        captured.args = {
+          num = num,
+          title = title,
+          body = body,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'update-issue', num, title, body }
+      end,
+    }
+
+    compose.open_issue_edit(f, '42', {
+      title = 'existing issue',
+      body = 'body',
+      labels = {},
+      assignees = {},
+      milestone = '',
+    })
+
+    local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    assert.is_false(vim.tbl_contains(lines, '  Labels: '))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
   end)
 
   it('treats a broken comment opener as body text on write', function()

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -163,6 +163,11 @@ describe('compose pr edit', function()
       assert.is_false(line == '  Changes not in origin/main:')
       assert.is_false(line == '   lua/forge/init.lua | 2 +-')
     end
+    assert.is_true(vim.tbl_contains(lines, '  Draft: false'))
+    assert.is_false(vim.tbl_contains(lines, '  Reviewers: '))
+    assert.is_false(vim.tbl_contains(lines, '  Labels: '))
+    assert.is_false(vim.tbl_contains(lines, '  Assignees: '))
+    assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
   end)
 
   it('extracts PR metadata from the comment block on write', function()


### PR DESCRIPTION
## Problem

Compose buffers still render metadata labels like `Milestone:` and `Assignees:` even when the current value is empty. That leaves placeholder-looking empty fields in the editable comment scaffold instead of only showing metadata that is actually present.

## Solution

Only render reviewer, label, assignee, and milestone lines when they have a non-empty value, while still keeping boolean draft state visible. Update the compose specs to cover empty create/edit metadata blocks so blank fields stay omitted.