### PR TITLE
fix(ci): align GitHub run and watch interactions

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -140,7 +140,8 @@ Top-level keys: ~
     Maximum number of log lines fetched for CI/check log output.
 
   `ci.refresh`      `integer`  (default `5`)
-    Auto-refresh interval in seconds for in-progress CI views.
+    Auto-refresh interval in seconds for Forge-managed in-progress CI log
+    and summary views.
     Set to `0` to disable auto-refresh entirely.
 
   `ci.split`        `string?`  (default `nil`, inherits from `split`)
@@ -315,8 +316,9 @@ Top-level keys: ~
     `refresh`.
     `keys.commit` supports `browse`, `yank`, and `refresh`.
     `keys.worktree` supports `add`, `delete`, `yank`, and `refresh`.
-    `keys.log` supports `close`, step/error navigation, `browse`, and
-    `refresh` for CI log and summary buffers.
+    `keys.log` supports `close` and `browse` across CI terminal/log views,
+    plus step/error navigation and `refresh` for Forge-managed CI log and
+    summary buffers.
 
 `display`                                               *forge-config-display*
   Controls icons, column widths, and fetch limits used in picker
@@ -487,11 +489,14 @@ BANG SEMANTICS                                            *forge-command-bang*
     Open the issue edit compose flow for issue `{num}`.
 
 `:Forge ci log` {run-id} [repo=...]                            *:Forge-ci-log*
-    Open logs for CI run `{run-id}`.
+    Open the primary run view for CI run `{run-id}`. On GitHub this uses a
+    normal-mode terminal with contextual `gx` and `<cr>` on job/step lines.
 
 `:Forge ci watch` {run-id} [repo=...]                        *:Forge-ci-watch*
     Open the forge's live watch view for CI run `{run-id}` when
-    supported.
+    supported. On GitHub, `<cr>` on a job or step during an active watch
+    opens a refreshing per-job log because `gh` only supports live watch at
+    the run level.
 
 `:Forge release browse` {tag} [repo=...]               *:Forge-release-browse*
     Open release `{tag}` in the browser.
@@ -682,17 +687,26 @@ For repo-wide CI runs, Forge fetches an initial page using
 `Load more...` row on `<cr>`. The `all` view is shown newest-first, and
 loading more appends older runs below the current list.
 
-On GitHub, `<cr>` on a run opens a summary buffer showing all jobs with
-status, durations, and annotations. Press `<cr>` on a job line to open its
-full log. On GitLab and Codeberg, in-progress jobs open a live-tailing
-terminal (`glab ci trace`, `tea actions runs logs --follow`); completed jobs
-render in a buffer with highlighting and folds left open by default.
+On GitHub, `log` opens a normal-mode terminal using `gh run view`, and
+`watch` opens a normal-mode terminal using `gh run watch`. In either view,
+`gx` opens the run URL by default, the job URL on job lines, and the parent
+job URL on step lines. Press `<cr>` on a job or step line to open that job's
+log. During an active GitHub watch, Forge opens a refreshing per-job log
+buffer because GitHub does not expose a per-job live-watch surface.
 
-In-progress views auto-refresh at the `ci.refresh` interval.
+On GitLab and Codeberg, in-progress jobs open a live-tailing terminal
+(`glab ci trace`, `tea actions runs logs --follow`); completed jobs render
+in a buffer with highlighting and folds left open by default.
+
+Forge-managed in-progress log and summary buffers auto-refresh at the
+`ci.refresh` interval. GitHub run terminals rely on native `gh` rendering;
+per-job log buffers opened from active GitHub runs auto-refresh at the same
+interval.
 
   Action      Default Key    Description ~
-  `log`         `<cr>`           Summary (GitHub) or log buffer (others)
-  `watch`       `<c-w>`          Live-watch in terminal
+  `log`         `<cr>`           Run view terminal (GitHub) or log buffer
+                               (others)
+  `watch`       `<c-w>`          Run watch terminal
   `browse`      `<c-x>`          Open run/check URL in browser
   `filter`      `<tab>`          Cycle filter: all -> failed -> passed -> running
   `refresh`     `<c-r>`          Re-fetch runs

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -984,6 +984,32 @@ local function parse_summary(raw_lines)
   return { lines = lines, hls = hls, jobs = jobs, job_lnums = job_lnums }
 end
 
