### PR TITLE
fix(compose): keep pr footer context in logical order

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -213,6 +213,18 @@ local function add_section_gap(builder)
   end
 end
 
+local function add_pr_header(builder, prefix, forge_name, branch, base)
+  local ln = builder:add_line('%s%s.', prefix, forge_name)
+  builder:mark(ln, 2, #prefix - 2, 'ForgeComposeHeader')
+  builder:mark(ln, #prefix, #forge_name, 'ForgeComposeForge')
+
+  local branch_prefix = '  On branch '
+  local against = ' against '
+  ln = builder:add_line('%s%s%s%s.', branch_prefix, branch, against, base)
+  builder:mark(ln, #branch_prefix, #branch, 'ForgeComposeBranch')
+  builder:mark(ln, #branch_prefix + #branch + #against, #base, 'ForgeComposeBranch')
+end
+
 ---@param f forge.Forge
 ---@param branch string
 ---@param title string
@@ -536,16 +548,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
 
   b:add_line('<!--')
 
-  local branch_prefix = '  On branch '
-  local against = ' against '
-  local ln = b:add_line('%s%s%s%s.', branch_prefix, branch, against, base)
-  b:mark(ln, #branch_prefix, #branch, 'ForgeComposeBranch')
-  b:mark(ln, #branch_prefix + #branch + #against, #base, 'ForgeComposeBranch')
-
-  local creating_prefix = '  Creating ' .. pr_kind .. ' via '
-  ln = b:add_line('%s%s.', creating_prefix, f.name)
-  b:mark(ln, 2, #creating_prefix - 2, 'ForgeComposeHeader')
-  b:mark(ln, #creating_prefix, #f.name, 'ForgeComposeForge')
+  add_pr_header(b, '  Creating ' .. pr_kind .. ' via ', f.name, branch, base)
 
   add_optional_metadata_fields(b, f, 'pr', 'create', draft_metadata)
 
@@ -744,16 +747,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
 
   b:add_line('<!--')
 
-  local branch_prefix = '  On branch '
-  local against = ' against '
-  local ln = b:add_line('%s%s%s%s.', branch_prefix, branch, against, base)
-  b:mark(ln, #branch_prefix, #branch, 'ForgeComposeBranch')
-  b:mark(ln, #branch_prefix + #branch + #against, #base, 'ForgeComposeBranch')
-
-  local editing_prefix = '  Editing ' .. pr_kind .. ' #' .. num .. ' via '
-  ln = b:add_line('%s%s.', editing_prefix, f.name)
-  b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
-  b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
+  add_pr_header(b, '  Editing ' .. pr_kind .. ' #' .. num .. ' via ', f.name, branch, base)
 
   add_optional_metadata_fields(b, f, 'pr', 'update', submission.pr_metadata(details))
 

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -1,0 +1,115 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('compose pr create', function()
+  local captured
+  local old_fn_system
+  local old_system
+  local old_feedkeys
+  local old_preload
+
+  local function line_index(lines, target)
+    for i, line in ipairs(lines) do
+      if line == target then
+        return i
+      end
+    end
+    return nil
+  end
+
+  before_each(function()
+    captured = {
+      diff_stat = '',
+    }
+
+    old_fn_system = vim.fn.system
+    old_system = vim.system
+    old_feedkeys = vim.api.nvim_feedkeys
+    old_preload = {
+      ['forge.template'] = package.preload['forge.template'],
+    }
+
+    vim.api.nvim_feedkeys = function() end
+    vim.fn.system = function(cmd)
+      if cmd == 'git diff --stat origin/main..HEAD' then
+        return captured.diff_stat
+      end
+      return ''
+    end
+    vim.system = function(_, _, cb)
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    package.preload['forge.template'] = function()
+      return {
+        fill_from_commits = function()
+          return 'test', '## Problem\n\n## Solution'
+        end,
+        normalize_body = function(s)
+          return vim.trim(s):gsub('%s+', ' ')
+        end,
+      }
+    end
+
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.template'] = nil
+  end)
+
+  after_each(function()
+    vim.fn.system = old_fn_system
+    vim.system = old_system
+    vim.api.nvim_feedkeys = old_feedkeys
+
+    package.preload['forge.template'] = old_preload['forge.template']
+
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.template'] = nil
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == 'forge://pr/new' then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end
+    vim.cmd('enew!')
+  end)
+
+  it(
+    'orders the create footer from action to branch to metadata to diff stat to instructions',
+    function()
+      captured.diff_stat = ' lua/forge/pickers.lua | 1 +\n 1 file changed, 1 insertion(+)\n'
+
+      local compose = require('forge.compose')
+      compose.open_pr({
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = false },
+        name = 'github',
+      }, 'new', 'main', false, nil, nil, 'origin', 'origin/main', 'HEAD')
+
+      local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+      local creating_line = line_index(lines, '  Creating Pull Request via github.')
+
+      assert.is_not_nil(creating_line)
+      assert.equals('  On branch new against main.', lines[creating_line + 1])
+      assert.equals('', lines[creating_line + 2])
+      assert.equals('  Draft: false', lines[creating_line + 3])
+      assert.equals('', lines[creating_line + 4])
+      assert.equals('  Changes not in origin/main:', lines[creating_line + 5])
+      assert.equals('', lines[creating_line + 6])
+      assert.equals('   lua/forge/pickers.lua | 1 +', lines[creating_line + 7])
+      assert.equals('   1 file changed, 1 insertion(+)', lines[creating_line + 8])
+      assert.equals('', lines[creating_line + 9])
+      assert.equals('  Write (:w) submits this buffer.', lines[creating_line + 10])
+    end
+  )
+end)

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -7,6 +7,15 @@ describe('compose pr edit', function()
   local old_feedkeys
   local old_preload
 
+  local function line_index(lines, target)
+    for i, line in ipairs(lines) do
+      if line == target then
+        return i
+      end
+    end
+    return nil
+  end
+
   before_each(function()
     captured = {
       infos = {},
@@ -123,6 +132,10 @@ describe('compose pr edit', function()
     )
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+    local editing_line = line_index(lines, '  Editing Pull Request #23 via github.')
+
+    assert.is_not_nil(editing_line)
+    assert.equals('  On branch real-pr-head against main.', lines[editing_line + 1])
     assert.is_truthy(vim.tbl_contains(lines, '  On branch real-pr-head against main.'))
     assert.is_false(vim.tbl_contains(lines, '  On branch other-local-branch against main.'))
     assert.is_true(vim.tbl_contains(lines, '  Draft: false'))
@@ -171,7 +184,7 @@ describe('compose pr edit', function()
   end)
 
   it(
-    'keeps a single blank line between the forge line and instructions when metadata and diff stat are empty',
+    'keeps a single blank line after the branch line when metadata and diff stat are empty',
     function()
       local compose = require('forge.compose')
       compose.open_pr_edit(
@@ -196,17 +209,12 @@ describe('compose pr edit', function()
       )
 
       local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-      local editing_line
-      for i, line in ipairs(lines) do
-        if line == '  Editing Pull Request #23 via github.' then
-          editing_line = i
-          break
-        end
-      end
+      local editing_line = line_index(lines, '  Editing Pull Request #23 via github.')
 
       assert.is_not_nil(editing_line)
-      assert.equals('', lines[editing_line + 1])
-      assert.equals('  Write (:w) submits this buffer.', lines[editing_line + 2])
+      assert.equals('  On branch real-pr-head against main.', lines[editing_line + 1])
+      assert.equals('', lines[editing_line + 2])
+      assert.equals('  Write (:w) submits this buffer.', lines[editing_line + 3])
     end
   )
 


### PR DESCRIPTION
## Problem

The PR compose footer currently leads with branch context and only then states the action being performed. That makes the comment block read less naturally than the issue compose flow, and the create/edit PR paths duplicate the header-building logic while testing only the edit ordering directly.

## Solution

Add a shared PR footer header helper so both create and edit compose buffers render the context in the same order: action first, then branch context, then metadata, diff summary, and submit/discard instructions. Add focused compose specs for PR creation ordering and tighten the edit specs around the same sequence.