### PR TITLE
fix(compose): narrow scaffold accents

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -832,8 +832,9 @@ Layout: ~
   `<!--`        Informational comment block (branch, forge, diff stat).
   `-->`         End of metadata
 
-Write (`:w`) to push the branch and create the PR. An empty title or body
-aborts creation. The PR URL is copied to the `+` register on success.
+Writing (`:w`) pushes the branch and creates the PR. Creation is aborted if
+the title or body is empty. The PR URL is copied to the `+` register on
+success.
 
 Creating an issue (without `--web`) opens a compose buffer at
 `forge://issue/new` with filetype `markdown` and buftype `acwrite`.
@@ -845,12 +846,12 @@ Layout: ~
   `<!--`        Informational comment block (forge, submit/discard hints).
   `-->`         End of metadata
 
-Write (`:w`) to create the issue. An empty title aborts creation. The
-issue URL is copied to the `+` register on success.
+Writing (`:w`) creates the issue. Creation is aborted if the title is empty.
+The issue URL is copied to the `+` register on success.
 
 Editing an issue opens a compose buffer at `forge://issue/{num}/edit` with
-the same title/body layout as issue creation. Write (`:w`) to update the
-issue. An empty title aborts editing. Empty bodies are allowed.
+the same title/body layout as issue creation. Writing (`:w`) updates the
+issue. Editing is aborted if the title is empty. Empty bodies are allowed.
 
 Integration: ~                                                 *forge-compose-integration*
   Compose buffers expose a small public buffer-local table for completion
@@ -952,7 +953,6 @@ Compose buffer: ~
   `ForgeComposeFile`         `Directory`        File paths in diff stat
   `ForgeComposeAdded`        `Added`            Addition indicators (+)
   `ForgeComposeRemoved`      `Removed`          Deletion indicators (-)
-  `ForgeComposeHeader`       `PreProc`          Section headers
 
 Picker lines: ~
 

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -113,8 +113,8 @@ local function close_compose_buf(buf)
 end
 
 local function add_discard_hints(builder)
-  builder:add_line('  Write (:w) submits this buffer.')
-  builder:add_line('  Quit or delete without ! keeps modified-buffer protection.')
+  builder:add_line('  Writing (:w) submits this buffer.')
+  builder:add_line('  Quitting or deleting without ! preserves modified-buffer protection.')
   builder:add_line('  Use :q!, :bd!, or :bwipeout! to discard it.')
 end
 
@@ -260,7 +260,6 @@ end
 
 local function add_pr_header(builder, prefix, forge_name, branch, base)
   local ln = builder:add_line('%s%s.', prefix, forge_name)
