### PR TITLE
docs(api): document forge.ops verbs and custom picker recipes

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -53,6 +53,7 @@ CONTENTS                                                 *forge.nvim-contents*
     HIGHLIGHTS..............................................|forge-highlights|
     SOURCES....................................................|forge-sources|
     HEALTH......................................................|forge-health|
+    EXTENDING................................................|forge-extending|
     API............................................................|forge-api|
 
 ==============================================================================
@@ -1151,6 +1152,154 @@ Reports on: ~
 - Custom registered sources and their CLI availability
 
 ==============================================================================
+EXTENDING                                                    *forge-extending*
+
+forge.nvim is designed to be used as a library as well as a plugin. You can
+call any of its forge-aware actions from your own picker, keymap, or command
+without replacing or configuring the built-in root surface. The public Lua
+surfaces exist at three layers; pick the one that matches how much control
+you want.
+
+MENTAL MODEL                                           *forge-extending-model*
+
+  Layer             Entry point                              When to use ~
+  Route             `require('forge').open(route)`             You want the
+                                                             built-in picker
+                                                             UI for a
+                                                             section (PRs,
+                                                             issues, CI,
+                                                             releases,
+                                                             browse).
+  Verb              `require('forge.ops').<action>(...)`       You already
+                                                             know the target
+                                                             (PR number,
+                                                             issue number,
+                                                             run id,
+                                                             commit) and
+                                                             want to skip
+                                                             the picker.
+  Picker primitive  `require('forge.picker').pick(opts)`       You are
+                                                             building a
+                                                             custom picker
+                                                             from scratch
+                                                             and want forge
+                                                             to render it
+                                                             with the
+                                                             configured
+                                                             backend.
+
+Routes are the highest-level and most stable surface; they hide context
+resolution, scope detection, and forge dispatch behind a single string. Verbs
+are the layer `:Forge` and the built-in pickers both call into, so binding a
+verb to your own keymap or picker row gets exactly the behavior a `:Forge`
+invocation would. The picker primitive is the same call the built-in
+pickers use; it is backend-agnostic and forwards to the adapter configured
+under |forge-config-picker|.
+
+CALLING FORGE FROM YOUR OWN PICKER            *forge-extending-custom-picker*
+
+The simplest pattern is to build a master picker in your own config (using
+`fzf-lua`, snacks.nvim, or any backend), list the forge sections you care
+about, and bind each row to `require('forge').open()`. Forge-specific rows
+inherit all built-in actions (checkout, worktree, browse, merge, approve,
+etc.). Non-forge rows can call into whatever you already use for local git. >lua
+    local forge = require('forge')
+    local fzf = require('fzf-lua')
+
+    local dispatch = {
+      ['Open PRs']           = function() forge.open('prs.open') end,
+      ['Open Issues']        = function() forge.open('issues.open') end,
+      ['Current branch CI']  = function() forge.open('ci.current_branch') end,
+      ['Browse branch']      = function() forge.open('browse.branch') end,
+      ['Browse commit']      = function() forge.open('browse.commit') end,
+      ['Releases']           = function() forge.open('releases.all') end,
+      ['Local branches']     = fzf.git_branches,
+      ['Commits']            = fzf.git_commits,
+      ['Worktrees']          = function() vim.cmd('Neogit') end,
+    }
+
+    local rows = vim.tbl_keys(dispatch)
+    table.sort(rows)
+
+    vim.keymap.set('n', '<leader>g', function()
+      fzf.fzf_exec(rows, {
+        prompt = 'Git> ',
+        actions = {
+          default = function(selected)
+            local row = dispatch[selected[1]]
+            if row then row() end
+          end,
+        },
+      })
+    end)
+<
+
+CALLING VERBS DIRECTLY                                *forge-extending-verbs*
+
+When you already have a PR number, issue number, run id, or commit in hand
+and do not need a picker, call `require('forge.ops')` directly. This is the
+layer `:Forge pr checkout 42` and the PR picker's `<cr>` both dispatch to. >lua
+    local forge = require('forge')
+    local ops = require('forge.ops')
+    local f = assert(forge.detect(), 'no forge detected')
+
+    ops.pr_browse(f, { num = '42' })
+    ops.pr_checkout(f, { num = '42' })
+    ops.pr_worktree(f, { num = '42' })
+    ops.ci_log(f, { id = '987654321' })
+    ops.browse_commit({ commit = 'abc1234' })
+    ops.browse_branch('main')
+<
+
+See |forge-ops| for the full verb inventory.
+
+BUILDING A CUSTOM PICKER FROM SCRATCH                *forge-extending-picker*
+
+If you want forge to render your picker with the same backend it uses for
+its own (so you inherit picker-level styling, highlight groups, and the
+configured fzf-lua adapter), call `require('forge.picker').pick()` directly.
+Entries and actions follow the shapes documented under |forge-picker-api|. >lua
+    local picker = require('forge.picker')
+    local forge = require('forge')
+
+    picker.pick({
+      prompt = 'My workflow> ',
+      picker_name = 'custom',
+      entries = {
+        {
+          display = { { 'Open PRs', 'ForgeOpen' } },
+          value = 'prs.open',
+        },
+        {
+          display = { { 'Browse current commit', 'ForgeBranch' } },
+          value = 'browse.commit',
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(entry)
+            if entry then forge.open(entry.value) end
+          end,
+        },
+      },
+    })
+<
+
+STABILITY NOTES                                    *forge-extending-stability*
+
+- `require('forge').open()` and the route names are the most stable surface.
+  Route names are validated by the config layer and intentionally kept
+  forward-compatible.
+- `require('forge.ops')` verbs are stable in shape (signatures take either a
+  numeric/string id or a normalized ref table with `num`/`id`/`tag`/`scope`)
+  but may gain optional parameters over time.
+- `require('forge.picker').pick()` opts (|forge-picker-api|) are stable.
+- `require('forge.pickers')` internals other than the entry points listed in
+  |forge-api| are implementation details; treat the rest as private.
+
+==============================================================================
 API                                                                *forge-api*
 
 PUBLIC API: `require('forge')` ~
