### PR TITLE
fix(cmd): keep direct Forge actions picker-free

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -422,7 +422,9 @@ BANG SEMANTICS                                            *forge-command-bang*
     PR creation commands are branch-relative. Default targets: `head=` is
     the current branch push context and `base=` is the collaboration repo
     default branch.
-    (no modifiers)     Open the compose buffer (|forge-compose|).
+    (no modifiers)     Open the compose buffer (|forge-compose|). If
+                       multiple PR templates exist, Forge does not prompt
+                       here and opens the default compose body instead.
     `draft`            Open compose buffer with draft pre-set.
     `fill`             Create instantly from commits (skip compose).
     `web`              Push and open the forge's web create-PR page for the
@@ -474,7 +476,9 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge issue create` [repo=...] [web] [blank] [template=...]
                                                          *:Forge-issue-create*
     Create a new issue.
-    (no modifiers)     Open the compose buffer.
+    (no modifiers)     Open the compose buffer. If multiple issue
+                       templates exist, use `template=...` to select one;
+                       otherwise Forge opens a blank issue compose.
     `web`              Open the forge's web create-issue page.
     `blank`            Start from a blank issue template when supported.
     `template=...`     Use the named issue template.
@@ -818,7 +822,7 @@ Creating a PR (without `--fill` or `--web`) opens a compose buffer at
 Layout: ~
   Line 1      PR title (pre-filled from single commit subject or branch)
   Line 2      Empty separator
-  Lines 3+    PR body (from commit body or discovered PR template)
+  Lines 3+    PR body (from commit body or a single discovered PR template)
   `<!--`        Informational comment block (branch, forge, diff stat).
   `-->`         End of metadata
 
@@ -831,7 +835,7 @@ Creating an issue (without `--web`) opens a compose buffer at
 Layout: ~
   Line 1      Issue title
   Line 2      Empty separator
-  Lines 3+    Issue body (from discovered issue template, or empty)
+  Lines 3+    Issue body (from a single discovered issue template, or empty)
   `<!--`        Informational comment block (forge, submit/discard hints).
   `-->`         End of metadata
 

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -507,61 +507,17 @@ function M.create_pr(opts)
               log.error(err)
               return
             end
-            if tmpl or not templates then
-              compose_mod.open_pr(
-                f,
-                branch,
-                base,
-                draft,
-                tmpl,
-                base_scope,
-                push_to,
-                target_ref,
-                head_ref
-              )
-            else
-              local picker = require('forge.picker')
-              local entries = {}
-              for _, t in ipairs(templates) do
-                table.insert(entries, {
-                  display = { { t.display } },
-                  value = t,
-                  ordinal = t.display,
-                })
-              end
-              picker.pick({
-                prompt = f.labels.pr_one .. ' Template> ',
-                entries = entries,
-                actions = {
-                  {
-                    name = 'default',
-                    label = 'use',
-                    fn = function(entry)
-                      if entry then
-                        local template, load_err = template_mod.load(entry.value)
-                        if load_err then
-                          log.error(load_err)
-                          return
-                        end
-                        compose_mod.open_pr(
-                          f,
-                          branch,
-                          base,
-                          draft,
-                          template,
-                          base_scope,
-                          push_to,
-                          target_ref,
-                          head_ref
-                        )
-                      end
-                    end,
-                  },
-                },
-                picker_name = '_menu',
-                back = opts.back,
-              })
-            end
+            compose_mod.open_pr(
+              f,
+              branch,
+              base,
+              draft,
+              templates and nil or tmpl,
+              base_scope,
+              push_to,
+              target_ref,
+              head_ref
+            )
           end
         end)
       end)
@@ -671,71 +627,32 @@ function M.create_issue(opts)
   end
 
   local root = git_root() or ''
-  local templates = template_mod.entries(f:issue_template_paths(), root)
-
-  if opts.template and templates then
-    local slug = opts.template:lower()
-    for _, t in ipairs(templates) do
-      if t.name:gsub('%.ya?ml$', ''):gsub('%.md$', ''):lower() == slug then
-        local template, load_err = template_mod.load(t)
-        if load_err then
-          log.error(load_err)
+  if opts.template then
+    local templates = template_mod.entries(f:issue_template_paths(), root)
+    if templates then
+      local slug = opts.template:lower()
+      for _, t in ipairs(templates) do
+        if t.name:gsub('%.ya?ml$', ''):gsub('%.md$', ''):lower() == slug then
+          local template, load_err = template_mod.load(t)
+          if load_err then
+            log.error(load_err)
+            return
+          end
+          compose_mod.open_issue(f, template, ref)
           return
         end
-        compose_mod.open_issue(f, template, ref)
-        return
       end
     end
     log.warn('template not found: ' .. opts.template)
     return
   end
 
-  if not templates then
-    compose_mod.open_issue(f, nil, ref)
+  local template, templates, err = template_mod.discover(f:issue_template_paths(), root)
+  if err then
+    log.error(err)
     return
   end
-
-  local picker = require('forge.picker')
-  local entries = {}
-  for _, t in ipairs(templates) do
-    table.insert(entries, {
-      display = { { t.display } },
-      value = t,
-      ordinal = t.display,
-    })
-  end
-  table.insert(entries, {
-    display = { { 'Blank Issue' } },
-    value = nil,
-    ordinal = 'Blank Issue',
-    blank = true,
-  })
-  picker.pick({
-    prompt = 'Issue Template> ',
-    entries = entries,
-    actions = {
-      {
-        name = 'default',
-        label = 'use',
-        fn = function(entry)
-          if entry then
-            if entry.blank then
-              compose_mod.open_issue(f, nil, ref)
-              return
-            end
-            local template, load_err = template_mod.load(entry.value)
-            if load_err then
-              log.error(load_err)
-              return
-            end
-            compose_mod.open_issue(f, template, ref)
-          end
-        end,
-      },
-    },
-    picker_name = '_menu',
-    back = opts.back,
-  })
+  compose_mod.open_issue(f, templates and nil or template, ref)
 end
 
 function M.template_slugs()

--- a/spec/create_issue_spec.lua
+++ b/spec/create_issue_spec.lua
@@ -14,6 +14,7 @@ describe('create_issue', function()
       infos = {},
       systems = {},
       open_urls = {},
+      warnings = {},
     }
 
     old_fn_system = vim.fn.system
@@ -200,54 +201,46 @@ describe('create_issue', function()
     package.loaded['forge.template'] = nil
   end)
 
-  it('offers Blank Issue alongside a single yaml template', function()
+  it('opens a blank issue compose instead of prompting when multiple templates exist', function()
     package.preload['forge.template'] = function()
       return {
-        entries = function()
-          return {
-            {
-              name = 'bug_report.yaml',
-              display = 'Bug Report',
-              is_yaml = true,
-              dir = '/repo/.github/ISSUE_TEMPLATE',
-            },
-          }
-        end,
-        load = function()
+        discover = function()
           return nil,
-            'tree-sitter yaml parser not found; install it to use YAML issue form templates'
+            {
+              {
+                name = 'bug_report.md',
+                display = 'Bug Report',
+                is_yaml = false,
+                dir = '/repo/.github/ISSUE_TEMPLATE',
+              },
+              {
+                name = 'feature_request.md',
+                display = 'Feature Request',
+                is_yaml = false,
+                dir = '/repo/.github/ISSUE_TEMPLATE',
+              },
+            },
+            nil
         end,
       }
     end
 
     require('forge').create_issue()
 
-    assert.is_not_nil(captured.picker)
-    assert.same('Bug Report', captured.picker.entries[1].display[1][1])
-    assert.same('Blank Issue', captured.picker.entries[2].display[1][1])
-    captured.picker.actions[1].fn(captured.picker.entries[2])
     assert.equals(1, captured.opened_calls)
     assert.is_nil(captured.opened)
+    assert.is_nil(captured.picker)
     assert.same({}, captured.errors)
   end)
 
   it(
-    'logs an error instead of opening a blank issue when a selected yaml template fails to load',
+    'logs an error instead of opening an issue when the discovered template fails to load',
     function()
       package.preload['forge.template'] = function()
         return {
-          entries = function()
-            return {
-              {
-                name = 'bug_report.yaml',
-                display = 'Bug Report',
-                is_yaml = true,
-                dir = '/repo/.github/ISSUE_TEMPLATE',
-              },
-            }
-          end,
-          load = function()
+          discover = function()
             return nil,
+              nil,
               'tree-sitter yaml parser not found; install it to use YAML issue form templates'
           end,
         }
@@ -255,10 +248,8 @@ describe('create_issue', function()
 
       require('forge').create_issue()
 
-      assert.is_not_nil(captured.picker)
-      captured.picker.actions[1].fn(captured.picker.entries[1])
-
       assert.is_nil(captured.opened_calls)
+      assert.is_nil(captured.picker)
       assert.same(
         { 'tree-sitter yaml parser not found; install it to use YAML issue form templates' },
         captured.errors
@@ -266,9 +257,7 @@ describe('create_issue', function()
     end
   )
 
-  it('preserves back on the issue template picker', function()
-    local back_calls = 0
-
+  it('uses an explicit issue template slug without invoking the picker', function()
     package.preload['forge.template'] = function()
       return {
         entries = function()
@@ -279,28 +268,26 @@ describe('create_issue', function()
               is_yaml = false,
               dir = '/repo/.github/ISSUE_TEMPLATE',
             },
+            {
+              name = 'feature_request.md',
+              display = 'Feature Request',
+              is_yaml = false,
+              dir = '/repo/.github/ISSUE_TEMPLATE',
+            },
           }
         end,
-        load = function()
-          return { body = 'template' }
+        load = function(entry)
+          return { body = entry.display }
         end,
       }
     end
 
-    require('forge').create_issue({
-      back = function()
-        back_calls = back_calls + 1
-      end,
-    })
+    require('forge').create_issue({ template = 'feature_request' })
 
-    assert.is_not_nil(captured.picker)
-    assert.same('Bug Report', captured.picker.entries[1].display[1][1])
-    assert.same('Blank Issue', captured.picker.entries[2].display[1][1])
-    assert.is_function(captured.picker.back)
-
-    captured.picker.back()
-
-    assert.equals(1, back_calls)
+    assert.equals(1, captured.opened_calls)
+    assert.same({ body = 'Feature Request' }, captured.opened)
+    assert.is_nil(captured.picker)
+    assert.same({}, captured.errors)
   end)
 
   it('reports success when the web issue command succeeds', function()

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -126,6 +126,7 @@ describe('create_pr', function()
     package.preload['forge.compose'] = function()
       return {
         open_pr = function(_, _, _, _, result)
+          captured.opened_calls = (captured.opened_calls or 0) + 1
           captured.opened = result
         end,
       }
@@ -264,25 +265,16 @@ describe('create_pr', function()
     })
   end
 
-  it('preserves back on the PR template picker', function()
-    local back_calls = 0
-
-    require('forge').create_pr({
-      back = function()
-        back_calls = back_calls + 1
-      end,
-    })
+  it('opens PR compose without prompting when multiple templates exist', function()
+    require('forge').create_pr()
 
     vim.wait(100, function()
-      return captured.picker ~= nil
+      return captured.opened_calls ~= nil
     end)
 
-    assert.is_not_nil(captured.picker)
-    assert.is_function(captured.picker.back)
-
-    captured.picker.back()
-
-    assert.equals(1, back_calls)
+    assert.equals(1, captured.opened_calls)
+    assert.is_nil(captured.opened)
+    assert.is_nil(captured.picker)
   end)
 
   it('blocks web PR creation when the current branch already matches the base', function()
@@ -454,27 +446,17 @@ describe('create_pr', function()
   end)
 
   it('keeps forge detection working when shell_error is stale', function()
-    local back_calls = 0
-
     old_fn_system('false')
     assert.not_equals(0, vim.v.shell_error)
 
-    require('forge').create_pr({
-      back = function()
-        back_calls = back_calls + 1
-      end,
-    })
+    require('forge').create_pr()
 
     vim.wait(100, function()
-      return captured.picker ~= nil
+      return captured.opened_calls ~= nil
     end)
 
-    assert.is_not_nil(captured.picker)
-    assert.is_function(captured.picker.back)
-
-    captured.picker.back()
-
-    assert.equals(1, back_calls)
+    assert.equals(1, captured.opened_calls)
+    assert.is_nil(captured.picker)
     old_fn_system('true')
   end)
 end)


### PR DESCRIPTION
## Problem

Some direct `:Forge` command paths still depended on the picker layer. `:Forge pr create` and `:Forge issue create` could prompt for templates, and `:Forge pr ci` exposed a list-based picker workflow through the Ex command surface. That conflicted with the intended contract that `:Forge` stays action-oriented while interactive list workflows live behind the picker UI.

## Solution

Keep direct create flows non-interactive and remove the remaining picker-backed PR CI verb from the command grammar. PR and issue creation now fall back to normal compose behavior instead of prompting for template selection, and `:Forge pr ci` is no longer a valid Ex command. Interactive CI and per-PR checks remain available through the picker surface and nested picker actions.
