### PR TITLE
fix(issue): move Blank Issue after templates

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -696,14 +696,7 @@ function M.create_issue(opts)
   end
 
   local picker = require('forge.picker')
-  local entries = {
-    {
-      display = { { 'Blank Issue' } },
-      value = nil,
-      ordinal = 'Blank Issue',
-      blank = true,
-    },
-  }
+  local entries = {}
   for _, t in ipairs(templates) do
     table.insert(entries, {
       display = { { t.display } },
@@ -711,6 +704,12 @@ function M.create_issue(opts)
       ordinal = t.display,
     })
   end
+  table.insert(entries, {
+    display = { { 'Blank Issue' } },
+    value = nil,
+    ordinal = 'Blank Issue',
+    blank = true,
+  })
   picker.pick({
     prompt = 'Issue Template> ',
     entries = entries,

--- a/spec/create_issue_spec.lua
+++ b/spec/create_issue_spec.lua
@@ -223,9 +223,9 @@ describe('create_issue', function()
     require('forge').create_issue()
 
     assert.is_not_nil(captured.picker)
-    assert.same('Blank Issue', captured.picker.entries[1].display[1][1])
-    assert.same('Bug Report', captured.picker.entries[2].display[1][1])
-    captured.picker.actions[1].fn(captured.picker.entries[1])
+    assert.same('Bug Report', captured.picker.entries[1].display[1][1])
+    assert.same('Blank Issue', captured.picker.entries[2].display[1][1])
+    captured.picker.actions[1].fn(captured.picker.entries[2])
     assert.equals(1, captured.opened_calls)
     assert.is_nil(captured.opened)
     assert.same({}, captured.errors)
@@ -256,7 +256,7 @@ describe('create_issue', function()
       require('forge').create_issue()
 
       assert.is_not_nil(captured.picker)
-      captured.picker.actions[1].fn(captured.picker.entries[2])
+      captured.picker.actions[1].fn(captured.picker.entries[1])
 
       assert.is_nil(captured.opened_calls)
       assert.same(
@@ -294,8 +294,8 @@ describe('create_issue', function()
     })
 
     assert.is_not_nil(captured.picker)
-    assert.same('Blank Issue', captured.picker.entries[1].display[1][1])
-    assert.same('Bug Report', captured.picker.entries[2].display[1][1])
+    assert.same('Bug Report', captured.picker.entries[1].display[1][1])
+    assert.same('Blank Issue', captured.picker.entries[2].display[1][1])
     assert.is_function(captured.picker.back)
 
     captured.picker.back()


### PR DESCRIPTION
## Problem

The issue template picker now always offers `Blank Issue`, but it appears before all configured templates. That puts the fallback path ahead of the actual repository templates and makes the picker feel out of order.

## Solution

Append `Blank Issue` after the discovered issue templates so repository-defined templates stay first while the blank fallback remains available at the end. Update the focused create-issue specs to lock in the new ordering.