### PR TITLE
fix(ci): browse summaries contextually

### DIFF
--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -304,6 +304,27 @@ function M:view_cmd(id, opts)
 end
 
 ---@param id string
+---@return string?
+function M:run_web_url(id, scope)
+  local base = forge.remote_web_url(scope)
+  if not base or base == '' then
+    return nil
+  end
+  return ('%s/actions/runs/%s'):format(base, id)
+end
+
+---@param run_id string
+---@param job_id string
+---@return string?
+function M:job_web_url(run_id, job_id, scope)
+  local run_url = self:run_web_url(run_id, scope)
+  if not run_url or run_url == '' then
+    return nil
+  end
+  return ('%s/job/%s'):format(run_url, job_id)
+end
+
+---@param id string
 ---@return string[]
 function M:summary_json_cmd(id, scope)
   local jq = table.concat({

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -924,6 +924,7 @@ end
 ---@field in_progress boolean?
 ---@field status_cmd string[]?
 ---@field json boolean?
+---@field browse_url_fn fun(job_id: string): string?
 ---@field log_cmd_fn fun(job_id: string, failed: boolean): string[], forge.LogOpts
 
 local function parse_summary(raw_lines)
@@ -933,30 +934,51 @@ local function parse_summary(raw_lines)
   local job_lnums = {}
   local section
   local current_job
+  local first = 1
+  local last = #raw_lines
 
-  for _, raw in ipairs(raw_lines) do
+  while first <= last do
+    local text = strip_ansi(raw_lines[first])
+    if not text:match('^%s*$') then
+      break
+    end
+    first = first + 1
+  end
+
+  while last >= first do
+    local text = strip_ansi(raw_lines[last])
+    if not text:match('^%s*$') then
+      break
+    end
+    last = last - 1
+  end
+
+  for i = first, last do
+    local raw = raw_lines[i]
     local text, h = strip_ansi(raw)
+    local lnum = #lines + 1
     if text:match('^%s*$') then
+      text = ''
+      h = {}
       current_job = nil
-      goto continue
+    else
+      local prefix = text:match('^(%S+)')
+      local status = prefix and summary_status(prefix) or nil
+      if text:match('^%u[%u%s]+$') then
+        section = text
+        current_job = nil
+      end
+      local job_id = text:match('%(ID (%d+)%)%s*$')
+      if job_id then
+        jobs[lnum] = { id = job_id, failed = status == 'failure' }
+        current_job = jobs[lnum]
+        job_lnums[#job_lnums + 1] = lnum
+      elseif current_job and text:match('^%s+') and section ~= 'ANNOTATIONS' then
+        jobs[lnum] = current_job
+      end
     end
-    local prefix = text:match('^(%S+)')
-    local status = prefix and summary_status(prefix) or nil
-    lines[#lines + 1] = text
-    hls[#hls + 1] = h
-    if text:match('^%u[%u%s]+$') then
-      section = text
-      current_job = nil
-    end
-    local job_id = text:match('%(ID (%d+)%)%s*$')
-    if job_id then
-      jobs[#lines] = { id = job_id, failed = status == 'failure' }
-      current_job = jobs[#lines]
-      job_lnums[#job_lnums + 1] = #lines
-    elseif current_job and text:match('^%s+') and section ~= 'ANNOTATIONS' then
-      jobs[#lines] = current_job
-    end
-    ::continue::
+    lines[lnum] = text
+    hls[lnum] = h
   end
 
   return { lines = lines, hls = hls, jobs = jobs, job_lnums = job_lnums }
@@ -1130,8 +1152,16 @@ function M.open_summary(cmd, opts, reuse_buf)
             vim.api.nvim_buf_delete(buf, { force = true })
           end, 'Close')
           map(keys.browse, function()
-            if opts.url then
-              vim.ui.open(opts.url)
+            local url = opts.url
+            local d = buf_data[buf]
+            if d and d.jobs then
+              local job = d.jobs[vim.api.nvim_win_get_cursor(0)[1]]
+              if job and opts.browse_url_fn then
+                url = opts.browse_url_fn(job.id) or url
+              end
+            end
+            if url then
+              vim.ui.open(url)
             end
           end, 'Browse')
           map(keys.refresh, function()

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -284,6 +284,9 @@ function M.ci_log(f, run)
     or status == 'pending'
     or status == 'running'
   local url = trim(run.url)
+  if url == '' and f.run_web_url then
+    url = trim(f:run_web_url(run.id, run_ref) or '')
+  end
   url = url ~= '' and url or nil
   local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id, run_ref) or nil
   if f.view_cmd then
@@ -294,6 +297,12 @@ function M.ci_log(f, run)
       title = run.name or run.id,
       in_progress = in_progress,
       status_cmd = status_cmd,
+      browse_url_fn = function(job_id)
+        if f.job_web_url then
+          return f:job_web_url(run.id, job_id, run_ref)
+        end
+        return nil
+      end,
       log_cmd_fn = function(job_id, failed)
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
@@ -318,6 +327,12 @@ function M.ci_log(f, run)
       in_progress = in_progress,
       status_cmd = status_cmd,
       json = true,
+      browse_url_fn = function(job_id)
+        if f.job_web_url then
+          return f:job_web_url(run.id, job_id, run_ref)
+        end
+        return nil
+      end,
       log_cmd_fn = function(job_id, failed)
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
@@ -353,6 +368,9 @@ function M.ci_watch(f, run)
     return false
   end
   local url = trim(run.url)
+  if url == '' and f.run_web_url then
+    url = trim(f:run_web_url(run.id, run.scope) or '')
+  end
   require('forge.term').open(f:watch_cmd(run.id, run.scope), {
     url = url ~= '' and url or nil,
   })

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -162,6 +162,8 @@
 ---@field summary_json_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
 ---@field watch_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
 ---@field run_status_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
+---@field run_web_url (fun(self: forge.Forge, id: string, scope?: forge.Scope): string?)?
+---@field job_web_url (fun(self: forge.Forge, run_id: string, job_id: string, scope?: forge.Scope): string?)?
 ---@field live_tail_cmd (fun(self: forge.Forge, run_id: string, job_id: string?, scope?: forge.Scope): string[])?
 ---@field list_runs_json_cmd fun(self: forge.Forge, branch: string?, scope?: forge.Scope, limit?: integer): string[]
 ---@field list_runs_cmd fun(self: forge.Forge, branch: string?, scope?: forge.Scope): string

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -365,8 +365,10 @@ describe('parse_summary', function()
     assert.same({ { col = 0, end_col = 25, group = 'ForgeLogDim' } }, result.hls[3])
   end)
 
-  it('drops blank summary lines from native output', function()
+  it('trims boundary blank lines but preserves internal blank separators', function()
     local result = parse_summary({
+      '',
+      '   ',
       'header',
       '',
       'JOBS',
@@ -375,8 +377,10 @@ describe('parse_summary', function()
       'ANNOTATIONS',
       '',
       '! warning',
+      '  ',
+      '',
     })
-    assert.same({ 'header', 'JOBS', 'job', 'ANNOTATIONS', '! warning' }, result.lines)
+    assert.same({ 'header', '', 'JOBS', 'job', '', 'ANNOTATIONS', '', '! warning' }, result.lines)
   end)
 
   it('maps job step lines without binding annotation lines', function()
@@ -385,6 +389,7 @@ describe('parse_summary', function()
       '✓ lint (ID 12345)',
       '  ✓ Set up job',
       '  * Run stylua',
+      '',
       'ANNOTATIONS',
       '! warning',
     })
@@ -393,6 +398,7 @@ describe('parse_summary', function()
     assert.same({ id = '12345', failed = false }, result.jobs[4])
     assert.is_nil(result.jobs[5])
     assert.is_nil(result.jobs[6])
+    assert.is_nil(result.jobs[7])
     assert.equals(1, #result.job_lnums)
   end)
 end)
@@ -642,15 +648,18 @@ end)
 describe('summary job mappings', function()
   local original_system
   local original_open
+  local original_ui_open
 
   before_each(function()
     original_system = vim.system
     original_open = log_mod.open
+    original_ui_open = vim.ui.open
   end)
 
   after_each(function()
     vim.system = original_system
     log_mod.open = original_open
+    vim.ui.open = original_ui_open
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if vim.api.nvim_buf_is_valid(buf) then
@@ -673,6 +682,7 @@ describe('summary job mappings', function()
           '✓ lint (ID 12345)',
           '  ✓ Set up job',
           '  * Run stylua',
+          '',
           'ANNOTATIONS',
           '! warning',
         }, '\n'),
@@ -710,11 +720,62 @@ describe('summary job mappings', function()
     assert.same({ 'log', '12345', 'false' }, opened[1].cmd)
     assert.same({ title = '12345' }, opened[1].opts)
 
-    vim.api.nvim_win_set_cursor(0, { 5, 0 })
+    vim.api.nvim_win_set_cursor(0, { 6, 0 })
     enter()
     vim.wait(20)
 
     assert.equals(1, #opened)
+  end)
+
+  it('browses the job URL on job lines and the run URL elsewhere', function()
+    local opened = {}
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = table.concat({
+          '✓ lint (ID 12345)',
+          '  ✓ Set up job',
+          '',
+          'ANNOTATIONS',
+          '! warning',
+        }, '\n'),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+    vim.ui.open = function(url)
+      opened[#opened + 1] = url
+      return true
+    end
+
+    log_mod.open_summary({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      run_id = '12345',
+      title = 'summary',
+      url = 'https://example.com/runs/12345',
+      browse_url_fn = function(job_id)
+        return 'https://example.com/runs/12345/job/' .. job_id
+      end,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == '✓ lint (ID 12345)'
+    end)
+
+    local browse = vim.fn.maparg('gx', 'n', false, true).callback
+
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    browse()
+
+    vim.api.nvim_win_set_cursor(0, { 5, 0 })
+    browse()
+
+    assert.same({
+      'https://example.com/runs/12345/job/12345',
+      'https://example.com/runs/12345',
+    }, opened)
   end)
 end)
 

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -206,6 +206,12 @@ describe('shared operations', function()
       view_cmd = function(_, run_id, opts)
         return { 'view', run_id, opts and opts.scope or 'none' }
       end,
+      run_web_url = function(_, run_id, scope)
+        return ('https://example.com/runs/%s/%s'):format(run_id, scope or 'none')
+      end,
+      job_web_url = function(_, run_id, job_id, scope)
+        return ('https://example.com/runs/%s/jobs/%s/%s'):format(run_id, job_id, scope or 'none')
+      end,
       summary_json_cmd = function(_, run_id, scope)
         return { 'summary', run_id, scope or 'none' }
       end,
@@ -222,27 +228,30 @@ describe('shared operations', function()
       id = '77',
       name = 'CI',
       status = 'running',
-      url = 'https://example.com/runs/77',
       scope = 'repo/ref',
     })
 
     assert.same({ 'view', '77', 'repo/ref' }, captured.summaries[1].cmd)
     local summary_opts = vim.deepcopy(captured.summaries[1].opts)
-    summary_opts.log_cmd_fn = nil
+    summary_opts.log_cmd_fn, summary_opts.browse_url_fn = nil, nil
     assert.same({
       forge_name = 'github',
       run_id = '77',
-      url = 'https://example.com/runs/77',
+      url = 'https://example.com/runs/77/repo/ref',
       title = 'CI',
       in_progress = true,
       status_cmd = { 'status', '77', 'repo/ref' },
     }, summary_opts)
+    assert.equals(
+      'https://example.com/runs/77/jobs/job-1/repo/ref',
+      captured.summaries[1].opts.browse_url_fn('job-1')
+    )
 
     local cmd, opts = captured.summaries[1].opts.log_cmd_fn('job-1', true)
     assert.same({ 'check-log', '77', 'true', 'job-1', 'repo/ref' }, cmd)
     assert.same({
       forge_name = 'github',
-      url = 'https://example.com/runs/77',
+      url = 'https://example.com/runs/77/repo/ref',
       title = 'CI / job-1',
       steps_cmd = { 'steps', '77', 'repo/ref' },
       job_id = 'job-1',
@@ -274,7 +283,7 @@ describe('shared operations', function()
 
     assert.same({ 'summary', '77', 'repo/ref' }, captured.summaries[1].cmd)
     local summary_opts = vim.deepcopy(captured.summaries[1].opts)
-    summary_opts.log_cmd_fn = nil
+    summary_opts.log_cmd_fn, summary_opts.browse_url_fn = nil, nil
     assert.same({
       forge_name = 'custom',
       run_id = '77',
@@ -299,6 +308,9 @@ describe('shared operations', function()
       run_status_cmd = function(_, run_id, scope)
         return { 'status', run_id, scope or 'none' }
       end,
+      run_web_url = function(_, run_id, scope)
+        return ('https://example.com/runs/%s/%s'):format(run_id, scope or 'none')
+      end,
       watch_cmd = function(_, run_id, scope)
         return { 'watch', run_id, scope or 'none' }
       end,
@@ -306,23 +318,24 @@ describe('shared operations', function()
       id = '88',
       name = 'Deploy',
       status = 'failed',
-      url = 'https://example.com/runs/88',
       scope = 'repo/ref',
     })
     local watched = ops.ci_watch({
+      run_web_url = function(_, run_id, scope)
+        return ('https://example.com/runs/%s/%s'):format(run_id, scope or 'none')
+      end,
       watch_cmd = function(_, run_id, scope)
         return { 'watch', run_id, scope or 'none' }
       end,
     }, {
       id = '88',
-      url = 'https://example.com/runs/88',
       scope = 'repo/ref',
     })
 
     assert.same({ 'run-log', '88', 'true', 'repo/ref' }, captured.logs[1].cmd)
     assert.same({
       forge_name = 'gitlab',
-      url = 'https://example.com/runs/88',
+      url = 'https://example.com/runs/88/repo/ref',
       title = 'Deploy',
       steps_cmd = { 'steps', '88', 'repo/ref' },
       in_progress = false,
@@ -330,6 +343,6 @@ describe('shared operations', function()
     }, captured.logs[1].opts)
     assert.is_true(watched)
     assert.same({ 'watch', '88', 'repo/ref' }, captured.terms[1].cmd)
-    assert.same({ url = 'https://example.com/runs/88' }, captured.terms[1].opts)
+    assert.same({ url = 'https://example.com/runs/88/repo/ref' }, captured.terms[1].opts)
   end)
 end)


### PR DESCRIPTION
## Problem
GitHub CI summary buffers still had two rough edges after the native run view work. Direct `:Forge ci log` and `:Forge ci watch` commands could open summaries without a run URL, which made `gx` a no-op. The summary browse action also treated the whole buffer as a single run-level target instead of letting job rows browse to their specific job pages. Separately, the whitespace cleanup pass was too aggressive; it should preserve internal blank separators and only trim boundary blank lines.

## Solution
Add backend run and job web URL helpers so direct CI commands always have a browse target, make summary-buffer browse behavior context-sensitive for GitHub job lines and job step lines, and narrow summary whitespace cleanup so only leading and trailing blank lines are trimmed.