@@ -1391,6 +1540,183 @@ PUBLIC API: `require('forge.pickers')` ~
                                                 *forge.pickers.issue_reopen()*
 `issue_reopen(f, num)`
     Reopens issue `num`.
+
+PUBLIC API: `require('forge.ops')` ~                               *forge-ops*
+
+The `ops` module is the verb layer. Each function is the same entry point
+`:Forge` and the built-in pickers dispatch to, so calling `ops.pr_browse(f,
+{ num = '42' })` from your config is identical to running `:Forge pr browse
+42` or pressing `browse` in the PR picker. Functions that take a ref accept
+either a bare id (`num`, `id`, or `tag`) or a normalized table with `scope`
+and `num`/`id`/`tag`.
+
+                                                          *forge.ops.pr_list()*
+`pr_list(state?, opts?)`
+    Opens the PR list picker. `state`: `"open"`, `"closed"`, or `"all"`.
+
+                                                        *forge.ops.pr_create()*
+`pr_create(opts?)`
+    Creates a PR. See |forge.create_pr()| for `opts` shape.
+
+                                                          *forge.ops.pr_edit()*
+`pr_edit(pr)`
+    Opens the PR edit compose buffer for `pr`.
+
+                                                      *forge.ops.pr_checkout()*
+`pr_checkout(f, pr)`
+    Checks out the branch for `pr` via the forge CLI.
+
+                                                        *forge.ops.pr_browse()*
+`pr_browse(f, pr)`
+    Opens `pr` in the browser.
+
+                                                      *forge.ops.pr_worktree()*
+`pr_worktree(f, pr)`
+    Fetches `pr` and creates a git worktree for it.
+
+                                                            *forge.ops.pr_ci()*
+`pr_ci(f, pr, opts?)`
+    Opens the CI checks picker for `pr`.
+
+                                                         *forge.ops.pr_close()*
+`pr_close(f, pr, opts?)`
+    Closes `pr`. `opts`: `{ on_success?, on_failure? }`.
+
+                                                        *forge.ops.pr_reopen()*
+`pr_reopen(f, pr, opts?)`
+    Reopens `pr`. `opts`: `{ on_success?, on_failure? }`.
+
+                                                       *forge.ops.pr_approve()*
+`pr_approve(f, pr, opts?)`
+    Approves `pr`. `opts`: `{ on_success?, on_failure? }`.
+
+                                                         *forge.ops.pr_merge()*
+`pr_merge(f, pr, method?, opts?)`
+    Merges `pr`. `method`: `"merge"`, `"squash"`, or `"rebase"`. `opts`:
+    `{ on_success?, on_failure? }`.
+
+                                                  *forge.ops.pr_toggle_draft()*
+`pr_toggle_draft(f, pr, is_draft, opts?)`
+    Toggles draft/ready on `pr`. Pass the current `is_draft` state.
+
+                                                       *forge.ops.issue_list()*
+`issue_list(state?, opts?)`
+    Opens the issue list picker. `state`: `"open"`, `"closed"`, or `"all"`.
+
+                                                     *forge.ops.issue_create()*
+`issue_create(opts?)`
+    Creates an issue. See |forge.create_issue()| for `opts` shape.
+
+                                                       *forge.ops.issue_edit()*
+`issue_edit(issue)`
+    Opens the issue edit compose buffer for `issue`.
+
+                                                     *forge.ops.issue_browse()*
+`issue_browse(f, issue)`
+    Opens `issue` in the browser.
+
+                                                      *forge.ops.issue_close()*
+`issue_close(f, issue, opts?)`
+    Closes `issue`. `opts`: `{ on_success?, on_failure? }`.
+
+                                                     *forge.ops.issue_reopen()*
+`issue_reopen(f, issue, opts?)`
+    Reopens `issue`. `opts`: `{ on_success?, on_failure? }`.
+
+                                                          *forge.ops.ci_list()*
+`ci_list(branch?, opts?)`
+    Opens the CI runs picker. `nil` branch shows all runs.
+
+                                                           *forge.ops.ci_log()*
+`ci_log(f, run)`
+    Opens the log view for run `run` (terminal on GitHub, log buffer on
+    GitLab/Codeberg).
+
+                                                         *forge.ops.ci_watch()*
+`ci_watch(f, run)`
+    Opens a watch terminal for an in-progress run.
+
+                                                     *forge.ops.release_list()*
+`release_list(state?, opts?)`
+    Opens the release list picker. `state`: `"all"`, `"draft"`, or
+    `"prerelease"`.
+
+                                                   *forge.ops.release_browse()*
+`release_browse(f, release)`
+    Opens `release` in the browser.
+
+                                                   *forge.ops.release_delete()*
+`release_delete(f, release, opts?)`
+    Deletes `release`. `opts`: `{ confirm?, on_success?, on_failure? }`.
+
+                                                    *forge.ops.browse_commit()*
+`browse_commit(opts?)`
+    Opens a commit on the forge. `opts`: `{ commit?, scope? }`. Defaults
+    `commit` to current HEAD.
+
+                                                    *forge.ops.browse_branch()*
+`browse_branch(branch?, opts?)`
+    Opens a branch on the forge. Defaults `branch` to the current branch.
+
+                                                *forge.ops.browse_contextual()*
+`browse_contextual(opts?)`
+    Opens the current file/line permalink on the forge, falling back to the
+    repo root in non-file buffers.
+
+                                                      *forge.ops.browse_repo()*
+`browse_repo(opts?)`
+    Opens the repo root on the forge.
+
+                                                      *forge.ops.browse_file()*
+`browse_file(f, file_loc, branch, scope?)`
+    Opens `file_loc` on `branch`. Returns `true` on success, `false` if
+    `file_loc` or `branch` is empty.
+
+                                                  *forge.ops.browse_location()*
+`browse_location(f, location, scope?)`
+    Opens a parsed location (from `target.parse_location`).
+
+PUBLIC API: `require('forge.picker')` ~                     *forge-picker-api*
+
+The picker primitive. Forwards to the adapter configured under
+|forge-config-picker| (currently only `fzf-lua`).
+
+                                                           *forge.picker.pick()*
+`pick(opts)`
+    Opens a picker with the given `opts`:
+      `prompt`       `string?`                Prompt line.
+      `picker_name`  `string`                 Identifier used to look up
+                                              `vim.g.forge.keys.<picker_name>`
+                                              and contextual search keys.
+      `entries`      `forge.PickerEntry[]`    See below.
+      `actions`      `forge.PickerActionDef[]` See below.
+      `back`         `fun()?`                 Optional callback invoked when
+                                              the back key (`keys.back`) is
+                                              pressed on a nested picker.
+      `entry_source` `fun(): entries?`        Optional entry refresh
+                                              callback. Enables live width
+                                              and re-entry.
+
+    `forge.PickerEntry` shape:
+      `display`        `forge.Segment[]`      Rendered row, segmented into
+                                              `{ text, hl? }` pairs.
+      `value`          `any`                  User-defined value passed to
+                                              the action function.
+      `ordinal`        `string?`              Override sort/search key.
+      `render_display` `fun(width): forge.Segment[]?`  Optional width-aware
+                                              renderer.
+
+    `forge.PickerActionDef` shape:
+      `name`   `string`               Action name (`"default"` runs on `<cr>`).
+      `label`  `string?`              Header hint label.
+      `close`  `boolean?`             If `false`, the picker stays open.
+      `fn`     `fun(entry: forge.PickerEntry?)`   Action handler.
+
+                                                        *forge.picker.backend()*
+`backend()`
+    Returns the name of the active picker backend (e.g. `"fzf-lua"`).
+
+See |forge-extending| for composition recipes that combine these layers.
 
 ==============================================================================
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
## Problem

