### PR TITLE
fix(issue): always offer Blank Issue

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -1227,6 +1227,8 @@ SHARED OPERATIONS: `require('forge.ops')` ~
 `create_issue(opts?)`
     Creates an issue. `opts` is `forge.CreateIssueOpts?`:
       `web`       `boolean?`  Open web creation page.
+      `blank`     `boolean?`  Start from Blank Issue.
+      `template`  `string?`   Use the named issue template slug.
 
                                                           *forge.edit_issue()*
 `edit_issue(num, ref?)`

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -671,11 +671,7 @@ function M.create_issue(opts)
   end
 
   local root = git_root() or ''
-  local result, templates, err = template_mod.discover(f:issue_template_paths(), root)
-  if err then
-    log.error(err)
-    return
-  end
+  local templates = template_mod.entries(f:issue_template_paths(), root)
 
   if opts.template and templates then
     local slug = opts.template:lower()
@@ -694,13 +690,20 @@ function M.create_issue(opts)
     return
   end
 
-  if result or not templates then
-    compose_mod.open_issue(f, result, ref)
+  if not templates then
+    compose_mod.open_issue(f, nil, ref)
     return
   end
 
   local picker = require('forge.picker')
-  local entries = {}
+  local entries = {
+    {
+      display = { { 'Blank Issue' } },
+      value = nil,
+      ordinal = 'Blank Issue',
+      blank = true,
+    },
+  }
   for _, t in ipairs(templates) do
     table.insert(entries, {
       display = { { t.display } },
@@ -717,6 +720,10 @@ function M.create_issue(opts)
         label = 'use',
         fn = function(entry)
           if entry then
+            if entry.blank then
+              compose_mod.open_issue(f, nil, ref)
+              return
+            end
             local template, load_err = template_mod.load(entry.value)
             if load_err then
               log.error(load_err)

--- a/lua/forge/template.lua
+++ b/lua/forge/template.lua
@@ -108,27 +108,37 @@ end
 
 ---@param paths string[]
 ---@param repo_root string
----@return forge.TemplateResult? result
 ---@return forge.TemplateEntry[]? templates
----@return string? err
-function M.discover(paths, repo_root)
+function M.entries(paths, repo_root)
   local log = require('forge.logger')
   local t0 = vim.uv.hrtime()
+  ---@type forge.TemplateEntry[]
+  local templates = {}
   for _, p in ipairs(paths) do
     local full = repo_root .. '/' .. p
     local stat = vim.uv.fs_stat(full)
     if stat and stat.type == 'file' then
-      local content = M.read_file(full)
-      if content then
-        log.debug(('template: %s (%.1fms)'):format(p, (vim.uv.hrtime() - t0) / 1e6))
-        local result, err = M.make_template_result(content, M.is_yaml(p))
-        return result, nil, err
+      local name = vim.fs.basename(p)
+      local is_yml = M.is_yaml(name) and not name:match('^config%.ya?ml$')
+      local is_md = name:match('%.md$')
+      if is_md or is_yml then
+        local display = name
+        if is_yml then
+          local content = M.read_file(full)
+          if content then
+            display = M.yaml_name(content) or name
+          end
+        end
+        templates[#templates + 1] = {
+          name = name,
+          display = display,
+          is_yaml = is_yml == true,
+          dir = vim.fs.dirname(full),
+        }
       end
     elseif stat and stat.type == 'directory' then
       local handle = vim.uv.fs_scandir(full)
       if handle then
-        ---@type forge.TemplateEntry[]
-        local templates = {}
         while true do
           local name, typ = vim.uv.fs_scandir_next(handle)
           if not name then
@@ -147,32 +157,39 @@ function M.discover(paths, repo_root)
             table.insert(templates, {
               name = name,
               display = display,
-              is_yaml = is_yml ~= nil,
+              is_yaml = is_yml == true,
               dir = full,
             })
           end
         end
-        if #templates == 1 then
-          local content = M.read_file(full .. '/' .. templates[1].name)
-          if content then
-            local result, err = M.make_template_result(content, templates[1].is_yaml)
-            return result, nil, err
-          end
-        elseif #templates > 0 then
-          table.sort(templates, function(a, b)
-            return a.display < b.display
-          end)
-          log.debug(
-            ('templates: found %d in %s (%.1fms)'):format(
-              #templates,
-              full,
-              (vim.uv.hrtime() - t0) / 1e6
-            )
-          )
-          return nil, templates
-        end
       end
     end
+  end
+  if #templates == 0 then
+    return nil
+  end
+  table.sort(templates, function(a, b)
+    return a.display < b.display
+  end)
+  log.debug(('templates: found %d (%.1fms)'):format(#templates, (vim.uv.hrtime() - t0) / 1e6))
+  return templates
+end
+
+---@param paths string[]
+---@param repo_root string
+---@return forge.TemplateResult? result
+---@return forge.TemplateEntry[]? templates
+---@return string? err
+function M.discover(paths, repo_root)
+  local templates = M.entries(paths, repo_root)
+  if templates and #templates == 1 then
+    local content = M.read_file(templates[1].dir .. '/' .. templates[1].name)
+    if content then
+      local result, err = M.make_template_result(content, templates[1].is_yaml)
+      return result, nil, err
+    end
+  elseif templates and #templates > 1 then
+    return nil, templates
   end
   return nil, nil, nil
 end

--- a/spec/create_issue_spec.lua
+++ b/spec/create_issue_spec.lua
@@ -89,6 +89,7 @@ describe('create_issue', function()
     package.preload['forge.compose'] = function()
       return {
         open_issue = function(_, result)
+          captured.opened_calls = (captured.opened_calls or 0) + 1
           captured.opened = result
         end,
       }
@@ -199,26 +200,35 @@ describe('create_issue', function()
     package.loaded['forge.template'] = nil
   end)
 
-  it('aborts issue creation when a single yaml template cannot be loaded', function()
+  it('offers Blank Issue alongside a single yaml template', function()
     package.preload['forge.template'] = function()
       return {
-        discover = function()
+        entries = function()
+          return {
+            {
+              name = 'bug_report.yaml',
+              display = 'Bug Report',
+              is_yaml = true,
+              dir = '/repo/.github/ISSUE_TEMPLATE',
+            },
+          }
+        end,
+        load = function()
           return nil,
-            nil,
             'tree-sitter yaml parser not found; install it to use YAML issue form templates'
         end,
-        load = function() end,
       }
     end
 
     require('forge').create_issue()
 
+    assert.is_not_nil(captured.picker)
+    assert.same('Blank Issue', captured.picker.entries[1].display[1][1])
+    assert.same('Bug Report', captured.picker.entries[2].display[1][1])
+    captured.picker.actions[1].fn(captured.picker.entries[1])
+    assert.equals(1, captured.opened_calls)
     assert.is_nil(captured.opened)
-    assert.is_nil(captured.picker)
-    assert.same(
-      { 'tree-sitter yaml parser not found; install it to use YAML issue form templates' },
-      captured.errors
-    )
+    assert.same({}, captured.errors)
   end)
 
   it(
@@ -226,17 +236,15 @@ describe('create_issue', function()
     function()
       package.preload['forge.template'] = function()
         return {
-          discover = function()
-            return nil,
+          entries = function()
+            return {
               {
-                {
-                  name = 'bug_report.yaml',
-                  display = 'Bug Report',
-                  is_yaml = true,
-                  dir = '/repo/.github/ISSUE_TEMPLATE',
-                },
+                name = 'bug_report.yaml',
+                display = 'Bug Report',
+                is_yaml = true,
+                dir = '/repo/.github/ISSUE_TEMPLATE',
               },
-              nil
+            }
           end,
           load = function()
             return nil,
@@ -248,9 +256,9 @@ describe('create_issue', function()
       require('forge').create_issue()
 
       assert.is_not_nil(captured.picker)
-      captured.picker.actions[1].fn(captured.picker.entries[1])
+      captured.picker.actions[1].fn(captured.picker.entries[2])
 
-      assert.is_nil(captured.opened)
+      assert.is_nil(captured.opened_calls)
       assert.same(
         { 'tree-sitter yaml parser not found; install it to use YAML issue form templates' },
         captured.errors
@@ -263,17 +271,15 @@ describe('create_issue', function()
 
     package.preload['forge.template'] = function()
       return {
-        discover = function()
-          return nil,
+        entries = function()
+          return {
             {
-              {
-                name = 'bug_report.md',
-                display = 'Bug Report',
-                is_yaml = false,
-                dir = '/repo/.github/ISSUE_TEMPLATE',
-              },
+              name = 'bug_report.md',
+              display = 'Bug Report',
+              is_yaml = false,
+              dir = '/repo/.github/ISSUE_TEMPLATE',
             },
-            nil
+          }
         end,
         load = function()
           return { body = 'template' }
@@ -288,6 +294,8 @@ describe('create_issue', function()
     })
 
     assert.is_not_nil(captured.picker)
+    assert.same('Blank Issue', captured.picker.entries[1].display[1][1])
+    assert.same('Bug Report', captured.picker.entries[2].display[1][1])
     assert.is_function(captured.picker.back)
 
     captured.picker.back()


### PR DESCRIPTION
## Problem

Issue template selection does not always offer a blank issue path. When templates are present, especially in the single-template case, forge.nvim can skip straight to the template and hide the blank compose flow even though GitHub presents this as `Blank Issue`.

## Solution

Always prepend a `Blank Issue` entry to the issue template picker whenever templates are available, including the single-template case. Keep template loading behavior unchanged for real template entries, and align the `create_issue(opts?)` API docs with the supported `blank` and `template` options.