### PR TITLE
refactor(picker): share session json request flow

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -588,7 +588,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   if diff_stat ~= '' then
     add_section_gap(b)
     local changes_prefix = '  Changes not in '
-    ln = b:add_line('%s%s:', changes_prefix, base_ref)
+    local ln = b:add_line('%s%s:', changes_prefix, base_ref)
     b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
     b:mark(ln, #changes_prefix, #base_ref, 'ForgeComposeBranch')
     b:add_line('')
@@ -787,7 +787,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
   if diff_stat ~= '' then
     add_section_gap(b)
     local changes_prefix = '  Changes not in origin/'
-    ln = b:add_line('%s%s:', changes_prefix, base)
+    local ln = b:add_line('%s%s:', changes_prefix, base)
     b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
     b:mark(ln, #changes_prefix, #base, 'ForgeComposeBranch')
     b:add_line('')

--- a/lua/forge/picker/session.lua
+++ b/lua/forge/picker/session.lua
@@ -25,6 +25,21 @@ local function emit_entries(emit, entries)
   emit(nil)
 end
 
+local function request_json(key, cmd, callback)
+  local token = M.begin(key)
+  vim.system(resolve(cmd), { text = true }, function(result)
+    vim.schedule(function()
+      M.finish(key, token)
+      if not M.current(key, token) then
+        callback(false, nil, result, true)
+        return
+      end
+      local ok, data = M.decode_json(result)
+      callback(ok, data, result, false)
+    end)
+  end)
+end
+
 function M.begin(key)
   local item = scope(key)
   item.epoch = item.epoch + 1
@@ -68,22 +83,17 @@ function M.prefetch_json(opts)
   if M.inflight(opts.key) then
     return false
   end
-  local token = M.begin(opts.key)
-  vim.system(resolve(opts.cmd), { text = true }, function(result)
-    vim.schedule(function()
-      M.finish(opts.key, token)
-      if not M.current(opts.key, token) then
-        return
+  request_json(opts.key, opts.cmd, function(ok, data, result, stale)
+    if stale then
+      return
+    end
+    if ok then
+      if opts.on_success then
+        opts.on_success(data)
       end
-      local ok, data = M.decode_json(result)
-      if ok then
-        if opts.on_success then
-          opts.on_success(data)
-        end
-      elseif opts.on_failure then
-        opts.on_failure(result)
-      end
-    end)
+    elseif opts.on_failure then
+      opts.on_failure(result)
+    end
   end)
   return true
 end
@@ -120,23 +130,18 @@ function M.pick_json(opts)
     if opts.on_fetch then
       opts.on_fetch()
     end
-    local token = M.begin(opts.key)
-    vim.system(resolve(opts.cmd), { text = true }, function(result)
-      vim.schedule(function()
-        M.finish(opts.key, token)
-        if not M.current(opts.key, token) then
-          if emit then
-            emit(nil)
-          end
-          return
+    request_json(opts.key, opts.cmd, function(ok, data, result, stale)
+      if stale then
+        if emit then
+          emit(nil)
         end
-        local ok, data = M.decode_json(result)
-        if ok then
-          handle_success(data, emit)
-        else
-          handle_failure(result, emit)
-        end
-      end)
+        return
+      end
+      if ok then
+        handle_success(data, emit)
+      else
+        handle_failure(result, emit)
+      end
     end)
   end
 

--- a/spec/picker_session_spec.lua
+++ b/spec/picker_session_spec.lua
@@ -1,0 +1,336 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('picker session', function()
+  local captured
+  local old_system
+  local old_schedule
+  local old_preload
+
+  before_each(function()
+    captured = {
+      systems = {},
+      callbacks = {},
+      picker = nil,
+    }
+
+    old_system = vim.system
+    old_schedule = vim.schedule
+    old_preload = {
+      ['forge.picker'] = package.preload['forge.picker'],
+    }
+
+    vim.schedule = function(fn)
+      fn()
+    end
+
+    vim.system = function(cmd, _, cb)
+      table.insert(captured.systems, cmd)
+      table.insert(captured.callbacks, cb)
+      return {
+        wait = function()
+          return { code = 0, stdout = '[]' }
+        end,
+      }
+    end
+
+    package.preload['forge.picker'] = function()
+      return {
+        backend = function()
+          return captured.backend or 'plain'
+        end,
+        pick = function(opts)
+          captured.picker = opts
+        end,
+      }
+    end
+
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.session'] = nil
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.schedule = old_schedule
+
+    package.preload['forge.picker'] = old_preload['forge.picker']
+
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.session'] = nil
+  end)
+
+  it('decodes successful json results', function()
+    local session = require('forge.picker.session')
+    local ok, data = session.decode_json({
+      code = 0,
+      stdout = '[{"id":1}]',
+    })
+
+    assert.is_true(ok)
+    assert.same({ { id = 1 } }, data)
+  end)
+
+  it('rejects failed or invalid json results', function()
+    local session = require('forge.picker.session')
+
+    local ok_failed, data_failed = session.decode_json({
+      code = 1,
+      stdout = '[{"id":1}]',
+    })
+    local ok_invalid, data_invalid = session.decode_json({
+      code = 0,
+      stdout = '{',
+    })
+
+    assert.is_false(ok_failed)
+    assert.is_nil(data_failed)
+    assert.is_false(ok_invalid)
+    assert.is_nil(data_invalid)
+  end)
+
+  it('prefetches json and forwards successful data once', function()
+    local session = require('forge.picker.session')
+    local success
+    local failures = 0
+
+    local started = session.prefetch_json({
+      key = 'prs.open',
+      cmd = { 'prs', 'open' },
+      on_success = function(data)
+        success = data
+      end,
+      on_failure = function()
+        failures = failures + 1
+      end,
+    })
+
+    assert.is_true(started)
+    assert.same({ 'prs', 'open' }, captured.systems[1])
+
+    captured.callbacks[1]({
+      code = 0,
+      stdout = '[{"number":42}]',
+      stderr = '',
+    })
+
+    assert.same({ { number = 42 } }, success)
+    assert.equals(0, failures)
+    assert.is_false(session.inflight('prs.open'))
+  end)
+
+  it('skips prefetch when skip_if passes or the key is already inflight', function()
+    local session = require('forge.picker.session')
+
+    local skipped = session.prefetch_json({
+      key = 'prs.open',
+      cmd = { 'prs', 'open' },
+      skip_if = function()
+        return true
+      end,
+    })
+
+    local started = session.prefetch_json({
+      key = 'issues.open',
+      cmd = { 'issues', 'open' },
+    })
+    local blocked = session.prefetch_json({
+      key = 'issues.open',
+      cmd = { 'issues', 'open' },
+    })
+
+    assert.is_false(skipped)
+    assert.is_true(started)
+    assert.is_true(session.inflight('issues.open'))
+    assert.is_false(blocked)
+    assert.equals(1, #captured.systems)
+  end)
+
+  it('ignores stale prefetch responses after invalidation', function()
+    local session = require('forge.picker.session')
+    local success = 0
+    local failure = 0
+
+    assert.is_true(session.prefetch_json({
+      key = 'prs.open',
+      cmd = { 'prs', 'open' },
+      on_success = function()
+        success = success + 1
+      end,
+      on_failure = function()
+        failure = failure + 1
+      end,
+    }))
+
+    session.invalidate('prs.open')
+    captured.callbacks[1]({
+      code = 0,
+      stdout = '[{"number":42}]',
+      stderr = '',
+    })
+
+    assert.equals(0, success)
+    assert.equals(0, failure)
+    assert.is_false(session.inflight('prs.open'))
+  end)
+
+  it('opens cached data immediately without requesting json', function()
+    local session = require('forge.picker.session')
+    local opened
+
+    session.pick_json({
+      key = 'prs.open',
+      cached = { { number = 42 } },
+      open = function(data)
+        opened = data
+      end,
+    })
+
+    assert.same({ { number = 42 } }, opened)
+    assert.equals(0, #captured.systems)
+  end)
+
+  it('streams json into the fzf picker and emits built entries', function()
+    local session = require('forge.picker.session')
+    local emitted = {}
+    local opened = 0
+    local fetched = 0
+    captured.backend = 'fzf-lua'
+
+    session.pick_json({
+      key = 'prs.open',
+      cmd = function()
+        return { 'prs', 'open' }
+      end,
+      loading_prompt = function()
+        return 'PRs> '
+      end,
+      actions = {
+        { name = 'default', fn = function() end },
+      },
+      picker_name = 'pr',
+      build_entries = function(data)
+        return {
+          { display = { { '#' .. data[1].number } }, value = data[1].number },
+        }
+      end,
+      open = function()
+        opened = opened + 1
+      end,
+      on_fetch = function()
+        fetched = fetched + 1
+      end,
+    })
+
+    assert.is_not_nil(captured.picker)
+    assert.equals('PRs> ', captured.picker.prompt)
+    assert.equals('pr', captured.picker.picker_name)
+    assert.equals(0, fetched)
+    assert.equals(0, opened)
+
+    captured.picker.stream(function(entry)
+      table.insert(emitted, entry)
+    end)
+    assert.equals(1, fetched)
+
+    captured.callbacks[1]({
+      code = 0,
+      stdout = '[{"number":42}]',
+      stderr = '',
+    })
+
+    assert.same({
+      { display = { { '#42' } }, value = 42 },
+      vim.NIL,
+    }, {
+      emitted[1],
+      emitted[2] == nil and vim.NIL or emitted[2],
+    })
+  end)
+
+  it('emits an error entry for streamed failures and opens directly for non-fzf success', function()
+    local session = require('forge.picker.session')
+    local emitted = {}
+    local opened
+
+    captured.backend = 'fzf-lua'
+    session.pick_json({
+      key = 'prs.open',
+      cmd = { 'prs', 'open' },
+      picker_name = 'pr',
+      actions = {},
+      build_entries = function()
+        return {}
+      end,
+      error_entry = function(result)
+        return { display = { { result.stderr } }, value = false }
+      end,
+      open = function(data)
+        opened = data
+      end,
+    })
+
+    captured.picker.stream(function(entry)
+      table.insert(emitted, entry)
+    end)
+    captured.callbacks[1]({
+      code = 1,
+      stdout = '',
+      stderr = 'boom',
+    })
+
+    assert.same({
+      { display = { { 'boom' } }, value = false },
+      vim.NIL,
+    }, {
+      emitted[1],
+      emitted[2] == nil and vim.NIL or emitted[2],
+    })
+
+    captured.backend = 'plain'
+    session.pick_json({
+      key = 'issues.open',
+      cmd = { 'issues', 'open' },
+      open = function(data)
+        opened = data
+      end,
+    })
+
+    captured.callbacks[2]({
+      code = 0,
+      stdout = '[{"number":7}]',
+      stderr = '',
+    })
+
+    assert.same({ { number = 7 } }, opened)
+  end)
+
+  it('emits only a terminator for stale streamed requests', function()
+    local session = require('forge.picker.session')
+    local emitted = {}
+    captured.backend = 'fzf-lua'
+
+    session.pick_json({
+      key = 'prs.open',
+      cmd = { 'prs', 'open' },
+      picker_name = 'pr',
+      actions = {},
+      build_entries = function()
+        return {}
+      end,
+      open = function() end,
+    })
+
+    captured.picker.stream(function(entry)
+      table.insert(emitted, entry)
+    end)
+    session.invalidate('prs.open')
+    captured.callbacks[1]({
+      code = 0,
+      stdout = '[{"number":42}]',
+      stderr = '',
+    })
+
+    assert.same({ vim.NIL }, {
+      emitted[1] == nil and vim.NIL or emitted[1],
+    })
+  end)
+end)


### PR DESCRIPTION
## Problem

`forge.picker.session` handles a fair amount of async request and invalidation logic, but its JSON request flow is duplicated between prefetch and picker-open paths. The module also has very little direct unit coverage, which makes it harder to refactor safely when picker behavior changes.

## Solution

Extract the shared JSON request lifecycle into one helper and keep the stale-request handling behavior explicit at each call site. Add focused unit tests for decode behavior, prefetch skipping and invalidation, cached opens, streamed picker success and failure, and stale streamed requests.