### PR TITLE
test(release): cover load more flows

### DIFF
--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -127,8 +127,8 @@ local function fake_release_forge()
     delete_release_cmd = function(_, tag)
       return { 'delete', tag }
     end,
-    list_releases_json_cmd = function()
-      return { 'releases' }
+    list_releases_json_cmd = function(_, _, limit)
+      return { 'releases', tostring(limit or '') }
     end,
   }
 end
@@ -1698,6 +1698,84 @@ describe('pickers', function()
     assert.is_false(rawget(action_by_name('browse'), 'close'))
     assert.is_false(rawget(action_by_name('yank'), 'close'))
     assert.is_nil(rawget(action_by_name('delete'), 'close'))
+  end)
+
+  it('adds a load more row when the release list exceeds the configured limit', function()
+    vim.g.forge = {
+      display = {
+        limits = {
+          releases = 2,
+        },
+      },
+    }
+    cache['release:list'] = {
+      { tag = 'v3.0.0', title = 'Third', is_draft = false, is_prerelease = false },
+      { tag = 'v2.0.0', title = 'Second', is_draft = false, is_prerelease = false },
+      { tag = 'v1.0.0', title = 'First', is_draft = false, is_prerelease = false },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.release('all', fake_release_forge())
+
+    assert.same({ 'v3.0.0', 'v2.0.0' }, {
+      captured.entries[1].value.tag,
+      captured.entries[2].value.tag,
+    })
+    assert.equals('Load more...', captured.entries[3].display[1][1])
+    assert.is_true(captured.entries[3].load_more)
+  end)
+
+  it('fetches more releases in place with additive next limits', function()
+    vim.g.forge = {
+      display = {
+        limits = {
+          releases = 2,
+        },
+      },
+    }
+    cache['release:list'] = {
+      { tag = 'v3.0.0', title = 'Third', is_draft = false, is_prerelease = false },
+      { tag = 'v2.0.0', title = 'Second', is_draft = false, is_prerelease = false },
+      { tag = 'v1.0.0', title = 'First', is_draft = false, is_prerelease = false },
+    }
+
+    local old_system = vim.system
+    local calls = {}
+    vim.system = function(cmd, _, cb)
+      calls[#calls + 1] = { cmd = cmd, cb = cb }
+      return {
+        wait = function()
+          return {
+            code = 0,
+            stdout = vim.json.encode({
+              { tag = 'v5.0.0', title = 'Fifth', is_draft = false, is_prerelease = false },
+              { tag = 'v4.0.0', title = 'Fourth', is_draft = false, is_prerelease = false },
+              { tag = 'v3.0.0', title = 'Third', is_draft = false, is_prerelease = false },
+              { tag = 'v2.0.0', title = 'Second', is_draft = false, is_prerelease = false },
+              { tag = 'v1.0.0', title = 'First', is_draft = false, is_prerelease = false },
+            }),
+          }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.release('all', fake_release_forge())
+
+    action_by_name('browse').fn(captured.entries[3])
+    vim.system = old_system
+
+    assert.same({ 'releases', '5' }, calls[1].cmd)
+
+    local entries = captured.entry_source()
+    assert.same({ 'v5.0.0', 'v4.0.0', 'v3.0.0', 'v2.0.0' }, {
+      entries[1].value.tag,
+      entries[2].value.tag,
+      entries[3].value.tag,
+      entries[4].value.tag,
+    })
+    assert.equals('Load more...', entries[5].display[1][1])
+    assert.equals(6, entries[5].next_limit)
   end)
 
   it('keeps release copy working when the clipboard register is unavailable', function()

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -32,6 +32,12 @@ describe('github', function()
     assert.truthy(vim.tbl_contains(cmd, '55'))
   end)
 
+  it('respects explicit release list limits', function()
+    local cmd = gh:list_releases_json_cmd({ repo_arg = 'owner/repo' }, 42)
+    assert.truthy(vim.tbl_contains(cmd, '--limit'))
+    assert.truthy(vim.tbl_contains(cmd, '42'))
+  end)
+
   it('builds merge_cmd with method flag', function()
     local squash = gh:merge_cmd('42', 'squash')
     assert.same({ 'gh', 'pr', 'merge', '42', '--squash' }, vim.list_slice(squash, 1, 5))
@@ -402,6 +408,12 @@ describe('gitlab', function()
     local cmd = gl:list_issue_json_cmd('open', 44)
     assert.truthy(vim.tbl_contains(cmd, '--per-page'))
     assert.truthy(vim.tbl_contains(cmd, '44'))
+  end)
+
+  it('respects explicit release list limits', function()
+    local cmd = gl:list_releases_json_cmd({ repo_arg = 'group/repo' }, 42)
+    assert.truthy(vim.tbl_contains(cmd, '--per-page'))
+    assert.truthy(vim.tbl_contains(cmd, '42'))
   end)
 
   it('builds merge_cmd with method flags', function()
@@ -775,6 +787,10 @@ describe('codeberg', function()
     assert.same(
       { 'sh', '-c', 'tea releases list --limit 30 --output json --repo forgejo/tea-test' },
       cb:list_releases_json_cmd({ repo_arg = 'forgejo/tea-test' })
+    )
+    assert.same(
+      { 'sh', '-c', 'tea releases list --limit 55 --output json --repo forgejo/tea-test' },
+      cb:list_releases_json_cmd({ repo_arg = 'forgejo/tea-test' }, 55)
     )
     assert.same(
       { 'sh', '-c', 'tea releases delete --confirm --repo forgejo/tea-test v1.2.3' },


### PR DESCRIPTION
## Problem\nThe release pagination work needed focused coverage for the new picker expansion path and for the explicit release-limit commands exposed by each backend.\n\n## Solution\nAdd picker specs for release load-more rows and additive next-limit behavior, and extend the source specs to assert explicit release-limit handling for GitHub, GitLab, and Codeberg.