+local function summary_job_at_line(raw_lines, lnum)
+  local first, last = 1, #raw_lines
+
+  while first <= last do
+    local text = strip_ansi(raw_lines[first])
+    if not text:match('^%s*$') then
+      break
+    end
+    first = first + 1
+  end
+
+  while last >= first do
+    local text = strip_ansi(raw_lines[last])
+    if not text:match('^%s*$') then
+      break
+    end
+    last = last - 1
+  end
+
+  if lnum < first or lnum > last then
+    return nil
+  end
+
+  return parse_summary(raw_lines).jobs[lnum - first + 1]
+end
+
 local function summary_hls(prefix, status)
   return { { col = 0, end_col = #prefix, group = summary_status_group(status) } }
 end
@@ -1222,6 +1248,7 @@ M._strip_ansi = strip_ansi
 M._parse_github = parse_github
 M._parse_gitlab = parse_gitlab
 M._parse_summary = parse_summary
+M._summary_job_at_line = summary_job_at_line
 M._parse_summary_json = parse_summary_json
 
 return M

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -71,11 +71,13 @@ end
 
 local function summary_job_at_cursor(buf)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-  local parsed = require('forge.log')._parse_summary(lines)
-  return parsed.jobs[vim.api.nvim_win_get_cursor(0)[1]]
+  return require('forge.log')._summary_job_at_line(lines, vim.api.nvim_win_get_cursor(0)[1])
 end
 
-local function github_ci_log_term(f, run, run_ref, url, in_progress, status_cmd)
+local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd, opts)
+  opts = opts or {}
+  local warned_job_watch = false
+
   local function job_log(job_id, failed)
     return f:check_log_cmd(run.id, failed, job_id, run_ref),
       {
@@ -89,7 +91,7 @@ local function github_ci_log_term(f, run, run_ref, url, in_progress, status_cmd)
       }
   end
 
-  require('forge.term').open(f:view_cmd(run.id, { scope = run_ref }), {
+  require('forge.term').open(cmd, {
     url = url,
     startinsert = false,
     browse_fn = function(buf)
@@ -104,8 +106,12 @@ local function github_ci_log_term(f, run, run_ref, url, in_progress, status_cmd)
       if not job then
         return
       end
-      local cmd, opts = job_log(job.id, job.failed)
-      require('forge.log').open(cmd, opts)
+      if opts.watch and in_progress and not warned_job_watch then
+        warned_job_watch = true
+        log.info('GitHub does not support per-job live watch; opening a refreshing job log instead')
+      end
+      local log_cmd, log_opts = job_log(job.id, job.failed)
+      require('forge.log').open(log_cmd, log_opts)
     end,
   })
 end
@@ -331,7 +337,15 @@ function M.ci_log(f, run)
   url = url ~= '' and url or nil
   local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id, run_ref) or nil
   if f.name == 'github' and f.view_cmd then
-    github_ci_log_term(f, run, run_ref, url, in_progress, status_cmd)
+    github_ci_term(
+      f,
+      f:view_cmd(run.id, { scope = run_ref }),
+      run,
+      run_ref,
+      url,
+      in_progress,
+      status_cmd
+    )
     return
   end
   if f.view_cmd then
@@ -412,12 +426,26 @@ function M.ci_watch(f, run)
   if not f.watch_cmd then
     return false
   end
+  local run_ref = run.scope
+  local status = trim(run.status):lower()
+  local in_progress = status == 'in_progress'
+    or status == 'queued'
+    or status == 'pending'
+    or status == 'running'
   local url = trim(run.url)
   if url == '' and f.run_web_url then
-    url = trim(f:run_web_url(run.id, run.scope) or '')
+    url = trim(f:run_web_url(run.id, run_ref) or '')
   end
-  require('forge.term').open(f:watch_cmd(run.id, run.scope), {
-    url = url ~= '' and url or nil,
+  url = url ~= '' and url or nil
+  local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id, run_ref) or nil
+  if f.name == 'github' then
+    github_ci_term(f, f:watch_cmd(run.id, run_ref), run, run_ref, url, in_progress, status_cmd, {
+      watch = true,
+    })
+    return true
+  end
+  require('forge.term').open(f:watch_cmd(run.id, run_ref), {
+    url = url,
   })
   return true
 end

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -5,6 +5,7 @@ local strip_ansi = log_mod._strip_ansi
 local parse_github = log_mod._parse_github
 local parse_gitlab = log_mod._parse_gitlab
 local parse_summary = log_mod._parse_summary
+local summary_job_at_line = log_mod._summary_job_at_line
 local parse_summary_json = log_mod._parse_summary_json
 
 describe('strip_ansi', function()
@@ -400,6 +401,30 @@ describe('parse_summary', function()
     assert.is_nil(result.jobs[6])
     assert.is_nil(result.jobs[7])
     assert.equals(1, #result.job_lnums)
+  end)
+
+  it('maps raw line numbers to jobs when boundary blank lines are trimmed', function()
+    local lines = {
+      '',
+      '  ',
+      'JOBS',
+      '✓ lint (ID 12345)',
+      '  * Run stylua',
+      '',
+      'ANNOTATIONS',
+      '! warning',
+      '',
+    }
+
+    assert.is_nil(summary_job_at_line(lines, 1))
+    assert.is_nil(summary_job_at_line(lines, 2))
+    assert.is_nil(summary_job_at_line(lines, 3))
+    assert.same({ id = '12345', failed = false }, summary_job_at_line(lines, 4))
+    assert.same({ id = '12345', failed = false }, summary_job_at_line(lines, 5))
+    assert.is_nil(summary_job_at_line(lines, 6))
+    assert.is_nil(summary_job_at_line(lines, 7))
+    assert.is_nil(summary_job_at_line(lines, 8))
+    assert.is_nil(summary_job_at_line(lines, 9))
   end)
 end)
 

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -69,16 +69,23 @@ describe('shared operations', function()
         info = function(msg)
           captured.infos[#captured.infos + 1] = msg
         end,
+        warn = function(msg)
+          captured.infos[#captured.infos + 1] = msg
+        end,
         error = function(msg)
           captured.errors[#captured.errors + 1] = msg
         end,
         debug = function() end,
-        warn = function() end,
       }
     end
 
     package.preload['forge.log'] = function()
       return {
+        _summary_job_at_line = function(_, lnum)
+          if lnum == 2 then
+            return { id = '22', failed = true }
+          end
+        end,
         open_summary = function(cmd, opts)
           table.insert(captured.summaries, { cmd = cmd, opts = opts })
         end,
@@ -238,6 +245,67 @@ describe('shared operations', function()
       url = 'https://example.com/runs/77/repo/ref',
       startinsert = false,
     }, term_opts)
+  end)
+
+  it('gives GitHub CI watch the same contextual terminal actions', function()
+    local ops = require('forge.ops')
+    ops.ci_watch({
+      name = 'github',
+      watch_cmd = function(_, run_id, scope)
+        return { 'watch', run_id, scope or 'none' }
+      end,
+      check_log_cmd = function(_, run_id, failed, job_id, scope)
+        return { 'check-log', run_id, tostring(failed), job_id or '', scope or 'none' }
+      end,
+      run_status_cmd = function(_, run_id, scope)
+        return { 'status', run_id, scope or 'none' }
+      end,
+      run_web_url = function(_, run_id, scope)
+        return ('https://example.com/runs/%s/%s'):format(run_id, scope or 'none')
+      end,
+      job_web_url = function(_, run_id, job_id, scope)
+        return ('https://example.com/runs/%s/jobs/%s/%s'):format(run_id, job_id, scope or 'none')
+      end,
+      steps_cmd = function(_, run_id, scope)
+        return { 'steps', run_id, scope or 'none' }
+      end,
+    }, {
+      id = '88',
+      name = 'Deploy',
+      status = 'running',
+      scope = 'repo/ref',
+    })
+
+    assert.same({ 'watch', '88', 'repo/ref' }, captured.terms[1].cmd)
+
+    local buf = vim.api.nvim_create_buf(false, true)
+    vim.api.nvim_set_current_buf(buf)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, { '', '  * Run busted' })
+    vim.api.nvim_win_set_cursor(0, { 2, 0 })
+
+    local browse_url = captured.terms[1].opts.browse_fn(buf)
+    captured.terms[1].opts.enter_fn(buf)
+
+    local term_opts = vim.deepcopy(captured.terms[1].opts)
+    term_opts.browse_fn, term_opts.enter_fn = nil, nil
+    assert.same({
+      url = 'https://example.com/runs/88/repo/ref',
+      startinsert = false,
+    }, term_opts)
+    assert.equals('https://example.com/runs/88/jobs/22/repo/ref', browse_url)
+    assert.same({ 'check-log', '88', 'true', '22', 'repo/ref' }, captured.logs[1].cmd)
+    assert.same({
+      forge_name = 'github',
+      url = 'https://example.com/runs/88/repo/ref',
+      title = 'Deploy / 22',
+      steps_cmd = { 'steps', '88', 'repo/ref' },
+      job_id = '22',
+      in_progress = true,
+      status_cmd = { 'status', '88', 'repo/ref' },
+    }, captured.logs[1].opts)
+    assert.same({
+      'GitHub does not support per-job live watch; opening a refreshing job log instead',
+    }, captured.infos)
   end)
 
   it('falls back to JSON CI summaries when no run view is available', function()


### PR DESCRIPTION
## Problem

GitHub terminal run views did not consistently map the cursor to the right job, and `ci watch` lacked the same contextual `gx` and `<cr>` job interactions as `ci log`. The vimdoc was also still describing the older GitHub summary-buffer behavior.

## Solution

Fix raw-line job lookup for GitHub terminal run views, reuse the same contextual job actions for `ci watch`, fall back to a refreshing per-job log when an active GitHub watch cannot live-tail a single job, and update the vimdoc to match the current terminal-based behavior.