forge.nvim is genuinely useful as a library — users can wire their own master git picker that combines forge's PR/issue/CI surfaces with whatever they use for local git (fzf-lua, neogit, etc.). But the mechanism was undocumented: `require('forge.ops')` has 30 verbs with zero help coverage, `require('forge.picker').pick()` had no documented opts shape, and there was no narrative pointing users at the three-layer composition model (routes / ops / picker primitive).

## Solution

- Add a new `EXTENDING` section (`*forge-extending*`) between `HEALTH` and `API` that introduces the three-layer mental model and includes three concrete recipes:
  - a master-picker pattern that mixes `forge.open()` rows with fzf-lua's `git_branches` / `git_commits` and a Neogit row for worktrees
  - direct verb invocations via `require('forge.ops')` for when you already have a PR number / run id / commit
  - calling `require('forge.picker').pick()` directly to get forge's styling and configured backend
- Document every public verb in `require('forge.ops')` under a new `PUBLIC API: require('forge.ops')` subsection (`*forge-ops*`) covering pr_*, issue_*, ci_*, release_*, and browse_* families
- Document `require('forge.picker').pick()` opts, `forge.PickerEntry`, and `forge.PickerActionDef` shapes under `*forge-picker-api*` so downstream picker authors have a stable reference
- Add stability notes distinguishing what's guaranteed (routes, `forge.open`, `pick()` opts) from what's implementation detail (`forge.pickers` internals beyond the listed entry points)

Pure docs; no Lua changes. `scripts/ci.sh` green (vimdoc-language-server 0 diagnostics, lua-language-server clean, prettier clean, busted 443/0).