### PR TITLE
ux(ci): prefer native GitHub run views

### DIFF
--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -924,6 +924,8 @@ local function parse_summary(raw_lines)
   local hls = {}
   local jobs = {}
   local job_lnums = {}
+  local section
+  local current_job
 
   for _, raw in ipairs(raw_lines) do
     local text, h = strip_ansi(raw)
@@ -931,10 +933,19 @@ local function parse_summary(raw_lines)
     local status = prefix and summary_status(prefix) or nil
     lines[#lines + 1] = text
     hls[#hls + 1] = h
+    if text == '' then
+      current_job = nil
+    elseif text:match('^%u[%u%s]+$') then
+      section = text
+      current_job = nil
+    end
     local job_id = text:match('%(ID (%d+)%)%s*$')
     if job_id then
       jobs[#lines] = { id = job_id, failed = status == 'failure' }
+      current_job = jobs[#lines]
       job_lnums[#job_lnums + 1] = #lines
+    elseif current_job and text:match('^%s+') and section ~= 'ANNOTATIONS' then
+      jobs[#lines] = current_job
     end
   end
 
@@ -1129,14 +1140,6 @@ function M.open_summary(cmd, opts, reuse_buf)
               return
             end
             local job = d.jobs[lnum]
-            if not job then
-              for i = lnum, 1, -1 do
-                if d.jobs[i] then
-                  job = d.jobs[i]
-                  break
-                end
-              end
-            end
             if job and opts.log_cmd_fn then
               local log_cmd, log_opts = opts.log_cmd_fn(job.id, job.failed)
               M.open(log_cmd, log_opts)

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -286,15 +286,14 @@ function M.ci_log(f, run)
   local url = trim(run.url)
   url = url ~= '' and url or nil
   local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id, run_ref) or nil
-  if f.summary_json_cmd then
-    require('forge.log').open_summary(f:summary_json_cmd(run.id, run_ref), {
+  if f.view_cmd then
+    require('forge.log').open_summary(f:view_cmd(run.id, { scope = run_ref }), {
       forge_name = f.name,
       run_id = run.id,
       url = url,
       title = run.name or run.id,
       in_progress = in_progress,
       status_cmd = status_cmd,
-      json = true,
       log_cmd_fn = function(job_id, failed)
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
@@ -310,14 +309,15 @@ function M.ci_log(f, run)
     })
     return
   end
-  if f.view_cmd then
-    require('forge.log').open_summary(f:view_cmd(run.id, { scope = run_ref }), {
+  if f.summary_json_cmd then
+    require('forge.log').open_summary(f:summary_json_cmd(run.id, run_ref), {
       forge_name = f.name,
       run_id = run.id,
       url = url,
       title = run.name or run.id,
       in_progress = in_progress,
       status_cmd = status_cmd,
+      json = true,
       log_cmd_fn = function(job_id, failed)
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -349,6 +349,24 @@ describe('parse_summary', function()
     assert.equals(0, #result.lines)
     assert.equals(0, #result.job_lnums)
   end)
+
+  it('maps job step lines without binding annotation lines', function()
+    local result = parse_summary({
+      'JOBS',
+      '✓ lint (ID 12345)',
+      '  ✓ Set up job',
+      '  * Run stylua',
+      '',
+      'ANNOTATIONS',
+      '! warning',
+    })
+    assert.same({ id = '12345', failed = false }, result.jobs[2])
+    assert.same({ id = '12345', failed = false }, result.jobs[3])
+    assert.same({ id = '12345', failed = false }, result.jobs[4])
+    assert.is_nil(result.jobs[5])
+    assert.is_nil(result.jobs[6])
+    assert.equals(1, #result.job_lnums)
+  end)
 end)
 
 describe('parse_summary_json', function()
@@ -590,6 +608,86 @@ describe('buffer reuse refreshes', function()
     vim.wait(20)
 
     assert.same({ '✓ new job (ID 2)' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+  end)
+end)
+
+describe('summary job mappings', function()
+  local original_system
+  local original_open
+
+  before_each(function()
+    original_system = vim.system
+    original_open = log_mod.open
+  end)
+
+  after_each(function()
+    vim.system = original_system
+    log_mod.open = original_open
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        local name = vim.api.nvim_buf_get_name(buf)
+        if name:match('^forge://') then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end
+    vim.cmd('silent! %bwipeout!')
+    vim.cmd('enew!')
+  end)
+
+  it('opens logs from job step lines but not annotation lines', function()
+    local opened = {}
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = table.concat({
+          '✓ lint (ID 12345)',
+          '  ✓ Set up job',
+          '  * Run stylua',
+          '',
+          'ANNOTATIONS',
+          '! warning',
+        }, '\n'),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+    log_mod.open = function(cmd, opts)
+      opened[#opened + 1] = { cmd = cmd, opts = opts }
+    end
+
+    log_mod.open_summary({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      run_id = '12345',
+      title = 'summary',
+      log_cmd_fn = function(job_id, failed)
+        return { 'log', job_id, tostring(failed) }, { title = job_id }
+      end,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == '✓ lint (ID 12345)'
+    end)
+
+    local enter = vim.fn.maparg('<cr>', 'n', false, true).callback
+
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    enter()
+    vim.wait(100, function()
+      return #opened == 1
+    end)
+
+    assert.same({ 'log', '12345', 'false' }, opened[1].cmd)
+    assert.same({ title = '12345' }, opened[1].opts)
+
+    vim.api.nvim_win_set_cursor(0, { 6, 0 })
+    enter()
+    vim.wait(20)
+
+    assert.equals(1, #opened)
   end)
 end)
 

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -199,10 +199,13 @@ describe('shared operations', function()
     assert.equals(1, done)
   end)
 
-  it('opens CI summaries through the shared log operation', function()
+  it('prefers native CI summaries when a backend exposes a run view', function()
     local ops = require('forge.ops')
     ops.ci_log({
       name = 'github',
+      view_cmd = function(_, run_id, opts)
+        return { 'view', run_id, opts and opts.scope or 'none' }
+      end,
       summary_json_cmd = function(_, run_id, scope)
         return { 'summary', run_id, scope or 'none' }
       end,
@@ -223,7 +226,7 @@ describe('shared operations', function()
       scope = 'repo/ref',
     })
 
-    assert.same({ 'summary', '77', 'repo/ref' }, captured.summaries[1].cmd)
+    assert.same({ 'view', '77', 'repo/ref' }, captured.summaries[1].cmd)
     local summary_opts = vim.deepcopy(captured.summaries[1].opts)
     summary_opts.log_cmd_fn = nil
     assert.same({
@@ -233,7 +236,6 @@ describe('shared operations', function()
       title = 'CI',
       in_progress = true,
       status_cmd = { 'status', '77', 'repo/ref' },
-      json = true,
     }, summary_opts)
 
     local cmd, opts = captured.summaries[1].opts.log_cmd_fn('job-1', true)
@@ -247,6 +249,41 @@ describe('shared operations', function()
       in_progress = true,
       status_cmd = { 'status', '77', 'repo/ref' },
     }, opts)
+  end)
+
+  it('falls back to JSON CI summaries when no run view is available', function()
+    local ops = require('forge.ops')
+    ops.ci_log({
+      name = 'custom',
+      summary_json_cmd = function(_, run_id, scope)
+        return { 'summary', run_id, scope or 'none' }
+      end,
+      check_log_cmd = function(_, run_id, failed, job_id, scope)
+        return { 'check-log', run_id, tostring(failed), job_id or '', scope or 'none' }
+      end,
+      run_status_cmd = function(_, run_id, scope)
+        return { 'status', run_id, scope or 'none' }
+      end,
+    }, {
+      id = '77',
+      name = 'CI',
+      status = 'running',
+      url = 'https://example.com/runs/77',
+      scope = 'repo/ref',
+    })
+
+    assert.same({ 'summary', '77', 'repo/ref' }, captured.summaries[1].cmd)
+    local summary_opts = vim.deepcopy(captured.summaries[1].opts)
+    summary_opts.log_cmd_fn = nil
+    assert.same({
+      forge_name = 'custom',
+      run_id = '77',
+      url = 'https://example.com/runs/77',
+      title = 'CI',
+      in_progress = true,
+      status_cmd = { 'status', '77', 'repo/ref' },
+      json = true,
+    }, summary_opts)
   end)
 
   it('opens CI logs and watches through the shared operations', function()


### PR DESCRIPTION
## Problem
GitHub CI runs currently flow through a Forge-specific compact summary that loses the native `gh run view` shape. That makes the in-buffer run surface feel semantically different from GitHub itself, especially for in-progress runs. The old summary interaction model also risks treating non-job lines like annotations as if they belong to the last job.

## Solution
Prefer native run views whenever a backend exposes them, which moves GitHub summaries onto raw `gh run view` output instead of the compact JSON-reduced summary. Update summary parsing so job step lines still open the parent job log, while annotation lines stay non-actionable, and cover both behaviors with specs.