### PR TITLE
fix(compose): collapse empty metadata gaps

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -24,8 +24,20 @@ local M = {
       update = { labels = true, assignees = false, milestone = true },
     },
     pr = {
-      create = { draft = false, reviewers = false, labels = true, assignees = true, milestone = true },
-      update = { draft = false, reviewers = true, labels = true, assignees = false, milestone = true },
+      create = {
+        draft = false,
+        reviewers = false,
+        labels = true,
+        assignees = true,
+        milestone = true,
+      },
+      update = {
+        draft = false,
+        reviewers = true,
+        labels = true,
+        assignees = false,
+        milestone = true,
+      },
     },
   },
   pr_fields = {

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -1,7 +1,7 @@
 local M = {}
 
-local template = require('forge.template')
 local submission = require('forge.submission')
+local template = require('forge.template')
 
 local compose_ns = vim.api.nvim_create_namespace('forge_compose')
 
@@ -196,6 +196,23 @@ local function add_metadata_fields(builder, forge, kind, operation, metadata)
   end
 end
 
+local function add_optional_metadata_fields(builder, forge, kind, operation, metadata)
+  local before = #builder.lines
+  builder:add_line('')
+  add_metadata_fields(builder, forge, kind, operation, metadata)
+  if #builder.lines == before + 1 then
+    table.remove(builder.lines, #builder.lines)
+    return false
+  end
+  return true
+end
+
+local function add_section_gap(builder)
+  if builder.lines[#builder.lines] ~= '' then
+    builder:add_line('')
+  end
+end
+
 ---@param f forge.Forge
 ---@param branch string
 ---@param title string
@@ -303,27 +320,31 @@ end
 local function update_issue(f, num, title, body, buf, ref, metadata, previous)
   local log = require('forge.logger')
   log.info('updating issue #' .. num .. '...')
-  vim.system(f:update_issue_cmd(num, title, body, ref, metadata, previous), { text = true }, function(result)
-    vim.schedule(function()
-      if result.code == 0 then
-        log.info(('updated issue #%s'):format(num))
-        require('forge').clear_list()
-        if buf and vim.api.nvim_buf_is_valid(buf) then
-          vim.bo[buf].modified = false
-          vim.api.nvim_buf_delete(buf, { force = true })
+  vim.system(
+    f:update_issue_cmd(num, title, body, ref, metadata, previous),
+    { text = true },
+    function(result)
+      vim.schedule(function()
+        if result.code == 0 then
+          log.info(('updated issue #%s'):format(num))
+          require('forge').clear_list()
+          if buf and vim.api.nvim_buf_is_valid(buf) then
+            vim.bo[buf].modified = false
+            vim.api.nvim_buf_delete(buf, { force = true })
+          end
+        else
+          local msg = vim.trim(result.stderr or '')
+          if msg == '' then
+            msg = vim.trim(result.stdout or '')
+          end
+          if msg == '' then
+            msg = 'update failed'
+          end
+          log.error(msg)
         end
-      else
-        local msg = vim.trim(result.stderr or '')
-        if msg == '' then
-          msg = vim.trim(result.stdout or '')
-        end
-        if msg == '' then
-          msg = 'update failed'
-        end
-        log.error(msg)
-      end
-    end)
-  end)
+      end)
+    end
+  )
 end
 
 ---@param f forge.Forge
@@ -365,9 +386,8 @@ function M.open_issue(f, result, ref)
   local ln = b:add_line('%s%s.', creating_prefix, f.name)
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
-  b:add_line('')
-  add_metadata_fields(b, f, 'issue', 'create', template_metadata)
-  b:add_line('')
+  add_optional_metadata_fields(b, f, 'issue', 'create', template_metadata)
+  add_section_gap(b)
   add_discard_hints(b)
   b:add_line('  An empty title aborts creation.')
   b:add_line('-->')
@@ -431,9 +451,8 @@ function M.open_issue_edit(f, num, details, ref)
   b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
-  b:add_line('')
-  add_metadata_fields(b, f, 'issue', 'update', submission.issue_metadata(details))
-  b:add_line('')
+  add_optional_metadata_fields(b, f, 'issue', 'update', submission.issue_metadata(details))
+  add_section_gap(b)
   add_discard_hints(b)
   b:add_line('  An empty title aborts editing.')
   b:add_line('-->')
@@ -528,12 +547,11 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   b:mark(ln, 2, #creating_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
 
-  b:add_line('')
-  add_metadata_fields(b, f, 'pr', 'create', draft_metadata)
+  add_optional_metadata_fields(b, f, 'pr', 'create', draft_metadata)
 
   local stat_start, stat_end
   if diff_stat ~= '' then
-    b:add_line('')
+    add_section_gap(b)
     local changes_prefix = '  Changes not in '
     ln = b:add_line('%s%s:', changes_prefix, base_ref)
     b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
@@ -545,7 +563,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
     end
     stat_end = #b.lines
   end
-  b:add_line('')
+  add_section_gap(b)
   add_discard_hints(b)
   b:add_line('  An empty title or body aborts creation.')
   b:add_line('-->')
@@ -643,51 +661,55 @@ M.push_and_create = push_and_create
 local function update_pr(f, num, title, body, buf, ref, metadata, previous)
   local log = require('forge.logger')
   log.info('updating ' .. f.labels.pr_one .. ' #' .. num .. '...')
-  vim.system(f:update_pr_cmd(num, title, body, ref, metadata, previous), { text = true }, function(result)
-    vim.schedule(function()
-      if result.code ~= 0 then
-        local msg = vim.trim(result.stderr or '')
-        if msg == '' then
-          msg = vim.trim(result.stdout or '')
+  vim.system(
+    f:update_pr_cmd(num, title, body, ref, metadata, previous),
+    { text = true },
+    function(result)
+      vim.schedule(function()
+        if result.code ~= 0 then
+          local msg = vim.trim(result.stderr or '')
+          if msg == '' then
+            msg = vim.trim(result.stdout or '')
+          end
+          if msg == '' then
+            msg = 'update failed'
+          end
+          log.error(msg)
+          return
         end
-        if msg == '' then
-          msg = 'update failed'
-        end
-        log.error(msg)
-        return
-      end
-      if
-        submission.supports(f, 'pr', 'update', 'draft')
-        and previous
-        and previous.draft ~= metadata.draft
-        and f.draft_toggle_cmd
-      then
-        local draft_cmd = f:draft_toggle_cmd(num, previous.draft, ref)
-        if draft_cmd then
-          vim.system(draft_cmd, { text = true }, function(draft_result)
-            vim.schedule(function()
-              if draft_result.code ~= 0 then
-                local msg = vim.trim(draft_result.stderr or '')
-                if msg == '' then
-                  msg = vim.trim(draft_result.stdout or '')
+        if
+          submission.supports(f, 'pr', 'update', 'draft')
+          and previous
+          and previous.draft ~= metadata.draft
+          and f.draft_toggle_cmd
+        then
+          local draft_cmd = f:draft_toggle_cmd(num, previous.draft, ref)
+          if draft_cmd then
+            vim.system(draft_cmd, { text = true }, function(draft_result)
+              vim.schedule(function()
+                if draft_result.code ~= 0 then
+                  local msg = vim.trim(draft_result.stderr or '')
+                  if msg == '' then
+                    msg = vim.trim(draft_result.stdout or '')
+                  end
+                  if msg == '' then
+                    msg = 'draft toggle failed'
+                  end
+                  log.error(msg)
                 end
-                if msg == '' then
-                  msg = 'draft toggle failed'
-                end
-                log.error(msg)
-              end
+              end)
             end)
-          end)
+          end
         end
-      end
-      log.info(('updated %s #%s'):format(f.labels.pr_one, num))
-      require('forge').clear_list()
-      if buf and vim.api.nvim_buf_is_valid(buf) then
-        vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
-      end
-    end)
-  end)
+        log.info(('updated %s #%s'):format(f.labels.pr_one, num))
+        require('forge').clear_list()
+        if buf and vim.api.nvim_buf_is_valid(buf) then
+          vim.bo[buf].modified = false
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end)
+    end
+  )
 end
 
 ---@param f forge.Forge
@@ -733,12 +755,11 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
   b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
-  b:add_line('')
-  add_metadata_fields(b, f, 'pr', 'update', submission.pr_metadata(details))
+  add_optional_metadata_fields(b, f, 'pr', 'update', submission.pr_metadata(details))
 
   local stat_start, stat_end
   if diff_stat ~= '' then
-    b:add_line('')
+    add_section_gap(b)
     local changes_prefix = '  Changes not in origin/'
     ln = b:add_line('%s%s:', changes_prefix, base)
     b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
@@ -750,7 +771,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
     end
     stat_end = #b.lines
   end
-  b:add_line('')
+  add_section_gap(b)
   add_discard_hints(b)
   b:add_line('  An empty title or body aborts editing.')
   b:add_line('-->')

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -403,14 +403,20 @@ function M:update_pr_cmd(num, title, body, ref, metadata, previous)
   local add_labels, remove_labels = submission.diff(before.labels, current.labels)
   append_csv(cmd, '--label', add_labels)
   append_csv(cmd, '--unlabel', remove_labels)
-  if current.assignees ~= nil and vim.deep_equal(current.assignees, before.assignees or {}) == false then
+  if
+    current.assignees ~= nil
+    and vim.deep_equal(current.assignees, before.assignees or {}) == false
+  then
     if #current.assignees == 0 then
       table.insert(cmd, '--unassign')
     else
       append_csv(cmd, '--assignee', current.assignees)
     end
   end
-  if current.reviewers ~= nil and vim.deep_equal(current.reviewers, before.reviewers or {}) == false then
+  if
+    current.reviewers ~= nil
+    and vim.deep_equal(current.reviewers, before.reviewers or {}) == false
+  then
     if #current.reviewers == 0 then
       local removed = {}
       for _, reviewer in ipairs(before.reviewers or {}) do
@@ -446,7 +452,10 @@ function M:update_issue_cmd(num, title, body, ref, metadata, previous)
   local add_labels, remove_labels = submission.diff(before.labels, current.labels)
   append_csv(cmd, '--label', add_labels)
   append_csv(cmd, '--unlabel', remove_labels)
-  if current.assignees ~= nil and vim.deep_equal(current.assignees, before.assignees or {}) == false then
+  if
+    current.assignees ~= nil
+    and vim.deep_equal(current.assignees, before.assignees or {}) == false
+  then
     if #current.assignees == 0 then
       table.insert(cmd, '--unassign')
     else

--- a/lua/forge/submission.lua
+++ b/lua/forge/submission.lua
@@ -40,12 +40,14 @@ function M.filter(forge, kind, operation, metadata)
   metadata = metadata or {}
   return {
     labels = M.supports(forge, kind, operation, 'labels') and normalize_list(metadata.labels) or {},
-    assignees = M.supports(forge, kind, operation, 'assignees') and normalize_list(metadata.assignees)
-      or {},
+    assignees = M.supports(forge, kind, operation, 'assignees') and normalize_list(
+      metadata.assignees
+    ) or {},
     milestone = M.supports(forge, kind, operation, 'milestone') and trim(metadata.milestone) or '',
     draft = M.supports(forge, kind, operation, 'draft') and metadata.draft == true or false,
-    reviewers = M.supports(forge, kind, operation, 'reviewers') and normalize_list(metadata.reviewers)
-      or {},
+    reviewers = M.supports(forge, kind, operation, 'reviewers') and normalize_list(
+      metadata.reviewers
+    ) or {},
   }
 end
 

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -144,6 +144,32 @@ describe('compose issue create', function()
     assert.same({}, captured.errors)
   end)
 
+  it(
+    'keeps a single blank line between the forge line and instructions when metadata is empty',
+    function()
+      local compose = require('forge.compose')
+      compose.open_issue({
+        name = 'github',
+        create_issue_cmd = function()
+          return { 'create-issue' }
+        end,
+      })
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      local creating_line
+      for i, line in ipairs(lines) do
+        if line == '  Creating issue via github.' then
+          creating_line = i
+          break
+        end
+      end
+
+      assert.is_not_nil(creating_line)
+      assert.equals('', lines[creating_line + 1])
+      assert.equals('  Write (:w) submits this buffer.', lines[creating_line + 2])
+    end
+  )
+
   it('keeps template labels without rendering editable metadata', function()
     local compose = require('forge.compose')
     local f = {

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -170,6 +170,46 @@ describe('compose pr edit', function()
     assert.is_false(vim.tbl_contains(lines, '  Milestone: '))
   end)
 
+  it(
+    'keeps a single blank line between the forge line and instructions when metadata and diff stat are empty',
+    function()
+      local compose = require('forge.compose')
+      compose.open_pr_edit(
+        {
+          labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+          capabilities = { draft = false, reviewers = false },
+          name = 'github',
+        },
+        '23',
+        {
+          title = 'PR title',
+          body = 'PR body',
+          draft = false,
+          head_branch = 'real-pr-head',
+          base_branch = 'main',
+          reviewers = {},
+          labels = {},
+          assignees = {},
+          milestone = '',
+        },
+        'other-local-branch'
+      )
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      local editing_line
+      for i, line in ipairs(lines) do
+        if line == '  Editing Pull Request #23 via github.' then
+          editing_line = i
+          break
+        end
+      end
+
+      assert.is_not_nil(editing_line)
+      assert.equals('', lines[editing_line + 1])
+      assert.equals('  Write (:w) submits this buffer.', lines[editing_line + 2])
+    end
+  )
+
   it('extracts PR metadata from the comment block on write', function()
     local compose = require('forge.compose')
     local f = {

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -821,57 +821,60 @@ describe('fzf picker', function()
     assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m main\27%[0m'))
   end)
 
-  it('strips author and metadata background ANSI so the selected row highlight can win across pickers', function()
-    local utils = require('fzf-lua.utils')
-    local old_ansi_from_hl = utils.ansi_from_hl
-    utils.ansi_from_hl = function(group, text)
-      if group == 'FzfLuaHeaderBind' or group == 'FzfLuaHeaderText' then
-        return ('[%s:%s]'):format(group, text)
+  it(
+    'strips author and metadata background ANSI so the selected row highlight can win across pickers',
+    function()
+      local utils = require('fzf-lua.utils')
+      local old_ansi_from_hl = utils.ansi_from_hl
+      utils.ansi_from_hl = function(group, text)
+        if group == 'FzfLuaHeaderBind' or group == 'FzfLuaHeaderText' then
+          return ('[%s:%s]'):format(group, text)
+        end
+        if group then
+          return ('\27[48;2;255;255;255m\27[38;2;1;2;3m%s\27[0m'):format(text)
+        end
+        return text
       end
-      if group then
-        return ('\27[48;2;255;255;255m\27[38;2;1;2;3m%s\27[0m'):format(text)
-      end
-      return text
+
+      local picker = require('forge.picker.fzf')
+      picker.pick({
+        prompt = 'Issues> ',
+        entries = {
+          {
+            display = {
+              { '#7', 'ForgeNumber' },
+              { ' Cursorline bug ' },
+              { 'alice', 'ForgeAuthor' },
+              { ' 1h', 'ForgeTime' },
+            },
+            value = '7',
+          },
+          {
+            display = {
+              { 'abc1234', 'ForgeCommitHash' },
+              { ' fix selection ' },
+              { 'bob', 'ForgeCommitAuthor' },
+              { ' /repo-feature', 'Directory' },
+              { ' detached', 'ForgeDim' },
+            },
+            value = 'abc1234',
+          },
+        },
+        actions = {},
+        picker_name = 'issue',
+      })
+
+      utils.ansi_from_hl = old_ansi_from_hl
+
+      assert.is_not_nil(captured)
+      assert.same(2, #captured.lines)
+      assert.is_nil(captured.lines[1]:match('\27%[48;'))
+      assert.is_nil(captured.lines[2]:match('\27%[48;'))
+      assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3malice\27%[0m'))
+      assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m 1h\27%[0m'))
+      assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3mbob\27%[0m'))
+      assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3m /repo%-feature\27%[0m'))
+      assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3m detached\27%[0m'))
     end
-
-    local picker = require('forge.picker.fzf')
-    picker.pick({
-      prompt = 'Issues> ',
-      entries = {
-        {
-          display = {
-            { '#7', 'ForgeNumber' },
-            { ' Cursorline bug ' },
-            { 'alice', 'ForgeAuthor' },
-            { ' 1h', 'ForgeTime' },
-          },
-          value = '7',
-        },
-        {
-          display = {
-            { 'abc1234', 'ForgeCommitHash' },
-            { ' fix selection ' },
-            { 'bob', 'ForgeCommitAuthor' },
-            { ' /repo-feature', 'Directory' },
-            { ' detached', 'ForgeDim' },
-          },
-          value = 'abc1234',
-        },
-      },
-      actions = {},
-      picker_name = 'issue',
-    })
-
-    utils.ansi_from_hl = old_ansi_from_hl
-
-    assert.is_not_nil(captured)
-    assert.same(2, #captured.lines)
-    assert.is_nil(captured.lines[1]:match('\27%[48;'))
-    assert.is_nil(captured.lines[2]:match('\27%[48;'))
-    assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3malice\27%[0m'))
-    assert.truthy(captured.lines[1]:find('\27%[38;2;1;2;3m 1h\27%[0m'))
-    assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3mbob\27%[0m'))
-    assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3m /repo%-feature\27%[0m'))
-    assert.truthy(captured.lines[2]:find('\27%[38;2;1;2;3m detached\27%[0m'))
-  end)
+  )
 end)

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -676,11 +676,17 @@ describe('codeberg', function()
   end)
 
   it('builds simplified issue commands for tea', function()
-    local create = cb:create_issue_cmd('title', 'body', { 'bug' }, { repo_arg = 'forgejo/tea-test' }, {
-      labels = { 'bug' },
-      assignees = { 'alice' },
-      milestone = 'v1',
-    })
+    local create = cb:create_issue_cmd(
+      'title',
+      'body',
+      { 'bug' },
+      { repo_arg = 'forgejo/tea-test' },
+      {
+        labels = { 'bug' },
+        assignees = { 'alice' },
+        milestone = 'v1',
+      }
+    )
     assert.same({ 'tea', 'issues', 'create', '--title', 'title' }, vim.list_slice(create, 1, 5))
     assert.truthy(vim.tbl_contains(create, '--labels'))
     assert.truthy(vim.tbl_contains(create, 'bug'))


### PR DESCRIPTION
## Problem

Compose buffers always inserted a blank line before and after the metadata section, even when that section rendered nothing. In issue create and similar empty-metadata flows, that left two empty lines between the `Creating ... via ...` line and the submit/discard instructions.

## Solution

Make the compose footer spacing content-sensitive. The forge context line is kept, but empty metadata sections no longer reserve an extra spacer line. When no metadata rows render, there is now only a single blank separator before the next footer section. Focused compose specs cover both issue and PR footer layouts.
