### PR TITLE
fix(cmd): allow bar-chained Forge commands

### DIFF
--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -53,6 +53,7 @@ vim.api.nvim_create_user_command('Forge', function(opts)
   require('forge.cmd').run(opts)
 end, {
   bang = true,
+  bar = true,
   nargs = '*',
   range = true,
   complete = function(arglead, cmdline, cursorpos)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -407,6 +407,15 @@ describe(':Forge command', function()
     assert.is_nil(captured.ops_calls[1])
   end)
 
+  it('allows :Forge to be followed by a bar command', function()
+    vim.g.forge_bar_works = nil
+
+    vim.cmd('Forge clear | let g:forge_bar_works = 1')
+
+    assert.is_true(captured.cleared)
+    assert.equal(1, vim.g.forge_bar_works)
+  end)
+
   it('uses explicit browse defaults for omitted targets', function()
     vim.cmd('Forge browse')
 


### PR DESCRIPTION
## Problem

`:Forge ... | ...` was parsed as trailing characters because the user command did not opt into bar separators.

## Solution

Set `bar = true` on `:Forge` and add a command spec that verifies a chained `:Forge clear | ...` invocation works.