### PR TITLE
fix(compose): open compose sessions in dedicated splits

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -114,8 +114,9 @@ Top-level keys: ~
 
 `split`                                                   *forge-config-split*
   `string`  (default `"horizontal"`)
-    Default split direction for terminal views. One of `"horizontal"` or
-    `"vertical"`. Individual scopes (e.g. `ci.split`) override this value.
+    Default split direction for compose and terminal views. One of
+    `"horizontal"` or `"vertical"`. Individual scopes (e.g. `ci.split`)
+    override this value where supported.
 
 `confirm`                                               *forge-config-confirm*
   `table`  (default shown below)
@@ -824,6 +825,9 @@ COMPOSE BUFFER                                                 *forge-compose*
 Compose and edit buffers behave like native `acwrite` buffers. Write (`:w`)
 submits the current buffer. Quit or delete without `!` keeps modified-buffer
 protection. Use `:q!`, `:bd!`, or `:bwipeout!` to discard the buffer.
+Forge opens compose and edit buffers in a dedicated split using |forge-config-split|.
+On successful submission, that split closes and focus returns to the prior
+window.
 
 Creating a PR (without `--fill` or `--web`) opens a compose buffer at
 `forge://pr/new` with filetype `markdown` and buftype `acwrite`.

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -58,13 +58,45 @@ end
 
 ---@return integer
 local function create_compose_buf(name)
+  local prev_win = vim.api.nvim_get_current_win()
+  local split = 'horizontal'
+  local ok, cfg = pcall(require, 'forge.config')
+  if ok and cfg.config then
+    split = cfg.config().split or split
+  end
+  local prefix = split == 'vertical' and 'vertical' or 'botright'
+  vim.cmd(prefix .. ' new')
+  local win = vim.api.nvim_get_current_win()
+  local placeholder = vim.api.nvim_get_current_buf()
   local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_win_set_buf(win, buf)
+  if vim.api.nvim_buf_is_valid(placeholder) and placeholder ~= buf then
+    vim.api.nvim_buf_delete(placeholder, { force = true })
+  end
   vim.api.nvim_buf_set_name(buf, name)
   vim.bo[buf].buftype = 'acwrite'
   vim.bo[buf].bufhidden = 'wipe'
   vim.bo[buf].filetype = 'markdown'
   vim.bo[buf].swapfile = false
+  vim.b[buf].forge_compose_prev_win = prev_win
+  vim.b[buf].forge_compose_win = win
   return buf
+end
+
+local function close_compose_buf(buf)
+  if not (buf and vim.api.nvim_buf_is_valid(buf)) then
+    return
+  end
+  local prev_win = vim.b[buf].forge_compose_prev_win
+  local win = vim.b[buf].forge_compose_win
+  if prev_win and vim.api.nvim_win_is_valid(prev_win) and prev_win ~= win then
+    pcall(vim.api.nvim_set_current_win, prev_win)
+  end
+  if win and vim.api.nvim_win_is_valid(win) then
+    pcall(vim.api.nvim_win_close, win, true)
+    return
+  end
+  pcall(vim.api.nvim_buf_delete, buf, { force = true })
 end
 
 local function add_discard_hints(builder)
