### PR TITLE
feat(compose): expose buffer metadata for integrations

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -49,6 +49,7 @@ CONTENTS                                                 *forge.nvim-contents*
     PICKERS....................................................|forge-pickers|
     WORKFLOW SURFACE.........................................|forge-workflow|
     COMPOSE BUFFER.............................................|forge-compose|
+    COMPOSE INTEGRATION...........................|forge-compose-integration|
     HIGHLIGHTS..............................................|forge-highlights|
     SOURCES....................................................|forge-sources|
     HEALTH......................................................|forge-health|
@@ -850,6 +851,67 @@ issue URL is copied to the `+` register on success.
 Editing an issue opens a compose buffer at `forge://issue/{num}/edit` with
 the same title/body layout as issue creation. Write (`:w`) to update the
 issue. An empty title aborts editing. Empty bodies are allowed.
+
+Integration: ~                                                 *forge-compose-integration*
+  Compose buffers expose a small public buffer-local table for completion
+  and other integrations: >
+      vim.b.forge = {
+        version = 1,
+        kind = 'pr' | 'issue',
+        url = 'https://host/owner/repo',
+      }
+<
+  `kind` identifies the compose target. `url` is the target repository web
+  URL and is an empty string if forge.nvim cannot resolve it.
+
+  Blink (`blink-cmp-git`) example: >
+      local function is_forge_compose()
+        return vim.b.forge and vim.b.forge.kind ~= nil
+      end
+
+      require('blink.cmp').setup({
+        sources = {
+          default = function()
+            local sources = { 'lsp', 'path', 'snippets', 'buffer' }
+            if is_forge_compose() then
+              table.insert(sources, 1, 'git')
+            end
+            return sources
+          end,
+          providers = {
+            git = {
+              module = 'blink-cmp-git',
+              enabled = function()
+                return vim.bo.filetype == 'gitcommit' or is_forge_compose()
+              end,
+            },
+          },
+        },
+      })
+<
+  nvim-cmp (`cmp-git`) example: >
+      require('cmp_git').setup({
+        filetypes = { 'gitcommit', 'markdown' },
+      })
+
+      local group = vim.api.nvim_create_augroup('forge_cmp', { clear = true })
+
+      vim.api.nvim_create_autocmd('BufEnter', {
+        group = group,
+        callback = function(args)
+          if not (vim.b[args.buf].forge and vim.b[args.buf].forge.kind) then
+            return
+          end
+          require('cmp').setup.buffer({
+            sources = require('cmp').config.sources({
+              { name = 'git' },
+            }, {
+              { name = 'buffer' },
+            }),
+          })
+        end,
+      })
+<
 
 Template discovery: ~
   forge.nvim searches forge-specific template paths. If a template

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local scope = require('forge.scope')
 local submission = require('forge.submission')
 local template = require('forge.template')
 
@@ -54,6 +55,27 @@ function ComposeBuilder:apply(buf, comment_start)
       priority = 150,
     })
   end
+end
+
+local function current_repo_web_url(forge_name)
+  local remote = vim.trim(vim.fn.system('git remote get-url origin'))
+  if vim.v.shell_error ~= 0 or remote == '' then
+    return ''
+  end
+  local ref = scope.from_url(forge_name, remote)
+  return scope.web_url(ref)
+end
+
+local function set_public_buffer_state(buf, forge_name, kind, ref)
+  local url = scope.web_url(ref)
+  if url == '' then
+    url = current_repo_web_url(forge_name)
+  end
+  vim.b[buf].forge = {
+    version = 1,
+    kind = kind,
+    url = url,
+  }
 end
 
 ---@return integer
@@ -397,6 +419,7 @@ end
 function M.open_issue(f, result, ref)
   local buf = create_compose_buf('forge://issue/new')
   vim.b[buf].forge_scope = ref
+  set_public_buffer_state(buf, f.name, 'issue', ref)
 
   local template_title = result and result.title or ''
   local title_prefix = '# ' .. template_title
@@ -474,6 +497,7 @@ end
 function M.open_issue_edit(f, num, details, ref)
   local buf = create_compose_buf(('forge://issue/%s/edit'):format(num))
   vim.b[buf].forge_scope = ref
