### PR TITLE
docs(cli): clarify picker workflow boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,14 @@ without leaving your editor.
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
-- (Optionally) [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive
-  picker workflows
+- Optional: [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive
+  picker and listing workflows
 
-Direct `:Forge` action commands work without `fzf-lua`. Install it only if you
-want the interactive picker UI.
+Direct `:Forge` action commands work without `fzf-lua`. Install it if you want
+the interactive picker UI and list workflows. The `:Forge` command surface
+covers explicit forge actions such as create/edit/browse/close/reopen/approve/
+merge/draft/ready, while picker-only actions remain list-scoped controls and
+local navigation workflows.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,11 @@ without leaving your editor.
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
-- Optional: [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive
-  picker and listing workflows
+- (Optionally) [fzf-lua](https://github.com/ibhagwan/fzf-lua) for interactive
+  picker workflows
 
-Direct `:Forge` action commands work without `fzf-lua`. Install it if you want
-the interactive picker UI and list workflows. The `:Forge` command surface
-covers explicit forge actions such as create/edit/browse/close/reopen/approve/
-merge/draft/ready, while picker-only actions remain list-scoped controls and
-local navigation workflows.
+Direct `:Forge` action commands work without `fzf-lua`. Install it only if you
+want the interactive picker UI.
 
 ## Installation
 

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -68,10 +68,10 @@ Requirements: ~
   - `gh` for GitHub
   - `glab` for GitLab
   - `tea` for Codeberg/Gitea/Forgejo
-- Optional: `fzf-lua` for interactive picker workflows
+- Optional: `fzf-lua` for interactive picker and listing workflows
 
 Direct `:Forge` action commands work without `fzf-lua`. The built-in
-interactive picker surface requires it.
+interactive picker and listing surface requires it.
 
 Run |:checkhealth| forge to verify CLIs and dependencies.
 
@@ -368,6 +368,8 @@ COMMANDS                                                              *:Forge*
     UIs. `:Forge` with no arguments warns with `missing command`.
     Use |forge-plug| mappings such as `<Plug>(forge)` or
     `require('forge').open()` for the interactive picker surface.
+    Direct commands cover explicit forge actions with stable targets such as
+    PR/issue/release numbers or tags and CI run ids.
 
 TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Supported verbs accept explicit target modifiers such as `repo=...`,
@@ -406,6 +408,8 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
 
     Commands that need interactive selection are intentionally not exposed
     through `:Forge`; use the interactive picker surface instead.
+    This includes list navigation, list-scoped filters/refresh, nested per-PR
+    checks, copy helpers, and local branch/commit/worktree sections.
 
 BANG SEMANTICS                                            *forge-command-bang*
     `!` is only accepted on mutating commands with an explicit force variant:
@@ -754,6 +758,15 @@ command interface. Open it with `<Plug>(forge)` or
 `require('forge').open()`. The root picker uses label-only entries so the top
 level stays compact, while nested pickers and help docs carry the workflow
 detail.
+
+CLI parity: ~
+- Explicit forge actions exposed in pickers are also available through
+  `:Forge` when they can be addressed directly: create, edit, browse, close,
+  reopen, checkout, worktree, approve, merge, draft/ready, CI log/watch, and
+  release browse/delete.
+- Picker-only actions are the list workflow itself and row-scoped helpers such
+  as filter/refresh/load more, nested per-PR checks, copy-to-clipboard
+  helpers, and local branch/commit/worktree navigation.
 
 Architecture: ~
 - Interactive root entries go through `require('forge.client').open_root()`.

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -177,6 +177,26 @@ describe('command schema', function()
     assert.same({ 'repo', 'method' }, cmd.modifier_names('pr', 'merge'))
   end)
 
+  it('keeps direct forge verbs aligned with non-list picker actions', function()
+    assert.same({
+      'checkout',
+      'worktree',
+      'browse',
+      'close',
+      'reopen',
+      'create',
+      'edit',
+      'approve',
+      'merge',
+      'draft',
+      'ready',
+    }, cmd.verb_names('pr'))
+
+    assert.same({ 'browse', 'close', 'reopen', 'create', 'edit' }, cmd.verb_names('issue'))
+    assert.same({ 'log', 'watch' }, cmd.verb_names('ci'))
+    assert.same({ 'browse', 'delete' }, cmd.verb_names('release'))
+  end)
+
   it('keeps legacy browse modifiers separate from canonical ones', function()
     assert.same({ 'repo', 'rev', 'target' }, cmd.modifier_names('browse'))
     assert.same({ 'root', 'commit' }, cmd.legacy_modifier_names('browse'))


### PR DESCRIPTION
## Problem

The command surface and picker surface had drifted conceptually. Recent fixes moved direct `:Forge` flows away from picker dependencies, but the docs did not clearly spell out which workflows require `fzf-lua` and which forge actions are expected to remain available directly through the Ex command interface.

## Solution

Document the boundary explicitly and add a regression spec that pins command parity for non-list forge actions. The updated docs now state that `fzf-lua` is for interactive picker and listing workflows, while `:Forge` covers direct explicit actions with stable targets. Picker-only behavior is called out as list navigation, row-scoped helpers, nested checks, and local git navigation.
