### PR TITLE
fix(gitlab): honor release list limits

### DIFF
--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -705,8 +705,18 @@ function M:pr_state(num, ref)
   }
 end
 
-function M:list_releases_json_cmd(ref)
-  return { 'glab', 'release', 'list', '--output', 'json', '-R', repo_arg(ref) }
+function M:list_releases_json_cmd(ref, limit)
+  return {
+    'glab',
+    'release',
+    'list',
+    '--output',
+    'json',
+    '--per-page',
+    tostring(limit or forge.config().display.limits.releases),
+    '-R',
+    repo_arg(ref),
+  }
 end
 
 ---@param tag string


### PR DESCRIPTION
## Problem
The release picker now asks each backend for an expanded release window, but the GitLab release command still ignored that requested limit.

## Solution
Thread the requested release limit through the GitLab release list command with glab release list --per-page, matching the other backends and making the release picker expansion path work consistently.