-  builder:mark(ln, 2, #prefix - 2, 'ForgeComposeHeader')
   builder:mark(ln, #prefix, #forge_name, 'ForgeComposeForge')
 
   local branch_prefix = '  On branch '
@@ -268,6 +267,23 @@ local function add_pr_header(builder, prefix, forge_name, branch, base)
   ln = builder:add_line('%s%s%s%s.', branch_prefix, branch, against, base)
   builder:mark(ln, #branch_prefix, #branch, 'ForgeComposeBranch')
   builder:mark(ln, #branch_prefix + #branch + #against, #base, 'ForgeComposeBranch')
+end
+
+local function mark_diff_stat_runs(builder, line_num, line, pipe)
+  local fname_start = line:find('%S')
+  if fname_start then
+    builder:mark(line_num, fname_start - 1, pipe - fname_start - 1, 'ForgeComposeFile')
+  end
+  for pos, run in line:gmatch('()(%++)') do
+    if pos > pipe then
+      builder:mark(line_num, pos - 1, #run, 'ForgeComposeAdded')
+    end
+  end
+  for pos, run in line:gmatch('()(%-+)') do
+    if pos > pipe then
+      builder:mark(line_num, pos - 1, #run, 'ForgeComposeRemoved')
+    end
+  end
 end
 
 ---@param f forge.Forge
@@ -445,7 +461,7 @@ function M.open_issue(f, result, ref)
   add_optional_metadata_fields(b, f, 'issue', 'create', template_metadata)
   add_section_gap(b)
   add_discard_hints(b)
-  b:add_line('  An empty title aborts creation.')
+  b:add_line('  Creation is aborted if the title is empty.')
   b:add_line('-->')
 
   b:apply(buf)
@@ -503,13 +519,12 @@ function M.open_issue_edit(f, num, details, ref)
 
   local editing_prefix = '  Editing issue #' .. num .. ' via '
   local ln = b:add_line('%s%s.', editing_prefix, f.name)
-  b:mark(ln, 2, #editing_prefix - 2, 'ForgeComposeHeader')
   b:mark(ln, #editing_prefix, #f.name, 'ForgeComposeForge')
 
   add_optional_metadata_fields(b, f, 'issue', 'update', submission.issue_metadata(details))
   add_section_gap(b)
   add_discard_hints(b)
-  b:add_line('  An empty title aborts editing.')
+  b:add_line('  Editing is aborted if the title is empty.')
   b:add_line('-->')
 
   b:apply(buf)
@@ -599,7 +614,6 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
     add_section_gap(b)
     local changes_prefix = '  Changes not in '
     local ln = b:add_line('%s%s:', changes_prefix, base_ref)
-    b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
     b:mark(ln, #changes_prefix, #base_ref, 'ForgeComposeBranch')
     b:add_line('')
     stat_start = #b.lines + 1
@@ -610,7 +624,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
   end
   add_section_gap(b)
   add_discard_hints(b)
-  b:add_line('  An empty title or body aborts creation.')
+  b:add_line('  Creation is aborted if the title or body is empty.')
   b:add_line('-->')
 
   b:apply(buf)
@@ -620,16 +634,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
       local line = b.lines[i]
       local pipe = line:find('|')
       if pipe then
-        local fname_start = line:find('%S')
-        if fname_start then
-          b:mark(i, fname_start - 1, pipe - fname_start - 1, 'ForgeComposeFile')
-        end
-        for pos, run in line:gmatch('()([+-]+)') do
-          if pos > pipe then
-            local stat_hl = run:sub(1, 1) == '+' and 'ForgeComposeAdded' or 'ForgeComposeRemoved'
-            b:mark(i, pos - 1, #run, stat_hl)
-          end
-        end
+        mark_diff_stat_runs(b, i, line, pipe)
       end
     end
     for _, m in ipairs(b.marks) do
@@ -797,7 +802,6 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
     add_section_gap(b)
     local changes_prefix = '  Changes not in origin/'
     local ln = b:add_line('%s%s:', changes_prefix, base)
-    b:mark(ln, 2, #changes_prefix - 2, 'ForgeComposeHeader')
     b:mark(ln, #changes_prefix, #base, 'ForgeComposeBranch')
     b:add_line('')
     stat_start = #b.lines + 1
@@ -808,7 +812,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
   end
   add_section_gap(b)
   add_discard_hints(b)
-  b:add_line('  An empty title or body aborts editing.')
+  b:add_line('  Editing is aborted if the title or body is empty.')
   b:add_line('-->')
 
   b:apply(buf)
@@ -818,16 +822,7 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
       local line = b.lines[i]
       local pipe = line:find('|')
       if pipe then
-        local fname_start = line:find('%S')
-        if fname_start then
-          b:mark(i, fname_start - 1, pipe - fname_start - 1, 'ForgeComposeFile')
-        end
-        for pos, run in line:gmatch('()([+-]+)') do
-          if pos > pipe then
-            local stat_hl = run:sub(1, 1) == '+' and 'ForgeComposeAdded' or 'ForgeComposeRemoved'
-            b:mark(i, pos - 1, #run, stat_hl)
-          end
-        end
+        mark_diff_stat_runs(b, i, line, pipe)
       end
     end
     for _, m in ipairs(b.marks) do

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -254,7 +254,6 @@ local hl_defaults = {
   ForgeComposeFile = 'Directory',
   ForgeComposeAdded = 'Added',
   ForgeComposeRemoved = 'Removed',
-  ForgeComposeHeader = 'PreProc',
   ForgeNumber = 'Number',
   ForgeOpen = 'DiagnosticOk',
   ForgeMerged = 'Special',

--- a/spec/compose_abandon_spec.lua
+++ b/spec/compose_abandon_spec.lua
@@ -133,9 +133,9 @@ describe('compose abandon behavior', function()
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-    assert.is_true(contains_line(lines, '  Write (:w) submits this buffer.'))
+    assert.is_true(contains_line(lines, '  Writing (:w) submits this buffer.'))
     assert.is_true(
-      contains_line(lines, '  Quit or delete without ! keeps modified-buffer protection.')
+      contains_line(lines, '  Quitting or deleting without ! preserves modified-buffer protection.')
     )
     assert.is_true(contains_line(lines, '  Use :q!, :bd!, or :bwipeout! to discard it.'))
   end)
@@ -152,9 +152,9 @@ describe('compose abandon behavior', function()
 
     local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
 
-    assert.is_true(contains_line(lines, '  Write (:w) submits this buffer.'))
+    assert.is_true(contains_line(lines, '  Writing (:w) submits this buffer.'))
     assert.is_true(
-      contains_line(lines, '  Quit or delete without ! keeps modified-buffer protection.')
+      contains_line(lines, '  Quitting or deleting without ! preserves modified-buffer protection.')
     )
     assert.is_true(contains_line(lines, '  Use :q!, :bd!, or :bwipeout! to discard it.'))
   end)

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -1,5 +1,31 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local function extmark_groups_for_line(buf, target)
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  local line_num
+  for i, line in ipairs(lines) do
+    if line == target then
+      line_num = i
+      break
+    end
+  end
+  assert.is_not_nil(line_num)
+  local ns = vim.api.nvim_get_namespaces().forge_compose
+  local extmarks = vim.api.nvim_buf_get_extmarks(
+    buf,
+    ns,
+    { line_num - 1, 0 },
+    { line_num - 1, -1 },
+    { details = true }
+  )
+  local groups = {}
+  for _, extmark in ipairs(extmarks) do
+    table.insert(groups, extmark[4].hl_group)
+  end
+  table.sort(groups)
+  return groups
+end
+
 describe('compose issue create', function()
   local captured
   local old_system
@@ -193,7 +219,7 @@ describe('compose issue create', function()
 
       assert.is_not_nil(creating_line)
       assert.equals('', lines[creating_line + 1])
-      assert.equals('  Write (:w) submits this buffer.', lines[creating_line + 2])
+      assert.equals('  Writing (:w) submits this buffer.', lines[creating_line + 2])
     end
   )
 
@@ -223,6 +249,18 @@ describe('compose issue create', function()
       assert.is_true(saw_forge)
     end
   )
+
+  it('only accents the forge name on the issue create action line', function()
+    local compose = require('forge.compose')
+    compose.open_issue({
+      name = 'github',
+      create_issue_cmd = function()
+        return { 'create-issue' }
+      end,
+    })
+
+    assert.same({ 'ForgeComposeForge' }, extmark_groups_for_line(0, '  Creating issue via github.'))
+  end)
 
   it('keeps template labels without rendering editable metadata', function()
     local compose = require('forge.compose')
@@ -457,6 +495,31 @@ describe('compose issue edit', function()
     vim.cmd('enew!')
   end)
 
+  it('only accents the forge name on the issue edit action line', function()
+    local compose = require('forge.compose')
+    compose.open_issue_edit(
+      {
+        name = 'github',
+        update_issue_cmd = function()
+          return { 'update-issue' }
+        end,
+      },
+      '42',
+      {
+        title = 'existing issue',
+        body = 'body',
+        labels = {},
+        assignees = {},
+        milestone = '',
+      }
+    )
+
+    assert.same(
+      { 'ForgeComposeForge' },
+      extmark_groups_for_line(0, '  Editing issue #42 via github.')
+    )
+  end)
+
   it('extracts issue metadata from the comment block on write', function()
     local compose = require('forge.compose')
     local original = {
@@ -498,10 +561,10 @@ describe('compose issue edit', function()
       '  Assignees: alice, bob',
       '  Milestone: v2',
       '',
-      '  Write (:w) submits this buffer.',
-      '  Quit or delete without ! keeps modified-buffer protection.',
+      '  Writing (:w) submits this buffer.',
+      '  Quitting or deleting without ! preserves modified-buffer protection.',
       '  Use :q!, :bd!, or :bwipeout! to discard it.',
-      '  An empty title aborts editing.',
+      '  Editing is aborted if the title is empty.',
       '-->',
     })
     vim.cmd('write')

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -16,6 +16,26 @@ describe('compose pr create', function()
     return nil
   end
 
+  local function extmark_groups_for_line(buf, target)
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local line_num = line_index(lines, target)
+    assert.is_not_nil(line_num)
+    local ns = vim.api.nvim_get_namespaces().forge_compose
+    local extmarks = vim.api.nvim_buf_get_extmarks(
+      buf,
+      ns,
+      { line_num - 1, 0 },
+      { line_num - 1, -1 },
+      { details = true }
+    )
+    local groups = {}
+    for _, extmark in ipairs(extmarks) do
+      table.insert(groups, extmark[4].hl_group)
+    end
+    table.sort(groups)
+    return groups
+  end
+
   before_each(function()
     captured = {
       diff_stat = '',
@@ -113,9 +133,35 @@ describe('compose pr create', function()
       assert.equals('   lua/forge/pickers.lua | 1 +', lines[creating_line + 7])
       assert.equals('   1 file changed, 1 insertion(+)', lines[creating_line + 8])
       assert.equals('', lines[creating_line + 9])
-      assert.equals('  Write (:w) submits this buffer.', lines[creating_line + 10])
+      assert.equals('  Writing (:w) submits this buffer.', lines[creating_line + 10])
     end
   )
+
+  it('keeps PR create accents narrow and splits mixed diff-stat runs', function()
+    captured.diff_stat =
+      ' lua/forge/pickers.lua | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
+
+    local compose = require('forge.compose')
+    compose.open_pr({
+      labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+      capabilities = { draft = true, reviewers = false },
+      name = 'github',
+    }, 'new', 'main', false, nil, nil, 'origin', 'origin/main', 'HEAD')
+
+    assert.same(
+      { 'ForgeComposeForge' },
+      extmark_groups_for_line(0, '  Creating Pull Request via github.')
+    )
+    assert.same(
+      { 'ForgeComposeBranch' },
+      extmark_groups_for_line(0, '  Changes not in origin/main:')
+    )
+    assert.same(
+      { 'ForgeComposeAdded', 'ForgeComposeFile', 'ForgeComposeRemoved' },
+      extmark_groups_for_line(0, '   lua/forge/pickers.lua | 2 +-')
+    )
+    assert.same({}, extmark_groups_for_line(0, '   1 file changed, 1 insertion(+), 1 deletion(-)'))
+  end)
 
   it('exposes public forge buffer metadata for PR compose buffers', function()
     local compose = require('forge.compose')

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -16,6 +16,26 @@ describe('compose pr edit', function()
     return nil
   end
 
+  local function extmark_groups_for_line(buf, target)
+    local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+    local line_num = line_index(lines, target)
+    assert.is_not_nil(line_num)
+    local ns = vim.api.nvim_get_namespaces().forge_compose
+    local extmarks = vim.api.nvim_buf_get_extmarks(
+      buf,
+      ns,
+      { line_num - 1, 0 },
+      { line_num - 1, -1 },
+      { details = true }
+    )
+    local groups = {}
+    for _, extmark in ipairs(extmarks) do
+      table.insert(groups, extmark[4].hl_group)
+    end
+    table.sort(groups)
+    return groups
+  end
+
   before_each(function()
     captured = {
       infos = {},
@@ -214,9 +234,50 @@ describe('compose pr edit', function()
       assert.is_not_nil(editing_line)
       assert.equals('  On branch real-pr-head against main.', lines[editing_line + 1])
       assert.equals('', lines[editing_line + 2])
-      assert.equals('  Write (:w) submits this buffer.', lines[editing_line + 3])
+      assert.equals('  Writing (:w) submits this buffer.', lines[editing_line + 3])
     end
   )
+
+  it('keeps PR edit accents narrow and splits mixed diff-stat runs', function()
+    captured.diff_stat =
+      ' lua/forge/init.lua | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)\n'
+
+    local compose = require('forge.compose')
+    compose.open_pr_edit(
+      {
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = true },
+        name = 'github',
+      },
+      '23',
+      {
+        title = 'PR title',
+        body = 'PR body',
+        draft = false,
+        head_branch = 'feature',
+        base_branch = 'main',
+        reviewers = {},
+        labels = {},
+        assignees = {},
+        milestone = '',
+      },
+      'feature'
+    )
+
+    assert.same(
+      { 'ForgeComposeForge' },
+      extmark_groups_for_line(0, '  Editing Pull Request #23 via github.')
+    )
+    assert.same(
+      { 'ForgeComposeBranch' },
+      extmark_groups_for_line(0, '  Changes not in origin/main:')
+    )
+    assert.same(
+      { 'ForgeComposeAdded', 'ForgeComposeFile', 'ForgeComposeRemoved' },
+      extmark_groups_for_line(0, '   lua/forge/init.lua | 2 +-')
+    )
+    assert.same({}, extmark_groups_for_line(0, '   1 file changed, 1 insertion(+), 1 deletion(-)'))
+  end)
 
   it('extracts PR metadata from the comment block on write', function()
     local compose = require('forge.compose')


### PR DESCRIPTION
## Problem

Compose buffers still over-accented some scaffold text, diff-stat minus runs could inherit the added highlight when mixed with plus runs, and the compose footer copy read awkwardly.

## Solution

Keep compose accents narrow by highlighting only the forge name on action lines and only the base ref on `Changes not in ...`, split diff-stat plus and minus runs into separate highlights so removals render with `ForgeComposeRemoved`, and update the compose footer/docs wording to match the revised behavior. The compose specs now cover the narrower extmark surface and the mixed diff-stat case in both PR create and PR edit flows.