### PR TITLE
docs(compose): align top-level guidance wording

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -818,9 +818,10 @@ Built-in picker backend capabilities: ~
 ==============================================================================
 COMPOSE BUFFER                                                 *forge-compose*
 
-Compose and edit buffers behave like native `acwrite` buffers. Write (`:w`)
-submits the current buffer. Quit or delete without `!` keeps modified-buffer
-protection. Use `:q!`, `:bd!`, or `:bwipeout!` to discard the buffer.
+Compose and edit buffers behave like native `acwrite` buffers. Writing (`:w`)
+submits the current buffer. Quitting or deleting without `!` preserves
+modified-buffer protection. Use `:q!`, `:bd!`, or `:bwipeout!` to discard the
+buffer.
 
 Creating a PR (without `--fill` or `--web`) opens a compose buffer at
 `forge://pr/new` with filetype `markdown` and buftype `acwrite`.


### PR DESCRIPTION
## Problem
The top-level compose buffer help text still uses older wording that is slightly less direct than the surrounding help copy.

## Solution
Refresh that short paragraph to use clearer wording while keeping the behavior and commands unchanged.