@@ -264,7 +296,7 @@ local function push_and_create(
               require('forge').clear_list()
               if buf and vim.api.nvim_buf_is_valid(buf) then
                 vim.bo[buf].modified = false
-                vim.api.nvim_buf_delete(buf, { force = true })
+                close_compose_buf(buf)
               end
             else
               local msg = vim.trim(create_result.stderr or '')
@@ -300,7 +332,7 @@ local function submit_issue(f, title, body, labels, buf, ref, metadata)
           require('forge').clear_list()
           if buf and vim.api.nvim_buf_is_valid(buf) then
             vim.bo[buf].modified = false
-            vim.api.nvim_buf_delete(buf, { force = true })
+            close_compose_buf(buf)
           end
         else
           local msg = vim.trim(result.stderr or '')
@@ -330,7 +362,7 @@ local function update_issue(f, num, title, body, buf, ref, metadata, previous)
           require('forge').clear_list()
           if buf and vim.api.nvim_buf_is_valid(buf) then
             vim.bo[buf].modified = false
-            vim.api.nvim_buf_delete(buf, { force = true })
+            close_compose_buf(buf)
           end
         else
           local msg = vim.trim(result.stderr or '')
@@ -408,14 +440,14 @@ function M.open_issue(f, result, ref)
       then
         log.warn('aborting: empty title')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
       local issue_body = submission_data.body
       if body ~= '' and template.normalize_body(issue_body) == template.normalize_body(body) then
         log.warn('aborting: body unchanged from template')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
 
@@ -470,7 +502,7 @@ function M.open_issue_edit(f, num, details, ref)
       if issue_title == '' then
         log.warn('aborting: empty title')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
 
@@ -609,20 +641,20 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
       if pr_title == '' then
         log.warn('aborting: empty title')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
       local pr_body = submission_data.body
       if pr_body == '' then
         log.warn('aborting: empty body')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
       if body ~= '' and template.normalize_body(pr_body) == template.normalize_body(body) then
         log.warn('aborting: body unchanged from template')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
 
@@ -705,7 +737,7 @@ local function update_pr(f, num, title, body, buf, ref, metadata, previous)
         require('forge').clear_list()
         if buf and vim.api.nvim_buf_is_valid(buf) then
           vim.bo[buf].modified = false
-          vim.api.nvim_buf_delete(buf, { force = true })
+          close_compose_buf(buf)
         end
       end)
     end
@@ -817,14 +849,14 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
       if pr_title == '' then
         log.warn('aborting: empty title')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
       local pr_body = submission_data.body
       if pr_body == '' then
         log.warn('aborting: empty body')
         vim.bo[buf].modified = false
-        vim.api.nvim_buf_delete(buf, { force = true })
+        close_compose_buf(buf)
         return
       end
 

