### PR TITLE
fix(ci): reuse job log views in place

### DIFF
--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -726,6 +726,7 @@ end
 ---@field title string?
 ---@field steps_cmd string[]?
 ---@field job_id string?
+---@field replace_win integer?
 ---@field in_progress boolean?
 ---@field status_cmd string[]?
 
@@ -803,8 +804,18 @@ function M.open(cmd, opts, reuse_buf)
       saved_cursor = vim.api.nvim_win_get_cursor(wins[1])
     end
   else
-    vim.cmd('noautocmd botright new')
-    buf = vim.api.nvim_get_current_buf()
+    local replace_win = opts.replace_win
+    if replace_win and vim.api.nvim_win_is_valid(replace_win) then
+      local old_buf = vim.api.nvim_win_get_buf(replace_win)
+      buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_win_set_buf(replace_win, buf)
+      if vim.api.nvim_buf_is_valid(old_buf) and old_buf ~= buf then
+        vim.api.nvim_buf_delete(old_buf, { force = true })
+      end
+    else
+      vim.cmd('noautocmd botright new')
+      buf = vim.api.nvim_get_current_buf()
+    end
     vim.bo[buf].buftype = 'nofile'
     vim.bo[buf].bufhidden = 'wipe'
     vim.bo[buf].swapfile = false
@@ -1208,6 +1219,9 @@ function M.open_summary(cmd, opts, reuse_buf)
             local job = d.jobs[lnum]
             if job and opts.log_cmd_fn then
               local log_cmd, log_opts = opts.log_cmd_fn(job.id, job.failed)
+              log_opts = vim.tbl_extend('force', log_opts, {
+                replace_win = vim.api.nvim_get_current_win(),
+              })
               M.open(log_cmd, log_opts)
             end
           end, { buffer = buf, desc = 'Open job log' })

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -79,10 +79,14 @@ local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd
   local warned_job_watch = false
 
   local function job_log(job_id, failed)
+    local job_url = url
+    if f.job_web_url then
+      job_url = f:job_web_url(run.id, job_id, run_ref) or job_url
+    end
     return f:check_log_cmd(run.id, failed, job_id, run_ref),
       {
         forge_name = f.name,
-        url = url,
+        url = job_url,
         title = (run.name or run.id) .. ' / ' .. (job_id or ''),
         steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
         job_id = job_id,
@@ -111,6 +115,9 @@ local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd
         log.info('GitHub does not support per-job live watch; opening a refreshing job log instead')
       end
       local log_cmd, log_opts = job_log(job.id, job.failed)
+      log_opts = vim.tbl_extend('force', log_opts, {
+        replace_win = vim.api.nvim_get_current_win(),
+      })
       require('forge.log').open(log_cmd, log_opts)
     end,
   })
@@ -363,10 +370,14 @@ function M.ci_log(f, run)
         return nil
       end,
       log_cmd_fn = function(job_id, failed)
+        local job_url = url
+        if f.job_web_url then
+          job_url = f:job_web_url(run.id, job_id, run_ref) or job_url
+        end
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
             forge_name = f.name,
-            url = url,
+            url = job_url,
             title = (run.name or run.id) .. ' / ' .. (job_id or ''),
             steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
             job_id = job_id,
@@ -393,10 +404,14 @@ function M.ci_log(f, run)
         return nil
       end,
       log_cmd_fn = function(job_id, failed)
+        local job_url = url
+        if f.job_web_url then
+          job_url = f:job_web_url(run.id, job_id, run_ref) or job_url
+        end
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
             forge_name = f.name,
-            url = url,
+            url = job_url,
             title = (run.name or run.id) .. ' / ' .. (job_id or ''),
             steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
             job_id = job_id,

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -735,6 +735,7 @@ describe('summary job mappings', function()
     end)
 
     local enter = vim.fn.maparg('<cr>', 'n', false, true).callback
+    local win = vim.api.nvim_get_current_win()
 
     vim.api.nvim_win_set_cursor(0, { 2, 0 })
     enter()
@@ -743,7 +744,7 @@ describe('summary job mappings', function()
     end)
 
     assert.same({ 'log', '12345', 'false' }, opened[1].cmd)
-    assert.same({ title = '12345' }, opened[1].opts)
+    assert.same({ title = '12345', replace_win = win }, opened[1].opts)
 
     vim.api.nvim_win_set_cursor(0, { 6, 0 })
     enter()
@@ -801,6 +802,39 @@ describe('summary job mappings', function()
       'https://example.com/runs/12345/job/12345',
       'https://example.com/runs/12345',
     }, opened)
+  end)
+
+  it('browses the configured URL in a job log buffer', function()
+    local opened = {}
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = 'build\tstep\t2024-01-01T00:00:00Z hello',
+      })
+      return {
+        kill = function() end,
+      }
+    end
+    vim.ui.open = function(url)
+      opened[#opened + 1] = url
+      return true
+    end
+
+    log_mod.open({ 'gh', 'run', 'view', '--log', '--job', '12345' }, {
+      forge_name = 'github',
+      title = 'job',
+      url = 'https://example.com/runs/77/job/12345',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'build'
+    end)
+
+    local browse = vim.fn.maparg('gx', 'n', false, true).callback
+    browse()
+
+    assert.same({ 'https://example.com/runs/77/job/12345' }, opened)
   end)
 end)
 

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -282,6 +282,7 @@ describe('shared operations', function()
     vim.api.nvim_set_current_buf(buf)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, { '', '  * Run busted' })
     vim.api.nvim_win_set_cursor(0, { 2, 0 })
+    local win = vim.api.nvim_get_current_win()
 
     local browse_url = captured.terms[1].opts.browse_fn(buf)
     captured.terms[1].opts.enter_fn(buf)
@@ -296,10 +297,11 @@ describe('shared operations', function()
     assert.same({ 'check-log', '88', 'true', '22', 'repo/ref' }, captured.logs[1].cmd)
     assert.same({
       forge_name = 'github',
-      url = 'https://example.com/runs/88/repo/ref',
+      url = 'https://example.com/runs/88/jobs/22/repo/ref',
       title = 'Deploy / 22',
       steps_cmd = { 'steps', '88', 'repo/ref' },
       job_id = '22',
+      replace_win = win,
       in_progress = true,
       status_cmd = { 'status', '88', 'repo/ref' },
     }, captured.logs[1].opts)


### PR DESCRIPTION
## Problem

Drilling into a CI job from a run view opened a new split and left the nested job log buffer browsing the parent run URL instead of the job URL.

## Solution

Reuse the current window when opening nested CI job logs and carry the job-specific URL into those job log buffers so Enter and `gx` stay contextual as you move deeper into a run.