+  set_public_buffer_state(buf, f.name, 'issue', ref)
 
   local b = ComposeBuilder.new()
   b.lines = { '# ' .. details.title, '' }
@@ -560,6 +584,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
 
   local buf = create_compose_buf('forge://pr/new')
   vim.b[buf].forge_scope = ref
+  set_public_buffer_state(buf, f.name, 'pr', ref)
 
   local b = ComposeBuilder.new()
   b.lines = { '# ' .. title, '' }
@@ -755,6 +780,7 @@ end
 function M.open_pr_edit(f, num, details, current_branch, ref)
   local buf = create_compose_buf(('forge://pr/%s/edit'):format(num))
   vim.b[buf].forge_scope = ref
+  set_public_buffer_state(buf, f.name, 'pr', ref)
 
   local b = ComposeBuilder.new()
   b.lines = { '# ' .. details.title, '' }

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -144,6 +144,33 @@ describe('compose issue create', function()
     assert.same({}, captured.errors)
   end)
 
+  it('exposes public forge buffer metadata for issue compose buffers', function()
+    local compose = require('forge.compose')
+    local ref = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/repo',
+      repo_arg = 'owner/repo',
+      web_url = 'https://github.com/owner/repo',
+      owner = 'owner',
+      namespace = 'owner',
+      repo = 'repo',
+    }
+
+    compose.open_issue({
+      name = 'github',
+      create_issue_cmd = function()
+        return { 'create-issue' }
+      end,
+    }, nil, ref)
+
+    assert.same({
+      version = 1,
+      kind = 'issue',
+      url = 'https://github.com/owner/repo',
+    }, vim.b.forge)
+  end)
+
   it(
     'keeps a single blank line between the forge line and instructions when metadata is empty',
     function()

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -19,6 +19,7 @@ describe('compose pr create', function()
   before_each(function()
     captured = {
       diff_stat = '',
+      remote_url = 'git@github.com:barrettruth/forge.nvim.git',
     }
 
     old_fn_system = vim.fn.system
@@ -32,6 +33,9 @@ describe('compose pr create', function()
     vim.fn.system = function(cmd)
       if cmd == 'git diff --stat origin/main..HEAD' then
         return captured.diff_stat
+      end
+      if cmd == 'git remote get-url origin' then
+        return captured.remote_url
       end
       return ''
     end
@@ -112,4 +116,46 @@ describe('compose pr create', function()
       assert.equals('  Write (:w) submits this buffer.', lines[creating_line + 10])
     end
   )
+
+  it('exposes public forge buffer metadata for PR compose buffers', function()
+    local compose = require('forge.compose')
+    local ref = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/repo',
+      repo_arg = 'owner/repo',
+      web_url = 'https://github.com/owner/repo',
+      owner = 'owner',
+      namespace = 'owner',
+      repo = 'repo',
+    }
+
+    compose.open_pr({
+      labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+      capabilities = { draft = true, reviewers = false },
+      name = 'github',
+    }, 'new', 'main', false, nil, ref, 'origin', 'origin/main', 'HEAD')
+
+    assert.same({
+      version = 1,
+      kind = 'pr',
+      url = 'https://github.com/owner/repo',
+    }, vim.b.forge)
+  end)
+
+  it('derives the public forge buffer URL from origin when scope is absent', function()
+    local compose = require('forge.compose')
+
+    compose.open_pr({
+      labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+      capabilities = { draft = true, reviewers = false },
+      name = 'github',
+    }, 'new', 'main', false, nil, nil, 'origin', 'origin/main', 'HEAD')
+
+    assert.same({
+      version = 1,
+      kind = 'pr',
+      url = 'https://github.com/barrettruth/forge.nvim',
+    }, vim.b.forge)
+  end)
 end)


### PR DESCRIPTION
## Problem

Compose buffers kept their Markdown editing surface, but third-party completion plugins still had no explicit way to recognize Forge compose buffers or resolve the target repository cleanly in scoped flows.

## Solution

Expose a small public `vim.b.forge` table on compose buffers with `version`, `kind`, and `url`, populate it for PR and issue compose/edit flows, add regression coverage for explicit-scope and origin-derived URLs, and document the contract with concise Blink and nvim-cmp recipes in the help file.