### PR TITLE
fix(ci): restore native GitHub summary accents

### DIFF
--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -60,6 +60,10 @@ local function nwo(scope)
   return forge.scope_repo_arg(current) or ''
 end
 
+local function tty_env()
+  return { 'env', 'GH_FORCE_TTY=1000', 'CLICOLOR_FORCE=1' }
+end
+
 local function open_browse_url(cmd)
   local browse_cmd = vim.deepcopy(cmd)
   table.insert(browse_cmd, '--no-browser')
@@ -287,7 +291,8 @@ end
 ---@return string[]
 function M:view_cmd(id, opts)
   opts = opts or {}
-  local cmd = { 'gh', 'run', 'view', id, '-R', nwo(opts.scope) }
+  local cmd = tty_env()
+  vim.list_extend(cmd, { 'gh', 'run', 'view', id, '-R', nwo(opts.scope) })
   if opts.job_id then
     table.insert(cmd, '--job')
     table.insert(cmd, opts.job_id)

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -45,12 +45,14 @@ local function request_current(buf, request_id)
 end
 
 local sgr_map = {
+  [1] = 'ForgeLogJob',
   [2] = 'ForgeLogDim',
   [31] = 'ForgeFail',
   [32] = 'ForgePass',
   [33] = 'ForgeLogWarning',
   [34] = 'ForgeLogStep',
   [36] = 'ForgeLogSection',
+  [242] = 'ForgeLogDim',
   [91] = 'ForgeFail',
   [92] = 'ForgePass',
   [93] = 'ForgeLogWarning',
@@ -85,11 +87,16 @@ local function strip_ansi(line)
         hls[#hls + 1] = { col = grp_start, end_col = col, group = grp }
       end
       grp = nil
+      grp_start = nil
       if params ~= '' and params ~= '0' then
         for p in params:gmatch('(%d+)') do
           local n = tonumber(p)
           if n == 0 then
             grp = nil
+            grp_start = nil
+          elseif n == 1 then
+            grp = grp or sgr_map[n]
+            grp_start = grp_start or col
           elseif sgr_map[n] then
             grp = sgr_map[n]
             grp_start = col
@@ -929,13 +936,15 @@ local function parse_summary(raw_lines)
 
   for _, raw in ipairs(raw_lines) do
     local text, h = strip_ansi(raw)
+    if text:match('^%s*$') then
+      current_job = nil
+      goto continue
+    end
     local prefix = text:match('^(%S+)')
     local status = prefix and summary_status(prefix) or nil
     lines[#lines + 1] = text
     hls[#hls + 1] = h
-    if text == '' then
-      current_job = nil
-    elseif text:match('^%u[%u%s]+$') then
+    if text:match('^%u[%u%s]+$') then
       section = text
       current_job = nil
     end
@@ -947,6 +956,7 @@ local function parse_summary(raw_lines)
     elseif current_job and text:match('^%s+') and section ~= 'ANNOTATIONS' then
       jobs[#lines] = current_job
     end
+    ::continue::
   end
 
   return { lines = lines, hls = hls, jobs = jobs, job_lnums = job_lnums }

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -350,13 +350,41 @@ describe('parse_summary', function()
     assert.equals(0, #result.job_lnums)
   end)
 
+  it('preserves ansi-derived job styling from native GitHub output', function()
+    local result = parse_summary({
+      '\027[0;32m✓\027[0m \027[0;1;39mLua Test Check\027[0m in 2m12s (ID \027[0;36m71350221923\027[0m)',
+      '\027[0;33m!\027[0m warning text',
+      '\027[38;5;242mLua Test Check: .github#2\027[0m',
+    })
+    assert.same({
+      { col = 0, end_col = 3, group = 'ForgePass' },
+      { col = 4, end_col = 18, group = 'ForgeLogJob' },
+      { col = 32, end_col = 43, group = 'ForgeLogSection' },
+    }, result.hls[1])
+    assert.same({ { col = 0, end_col = 1, group = 'ForgeLogWarning' } }, result.hls[2])
+    assert.same({ { col = 0, end_col = 25, group = 'ForgeLogDim' } }, result.hls[3])
+  end)
+
+  it('drops blank summary lines from native output', function()
+    local result = parse_summary({
+      'header',
+      '',
+      'JOBS',
+      'job',
+      '   ',
+      'ANNOTATIONS',
+      '',
+      '! warning',
+    })
+    assert.same({ 'header', 'JOBS', 'job', 'ANNOTATIONS', '! warning' }, result.lines)
+  end)
+
   it('maps job step lines without binding annotation lines', function()
     local result = parse_summary({
       'JOBS',
       '✓ lint (ID 12345)',
       '  ✓ Set up job',
       '  * Run stylua',
-      '',
       'ANNOTATIONS',
       '! warning',
     })
@@ -645,7 +673,6 @@ describe('summary job mappings', function()
           '✓ lint (ID 12345)',
           '  ✓ Set up job',
           '  * Run stylua',
-          '',
           'ANNOTATIONS',
           '! warning',
         }, '\n'),
@@ -683,7 +710,7 @@ describe('summary job mappings', function()
     assert.same({ 'log', '12345', 'false' }, opened[1].cmd)
     assert.same({ title = '12345' }, opened[1].opts)
 
-    vim.api.nvim_win_set_cursor(0, { 6, 0 })
+    vim.api.nvim_win_set_cursor(0, { 5, 0 })
     enter()
     vim.wait(20)
 

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -57,6 +57,14 @@ describe('github', function()
     assert.falsy(vim.tbl_contains(cmd, '--rebase'))
   end)
 
+  it('forces tty color for run view summaries', function()
+    local cmd = gh:view_cmd('24423079286', { scope = { repo_arg = 'owner/repo' } })
+    assert.same({ 'env', 'GH_FORCE_TTY=1000', 'CLICOLOR_FORCE=1', 'gh', 'run', 'view' }, vim.list_slice(cmd, 1, 6))
+    assert.truthy(vim.tbl_contains(cmd, '24423079286'))
+    assert.truthy(vim.tbl_contains(cmd, '-R'))
+    assert.truthy(vim.tbl_contains(cmd, 'owner/repo'))
+  end)
+
   it('builds create_pr_cmd', function()
     local cmd = gh:create_pr_cmd('title', 'body', 'main', false, nil, {
       draft = true,

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -59,7 +59,10 @@ describe('github', function()
 
   it('forces tty color for run view summaries', function()
     local cmd = gh:view_cmd('24423079286', { scope = { repo_arg = 'owner/repo' } })
-    assert.same({ 'env', 'GH_FORCE_TTY=1000', 'CLICOLOR_FORCE=1', 'gh', 'run', 'view' }, vim.list_slice(cmd, 1, 6))
+    assert.same(
+      { 'env', 'GH_FORCE_TTY=1000', 'CLICOLOR_FORCE=1', 'gh', 'run', 'view' },
+      vim.list_slice(cmd, 1, 6)
+    )
     assert.truthy(vim.tbl_contains(cmd, '24423079286'))
     assert.truthy(vim.tbl_contains(cmd, '-R'))
     assert.truthy(vim.tbl_contains(cmd, 'owner/repo'))


### PR DESCRIPTION
## Problem
The new GitHub-native run summary shape was correct, but the buffer had lost a lot of the visual accents that make `gh run view` readable in a terminal. Status markers, bold job names, cyan ids, and dim annotation footers were flatter than the native CLI output, and the raw summary still included whitespace-only spacer lines.

## Solution
Force terminal-style ANSI output for GitHub run views, preserve those ANSI-derived highlight spans when rendering the summary buffer, and drop whitespace-only summary lines. The follow-up specs cover both the ANSI styling path and the denser blank-line-free summary layout.