--- a/spec/compose_abandon_spec.lua
+++ b/spec/compose_abandon_spec.lua
@@ -114,7 +114,6 @@ describe('compose abandon behavior', function()
   local function open_modified_issue_window()
     vim.cmd('enew')
     local base = vim.api.nvim_get_current_buf()
-    vim.cmd('vsplit')
     local buf = open_issue_buffer()
     vim.api.nvim_buf_set_lines(buf, 0, 1, false, { '# changed title' })
     return base, buf

--- a/spec/compose_split_spec.lua
+++ b/spec/compose_split_spec.lua
@@ -1,0 +1,244 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('compose split session', function()
+  local captured
+  local old_system
+  local old_feedkeys
+  local old_preload
+
+  local function issue_forge()
+    return {
+      name = 'github',
+      create_issue_cmd = function(_, title, body, labels, ref, metadata)
+        captured.issue_args = {
+          title = title,
+          body = body,
+          labels = labels,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'create-issue', title, body }
+      end,
+    }
+  end
+
+  local function pr_forge()
+    return {
+      labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+      name = 'github',
+      update_pr_cmd = function(_, num, title, body, ref, metadata)
+        captured.pr_args = {
+          num = num,
+          title = title,
+          body = body,
+          ref = ref,
+          metadata = metadata,
+        }
+        return { 'update-pr', num, title, body }
+      end,
+    }
+  end
+
+  before_each(function()
+    captured = {
+      cleared = 0,
+      split = 'horizontal',
+    }
+
+    old_system = vim.system
+    old_feedkeys = vim.api.nvim_feedkeys
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.config'] = package.preload['forge.config'],
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.template'] = package.preload['forge.template'],
+    }
+
+    vim.system = function(_, _, cb)
+      local result = {
+        code = 0,
+        stdout = 'https://github.com/owner/repo/issues/1\n',
+        stderr = '',
+      }
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    vim.api.nvim_feedkeys = function() end
+
+    package.preload['forge'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
+        end,
+      }
+    end
+
+    package.preload['forge.config'] = function()
+      return {
+        config = function()
+          return { split = captured.split }
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        info = function() end,
+        warn = function() end,
+        error = function() end,
+      }
+    end
+
+    package.preload['forge.template'] = function()
+      return {
+        fill_from_commits = function()
+          return 'title', 'body'
+        end,
+        normalize_body = function(s)
+          return vim.trim(s):gsub('%s+', ' ')
+        end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.template'] = nil
+
+    vim.cmd('silent! only')
+    vim.cmd('enew!')
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.api.nvim_feedkeys = old_feedkeys
+
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.config'] = old_preload['forge.config']
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.template'] = old_preload['forge.template']
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.compose'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.template'] = nil
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        local name = vim.api.nvim_buf_get_name(buf)
+        if name:match('^forge://') then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end
+    vim.cmd('silent! only')
+    vim.cmd('enew!')
+  end)
+
+  it('opens issue compose in a dedicated horizontal split', function()
+    local compose = require('forge.compose')
+    local base_win = vim.api.nvim_get_current_win()
+    local base_buf = vim.api.nvim_get_current_buf()
+
+    compose.open_issue(issue_forge())
+
+    local compose_win = vim.api.nvim_get_current_win()
+    local compose_buf = vim.api.nvim_get_current_buf()
+    local base_pos = vim.api.nvim_win_get_position(base_win)
+    local compose_pos = vim.api.nvim_win_get_position(compose_win)
+
+    assert.is_not.equals(base_win, compose_win)
+    assert.equals(2, #vim.api.nvim_tabpage_list_wins(0))
+    assert.equals(base_buf, vim.api.nvim_win_get_buf(base_win))
+    assert.equals(compose_buf, vim.api.nvim_win_get_buf(compose_win))
+    assert.equals(base_pos[2], compose_pos[2])
+    assert.is_not.equals(base_pos[1], compose_pos[1])
+  end)
+
+  it('respects vertical split config for compose buffers', function()
+    captured.split = 'vertical'
+
+    local compose = require('forge.compose')
+    local base_win = vim.api.nvim_get_current_win()
+
+    compose.open_issue(issue_forge())
+
+    local compose_win = vim.api.nvim_get_current_win()
+    local base_pos = vim.api.nvim_win_get_position(base_win)
+    local compose_pos = vim.api.nvim_win_get_position(compose_win)
+
+    assert.equals(2, #vim.api.nvim_tabpage_list_wins(0))
+    assert.equals(base_pos[1], compose_pos[1])
+    assert.is_not.equals(base_pos[2], compose_pos[2])
+  end)
+
+  it('closes the issue compose split and returns focus to the prior buffer on success', function()
+    local compose = require('forge.compose')
+    local base_win = vim.api.nvim_get_current_win()
+    local base_buf = vim.api.nvim_get_current_buf()
+
+    compose.open_issue(issue_forge())
+
+    local compose_buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(compose_buf, 0, 1, false, { '# split issue' })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.issue_args ~= nil and captured.cleared == 1
+    end)
+
+    assert.is_false(vim.api.nvim_buf_is_valid(compose_buf))
+    assert.equals(1, #vim.api.nvim_tabpage_list_wins(0))
+    assert.equals(base_win, vim.api.nvim_get_current_win())
+    assert.equals(base_buf, vim.api.nvim_get_current_buf())
+  end)
+
+  it('closes the PR edit compose split and returns focus to the prior buffer on success', function()
+    local compose = require('forge.compose')
+    local base_win = vim.api.nvim_get_current_win()
+    local base_buf = vim.api.nvim_get_current_buf()
+
+    compose.open_pr_edit(pr_forge(), '23', {
+      title = 'PR title',
+      body = 'PR body',
+      draft = false,
+      head_branch = 'feature',
+      base_branch = 'main',
+      reviewers = {},
+      labels = {},
+      assignees = {},
+      milestone = '',
+    }, 'feature')
+
+    local compose_buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(compose_buf, 0, -1, false, {
+      '# updated pr',
+      '',
+      'updated body',
+      '',
+      '<!--',
+      '  Draft: false',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return captured.pr_args ~= nil and captured.cleared == 1
+    end)
+
+    assert.is_false(vim.api.nvim_buf_is_valid(compose_buf))
+    assert.equals(1, #vim.api.nvim_tabpage_list_wins(0))
+    assert.equals(base_win, vim.api.nvim_get_current_win())
+    assert.equals(base_buf, vim.api.nvim_get_current_buf())
+  end)
+end)


### PR DESCRIPTION
## Problem

Forge compose and edit buffers currently replace the active window context even though they behave like temporary command-session editors. When submission succeeds, Forge deletes the compose buffer, but the return behavior is mostly whatever Neovim does after deleting the current buffer instead of an explicit split-based session lifecycle.

## Solution

Open issue and PR compose/edit flows in a dedicated split using the existing global `split` direction. Track the originating window so successful submission closes the compose split and returns focus to the prior buffer deterministically. Add focused specs for horizontal and vertical split opening, success-path focus restoration, and keep the vimdoc in sync with the new compose-session behavior.