### PR TITLE
chore(spec): trigger a fresh CI run

### DIFF
--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -146,7 +146,7 @@ describe('command schema', function()
     assert.equals('owner/upstream', create.default_targets.base.repo.slug)
   end)
 
-  it('tracks the intended bang matrix', function()
+  it('tracks the supported bang matrix', function()
     assert.is_true(cmd.supports_bang('pr', 'close'))
     assert.is_true(cmd.supports_bang('issue', 'close'))
     assert.is_true(cmd.supports_bang('release', 'delete'))


### PR DESCRIPTION
## Problem

We need a fresh GitHub Actions run to compare Forge `ci log` and `ci watch` behavior against the same active run.

## Solution

Make a harmless spec-description wording tweak that triggers CI without changing behavior.