### PR TITLE
refactor!: unify forge:// bufnames to host/slug/resource scheme

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -754,7 +754,7 @@ modified-buffer protection. Use `:q!`, `:bd!`, or `:bwipeout!` to discard the
 buffer.
 
 Creating a PR (without `--fill` or `--web`) opens a compose buffer at
-`forge://pr/new` with filetype `markdown` and buftype `acwrite`.
+`forge://{host}/{slug}/pr/new` with filetype `markdown` and buftype `acwrite`.
 
 Layout: ~
   Line 1      PR title (pre-filled from single commit subject or branch)
@@ -768,7 +768,8 @@ the title or body is empty. The PR URL is copied to the `+` register on
 success.
 
 Creating an issue (without `--web`) opens a compose buffer at
-`forge://issue/new` with filetype `markdown` and buftype `acwrite`.
+`forge://{host}/{slug}/issue/new` with filetype `markdown` and buftype
+`acwrite`.
 
 Layout: ~
   Line 1      Issue title
@@ -780,9 +781,10 @@ Layout: ~
 Writing (`:w`) creates the issue. Creation is aborted if the title is empty.
 The issue URL is copied to the `+` register on success.
 
-Editing an issue opens a compose buffer at `forge://issue/{num}/edit` with
-the same title/body layout as issue creation. Writing (`:w`) updates the
-issue. Editing is aborted if the title is empty. Empty bodies are allowed.
+Editing an issue opens a compose buffer at
+`forge://{host}/{slug}/issue/{num}/edit` with the same title/body layout as
+issue creation. Writing (`:w`) updates the issue. Editing is aborted if the
+title is empty. Empty bodies are allowed.
 
 Integration: ~                                                 *forge-compose-integration*
   Compose buffers expose a small public buffer-local table for completion

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -6,6 +6,21 @@ local template = require('forge.template')
 
 local compose_ns = vim.api.nvim_create_namespace('forge_compose')
 
+---@param ref? forge.Scope
+---@param forge_name string
+---@return string?
+local function resolve_bufpath(ref, forge_name)
+  local path = scope.bufpath(ref)
+  if path then
+    return path
+  end
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.current_scope) ~= 'function' then
+    return nil
+  end
+  return scope.bufpath(forge.current_scope(forge_name))
+end
+
 ---@class forge.ComposeBuilder
 ---@field lines string[]
 ---@field marks {line: integer, col: integer, end_col: integer, hl: string}[]
@@ -424,7 +439,12 @@ end
 ---@param result forge.TemplateResult?
 ---@param ref? forge.Scope
 function M.open_issue(f, result, ref)
-  local buf = create_compose_buf('forge://issue/new')
+  local prefix = resolve_bufpath(ref, f.name)
+  if not prefix then
+    require('forge.logger').warn('cannot open compose buffer: no repo scope available')
+    return
+  end
+  local buf = create_compose_buf(('forge://%s/issue/new'):format(prefix))
   vim.b[buf].forge_scope = ref
   set_public_buffer_state(buf, f.name, 'issue', ref)
 
@@ -500,7 +520,12 @@ function M.open_issue(f, result, ref)
 end
 
 function M.open_issue_edit(f, num, details, ref)
-  local buf = create_compose_buf(('forge://issue/%s/edit'):format(num))
+  local prefix = resolve_bufpath(ref, f.name)
+  if not prefix then
+    require('forge.logger').warn('cannot open compose buffer: no repo scope available')
+    return
+  end
+  local buf = create_compose_buf(('forge://%s/issue/%s/edit'):format(prefix, num))
   vim.b[buf].forge_scope = ref
   set_public_buffer_state(buf, f.name, 'issue', ref)
 
@@ -572,6 +597,11 @@ end
 ---@param base_ref string?
 ---@param head_ref string?
 function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, head_ref)
+  local bufpath = resolve_bufpath(ref, f.name)
+  if not bufpath then
+    require('forge.logger').warn('cannot open compose buffer: no repo scope available')
+    return
+  end
   base_ref = base_ref or ('origin/' .. base)
   head_ref = head_ref or 'HEAD'
   local title, commit_body = template.fill_from_commits(branch, base_ref, head_ref)
@@ -584,7 +614,7 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
     reviewers = {},
   }
 
-  local buf = create_compose_buf('forge://pr/new')
+  local buf = create_compose_buf(('forge://%s/pr/new'):format(bufpath))
   vim.b[buf].forge_scope = ref
   set_public_buffer_state(buf, f.name, 'pr', ref)
 
@@ -768,7 +798,12 @@ end
 ---@param current_branch string
 ---@param ref? forge.Scope
 function M.open_pr_edit(f, num, details, current_branch, ref)
-  local buf = create_compose_buf(('forge://pr/%s/edit'):format(num))
+  local prefix = resolve_bufpath(ref, f.name)
+  if not prefix then
+    require('forge.logger').warn('cannot open compose buffer: no repo scope available')
+    return
+  end
+  local buf = create_compose_buf(('forge://%s/pr/%s/edit'):format(prefix, num))
   vim.b[buf].forge_scope = ref
   set_public_buffer_state(buf, f.name, 'pr', ref)
 

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -1,7 +1,44 @@
 local M = {}
 
+local scope_mod = require('forge.scope')
 local ns = vim.api.nvim_create_namespace('forge_log')
 local buf_data = {}
+
+---@param opts forge.LogOpts
+---@return string?
+local function log_bufname(opts)
+  local prefix = scope_mod.bufpath(opts.scope)
+  if not prefix or not opts.run_id or opts.run_id == '' then
+    return nil
+  end
+  if opts.job_id and opts.job_id ~= '' then
+    return ('forge://%s/ci/%s/job/%s'):format(prefix, opts.run_id, opts.job_id)
+  end
+  return ('forge://%s/ci/%s/log'):format(prefix, opts.run_id)
+end
+
+---@param opts forge.SummaryOpts
+---@return string?
+local function summary_bufname(opts)
+  local prefix = scope_mod.bufpath(opts.scope)
+  if not prefix or not opts.run_id or opts.run_id == '' then
+    return nil
+  end
+  return ('forge://%s/ci/%s'):format(prefix, opts.run_id)
+end
+
+---@param name string?
+---@return integer?
+local function find_buf_by_name(name)
+  if not name or name == '' then
+    return nil
+  end
+  local bn = vim.fn.bufnr(name)
+  if bn ~= -1 and vim.api.nvim_buf_is_valid(bn) then
+    return bn
+  end
+  return nil
+end
 
 local function data_for(buf)
   local d = buf_data[buf]
@@ -722,8 +759,9 @@ end
 
 ---@class forge.LogOpts
 ---@field forge_name string
+---@field scope forge.Scope?
+---@field run_id string?
 ---@field url string?
----@field title string?
 ---@field steps_cmd string[]?
 ---@field job_id string?
 ---@field replace_win integer?
@@ -791,6 +829,7 @@ end
 ---@param reuse_buf integer?
 function M.open(cmd, opts, reuse_buf)
   local parse = parser_for[opts.forge_name] or parse_github
+  local bufname = log_bufname(opts)
   local buf
   local saved_cursor
   local old_line_count
@@ -804,33 +843,48 @@ function M.open(cmd, opts, reuse_buf)
       saved_cursor = vim.api.nvim_win_get_cursor(wins[1])
     end
   else
-    local replace_win = opts.replace_win
-    if replace_win and vim.api.nvim_win_is_valid(replace_win) then
-      local old_buf = vim.api.nvim_win_get_buf(replace_win)
-      buf = vim.api.nvim_create_buf(false, true)
-      vim.api.nvim_win_set_buf(replace_win, buf)
-      if vim.api.nvim_buf_is_valid(old_buf) and old_buf ~= buf then
-        vim.api.nvim_buf_delete(old_buf, { force = true })
+    local existing = find_buf_by_name(bufname)
+    if existing then
+      reusing = true
+      buf = existing
+      old_line_count = vim.api.nvim_buf_line_count(buf)
+      local wins = vim.fn.win_findbuf(buf)
+      if #wins > 0 then
+        saved_cursor = vim.api.nvim_win_get_cursor(wins[1])
+      else
+        vim.cmd('noautocmd botright sbuffer ' .. buf)
       end
     else
-      vim.cmd('noautocmd botright new')
-      buf = vim.api.nvim_get_current_buf()
+      local replace_win = opts.replace_win
+      if replace_win and vim.api.nvim_win_is_valid(replace_win) then
+        local old_buf = vim.api.nvim_win_get_buf(replace_win)
+        buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_win_set_buf(replace_win, buf)
+        if vim.api.nvim_buf_is_valid(old_buf) and old_buf ~= buf then
+          vim.api.nvim_buf_delete(old_buf, { force = true })
+        end
+      else
+        vim.cmd('noautocmd botright new')
+        buf = vim.api.nvim_get_current_buf()
+      end
+      vim.bo[buf].buftype = 'nofile'
+      vim.bo[buf].bufhidden = 'wipe'
+      vim.bo[buf].swapfile = false
+      vim.bo[buf].modifiable = false
+      vim.bo[buf].filetype = 'forge_log'
+      if bufname then
+        vim.api.nvim_buf_set_name(buf, bufname)
+      end
+      setup_keymaps(buf, opts.url, cmd, opts)
+      vim.api.nvim_create_autocmd('BufWipeout', {
+        buffer = buf,
+        callback = function()
+          stop_timer(buf)
+          stop_procs(buf)
+          buf_data[buf] = nil
+        end,
+      })
     end
-    vim.bo[buf].buftype = 'nofile'
-    vim.bo[buf].bufhidden = 'wipe'
-    vim.bo[buf].swapfile = false
-    vim.bo[buf].modifiable = false
-    vim.bo[buf].filetype = 'forge_log'
-    pcall(vim.api.nvim_buf_set_name, buf, 'forge://log/' .. (opts.title or 'ci'))
-    setup_keymaps(buf, opts.url, cmd, opts)
-    vim.api.nvim_create_autocmd('BufWipeout', {
-      buffer = buf,
-      callback = function()
-        stop_timer(buf)
-        stop_procs(buf)
-        buf_data[buf] = nil
-      end,
-    })
   end
   if not reusing then
     vim.bo[buf].modifiable = true
@@ -929,9 +983,9 @@ end
 
 ---@class forge.SummaryOpts
 ---@field forge_name string
+---@field scope forge.Scope?
 ---@field run_id string
 ---@field url string?
----@field title string?
 ---@field in_progress boolean?
 ---@field status_cmd string[]?
 ---@field json boolean?
@@ -1079,6 +1133,7 @@ end
 ---@param opts forge.SummaryOpts
 ---@param reuse_buf integer?
 function M.open_summary(cmd, opts, reuse_buf)
+  local bufname = summary_bufname(opts)
   local buf
   local saved_cursor
   local old_line_count
@@ -1092,25 +1147,43 @@ function M.open_summary(cmd, opts, reuse_buf)
       saved_cursor = vim.api.nvim_win_get_cursor(wins[1])
     end
   else
-    local cfg = require('forge').config()
-    local split = cfg.ci.split or cfg.split
-    local prefix = split == 'vertical' and 'vertical' or 'botright'
-    vim.cmd('noautocmd ' .. prefix .. ' new')
-    buf = vim.api.nvim_get_current_buf()
-    vim.bo[buf].buftype = 'nofile'
-    vim.bo[buf].bufhidden = 'wipe'
-    vim.bo[buf].swapfile = false
-    vim.bo[buf].modifiable = false
-    vim.bo[buf].filetype = 'forge_log'
-    pcall(vim.api.nvim_buf_set_name, buf, 'forge://ci/' .. (opts.title or 'summary'))
-    vim.api.nvim_create_autocmd('BufWipeout', {
-      buffer = buf,
-      callback = function()
-        stop_timer(buf)
-        stop_procs(buf)
-        buf_data[buf] = nil
-      end,
-    })
+    local existing = find_buf_by_name(bufname)
+    if existing then
+      reusing = true
+      buf = existing
+      old_line_count = vim.api.nvim_buf_line_count(buf)
+      local wins = vim.fn.win_findbuf(buf)
+      if #wins > 0 then
+        saved_cursor = vim.api.nvim_win_get_cursor(wins[1])
+      else
+        local cfg = require('forge').config()
+        local split = cfg.ci.split or cfg.split
+        local prefix = split == 'vertical' and 'vertical' or 'botright'
+        vim.cmd('noautocmd ' .. prefix .. ' sbuffer ' .. buf)
+      end
+    else
+      local cfg = require('forge').config()
+      local split = cfg.ci.split or cfg.split
+      local prefix = split == 'vertical' and 'vertical' or 'botright'
+      vim.cmd('noautocmd ' .. prefix .. ' new')
+      buf = vim.api.nvim_get_current_buf()
+      vim.bo[buf].buftype = 'nofile'
+      vim.bo[buf].bufhidden = 'wipe'
+      vim.bo[buf].swapfile = false
+      vim.bo[buf].modifiable = false
+      vim.bo[buf].filetype = 'forge_log'
+      if bufname then
+        vim.api.nvim_buf_set_name(buf, bufname)
+      end
+      vim.api.nvim_create_autocmd('BufWipeout', {
+        buffer = buf,
+        callback = function()
+          stop_timer(buf)
+          stop_procs(buf)
+          buf_data[buf] = nil
+        end,
+      })
+    end
   end
 
   if not reusing then

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -86,8 +86,9 @@ local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd
     return f:check_log_cmd(run.id, failed, job_id, run_ref),
       {
         forge_name = f.name,
+        scope = run_ref,
+        run_id = run.id,
         url = job_url,
-        title = (run.name or run.id) .. ' / ' .. (job_id or ''),
         steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
         job_id = job_id,
         in_progress = in_progress,
@@ -358,9 +359,9 @@ function M.ci_log(f, run)
   if f.view_cmd then
     require('forge.log').open_summary(f:view_cmd(run.id, { scope = run_ref }), {
       forge_name = f.name,
+      scope = run_ref,
       run_id = run.id,
       url = url,
-      title = run.name or run.id,
       in_progress = in_progress,
       status_cmd = status_cmd,
       browse_url_fn = function(job_id)
@@ -377,8 +378,9 @@ function M.ci_log(f, run)
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
             forge_name = f.name,
+            scope = run_ref,
+            run_id = run.id,
             url = job_url,
-            title = (run.name or run.id) .. ' / ' .. (job_id or ''),
             steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
             job_id = job_id,
             in_progress = in_progress,
@@ -391,9 +393,9 @@ function M.ci_log(f, run)
   if f.summary_json_cmd then
     require('forge.log').open_summary(f:summary_json_cmd(run.id, run_ref), {
       forge_name = f.name,
+      scope = run_ref,
       run_id = run.id,
       url = url,
-      title = run.name or run.id,
       in_progress = in_progress,
       status_cmd = status_cmd,
       json = true,
@@ -411,8 +413,9 @@ function M.ci_log(f, run)
         return f:check_log_cmd(run.id, failed, job_id, run_ref),
           {
             forge_name = f.name,
+            scope = run_ref,
+            run_id = run.id,
             url = job_url,
-            title = (run.name or run.id) .. ' / ' .. (job_id or ''),
             steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
             job_id = job_id,
             in_progress = in_progress,
@@ -427,8 +430,9 @@ function M.ci_log(f, run)
     f:run_log_cmd(run.id, status == 'failure' or status == 'failed', run_ref),
     {
       forge_name = f.name,
+      scope = run_ref,
+      run_id = run.id,
       url = url,
-      title = run.name or run.id,
       steps_cmd = f.steps_cmd and f:steps_cmd(run.id, run_ref) or nil,
       in_progress = in_progress,
       status_cmd = status_cmd,

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -342,8 +342,9 @@ function M.checks(f, num, filter, cached_checks, opts)
           local status_cmd = f.run_status_cmd and f:run_status_cmd(run_id, check_ref) or nil
           require('forge.log').open(cmd, {
             forge_name = f.name,
+            scope = check_ref,
+            run_id = run_id,
             url = c.link,
-            title = c.name or run_id,
             steps_cmd = steps_cmd,
             job_id = job_id,
             in_progress = in_progress,

--- a/lua/forge/scope.lua
+++ b/lua/forge/scope.lua
@@ -133,6 +133,23 @@ function M.key(scope)
   }, '|')
 end
 
+---@param scope forge.Scope?
+---@return string?
+function M.bufpath(scope)
+  if type(scope) ~= 'table' then
+    return nil
+  end
+  local host = scope.host
+  local slug = scope.slug
+  if type(host) ~= 'string' or host == '' then
+    return nil
+  end
+  if type(slug) ~= 'string' or slug == '' then
+    return nil
+  end
+  return host .. '/' .. slug
+end
+
 ---@param a forge.Scope?
 ---@param b forge.Scope?
 ---@return boolean

--- a/spec/compose_abandon_spec.lua
+++ b/spec/compose_abandon_spec.lua
@@ -35,6 +35,13 @@ describe('compose abandon behavior', function()
     package.preload['forge'] = function()
       return {
         clear_list = function() end,
+        current_scope = function()
+          return {
+            kind = 'github',
+            host = 'github.com',
+            slug = 'owner/repo',
+          }
+        end,
       }
     end
 

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -68,6 +68,13 @@ describe('compose issue create', function()
         clear_list = function()
           captured.cleared = captured.cleared + 1
         end,
+        current_scope = function()
+          return {
+            kind = 'github',
+            host = 'github.com',
+            slug = 'owner/repo',
+          }
+        end,
       }
     end
 
@@ -114,7 +121,8 @@ describe('compose issue create', function()
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if
-        vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == 'forge://issue/new'
+        vim.api.nvim_buf_is_valid(buf)
+        and vim.api.nvim_buf_get_name(buf) == 'forge://github.com/owner/repo/issue/new'
       then
         vim.api.nvim_buf_delete(buf, { force = true })
       end
@@ -440,6 +448,13 @@ describe('compose issue edit', function()
         clear_list = function()
           captured.cleared = captured.cleared + 1
         end,
+        current_scope = function()
+          return {
+            kind = 'github',
+            host = 'github.com',
+            slug = 'owner/repo',
+          }
+        end,
       }
     end
 
@@ -487,7 +502,7 @@ describe('compose issue edit', function()
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if
         vim.api.nvim_buf_is_valid(buf)
-        and vim.api.nvim_buf_get_name(buf) == 'forge://issue/42/edit'
+        and vim.api.nvim_buf_get_name(buf) == 'forge://github.com/owner/repo/issue/42/edit'
       then
         vim.api.nvim_buf_delete(buf, { force = true })
       end

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -57,6 +57,9 @@ describe('compose pr create', function()
       if cmd == 'git remote get-url origin' then
         return captured.remote_url
       end
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo'
+      end
       return ''
     end
     vim.system = function(_, _, cb)
@@ -101,7 +104,10 @@ describe('compose pr create', function()
     package.loaded['forge.template'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
-      if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == 'forge://pr/new' then
+      if
+        vim.api.nvim_buf_is_valid(buf)
+        and vim.api.nvim_buf_get_name(buf) == 'forge://github.com/barrettruth/forge.nvim/pr/new'
+      then
         vim.api.nvim_buf_delete(buf, { force = true })
       end
     end

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -82,6 +82,13 @@ describe('compose pr edit', function()
         clear_list = function()
           captured.cleared = captured.cleared + 1
         end,
+        current_scope = function()
+          return {
+            kind = 'github',
+            host = 'github.com',
+            slug = 'owner/repo',
+          }
+        end,
       }
     end
 
@@ -120,7 +127,7 @@ describe('compose pr edit', function()
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if
         vim.api.nvim_buf_is_valid(buf)
-        and vim.api.nvim_buf_get_name(buf) == 'forge://pr/23/edit'
+        and vim.api.nvim_buf_get_name(buf) == 'forge://github.com/owner/repo/pr/23/edit'
       then
         vim.api.nvim_buf_delete(buf, { force = true })
       end

--- a/spec/compose_split_spec.lua
+++ b/spec/compose_split_spec.lua
@@ -77,6 +77,13 @@ describe('compose split session', function()
         clear_list = function()
           captured.cleared = captured.cleared + 1
         end,
+        current_scope = function()
+          return {
+            kind = 'github',
+            host = 'github.com',
+            slug = 'owner/repo',
+          }
+        end,
       }
     end
 

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -8,6 +8,8 @@ local parse_summary = log_mod._parse_summary
 local summary_job_at_line = log_mod._summary_job_at_line
 local parse_summary_json = log_mod._parse_summary_json
 
+local test_scope = { kind = 'github', host = 'github.com', slug = 'owner/repo' }
+
 describe('strip_ansi', function()
   it('strips SGR codes and extracts highlights', function()
     local text, hls = strip_ansi('\027[31mhello\027[0m world')
@@ -587,7 +589,8 @@ describe('buffer reuse refreshes', function()
 
     log_mod.open({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
-      title = 'ci',
+      scope = test_scope,
+      run_id = '111',
     }, buf)
 
     assert.equals(1, #calls)
@@ -601,8 +604,8 @@ describe('buffer reuse refreshes', function()
 
     log_mod.open_summary({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
+      scope = test_scope,
       run_id = '123',
-      title = 'summary',
     }, buf)
 
     assert.equals(1, #calls)
@@ -616,11 +619,13 @@ describe('buffer reuse refreshes', function()
 
     log_mod.open({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
-      title = 'ci',
+      scope = test_scope,
+      run_id = '111',
     }, buf)
     log_mod.open({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
-      title = 'ci',
+      scope = test_scope,
+      run_id = '111',
     }, buf)
 
     assert.equals(2, #calls)
@@ -645,13 +650,13 @@ describe('buffer reuse refreshes', function()
 
     log_mod.open_summary({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
+      scope = test_scope,
       run_id = '123',
-      title = 'summary',
     }, buf)
     log_mod.open_summary({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
+      scope = test_scope,
       run_id = '123',
-      title = 'summary',
     }, buf)
 
     assert.equals(2, #calls)
@@ -722,10 +727,10 @@ describe('summary job mappings', function()
 
     log_mod.open_summary({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
+      scope = test_scope,
       run_id = '12345',
-      title = 'summary',
       log_cmd_fn = function(job_id, failed)
-        return { 'log', job_id, tostring(failed) }, { title = job_id }
+        return { 'log', job_id, tostring(failed) }, { job_id = job_id }
       end,
     })
 
@@ -744,7 +749,7 @@ describe('summary job mappings', function()
     end)
 
     assert.same({ 'log', '12345', 'false' }, opened[1].cmd)
-    assert.same({ title = '12345', replace_win = win }, opened[1].opts)
+    assert.same({ job_id = '12345', replace_win = win }, opened[1].opts)
 
     vim.api.nvim_win_set_cursor(0, { 6, 0 })
     enter()
@@ -777,8 +782,8 @@ describe('summary job mappings', function()
 
     log_mod.open_summary({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
+      scope = test_scope,
       run_id = '12345',
-      title = 'summary',
       url = 'https://example.com/runs/12345',
       browse_url_fn = function(job_id)
         return 'https://example.com/runs/12345/job/' .. job_id
@@ -822,7 +827,9 @@ describe('summary job mappings', function()
 
     log_mod.open({ 'gh', 'run', 'view', '--log', '--job', '12345' }, {
       forge_name = 'github',
-      title = 'job',
+      scope = test_scope,
+      run_id = '77',
+      job_id = '12345',
       url = 'https://example.com/runs/77/job/12345',
     })
 
@@ -867,7 +874,8 @@ describe('log folds', function()
 
     log_mod.open({ 'gh', 'run', 'view' }, {
       forge_name = 'github',
-      title = 'ci',
+      scope = test_scope,
+      run_id = '99',
     })
 
     local buf = vim.api.nvim_get_current_buf()

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -297,8 +297,9 @@ describe('shared operations', function()
     assert.same({ 'check-log', '88', 'true', '22', 'repo/ref' }, captured.logs[1].cmd)
     assert.same({
       forge_name = 'github',
+      scope = 'repo/ref',
+      run_id = '88',
       url = 'https://example.com/runs/88/jobs/22/repo/ref',
-      title = 'Deploy / 22',
       steps_cmd = { 'steps', '88', 'repo/ref' },
       job_id = '22',
       replace_win = win,
@@ -336,9 +337,9 @@ describe('shared operations', function()
     summary_opts.log_cmd_fn, summary_opts.browse_url_fn = nil, nil
     assert.same({
       forge_name = 'custom',
+      scope = 'repo/ref',
       run_id = '77',
       url = 'https://example.com/runs/77',
-      title = 'CI',
       in_progress = true,
       status_cmd = { 'status', '77', 'repo/ref' },
       json = true,
@@ -385,8 +386,9 @@ describe('shared operations', function()
     assert.same({ 'run-log', '88', 'true', 'repo/ref' }, captured.logs[1].cmd)
     assert.same({
       forge_name = 'gitlab',
+      scope = 'repo/ref',
+      run_id = '88',
       url = 'https://example.com/runs/88/repo/ref',
-      title = 'Deploy',
       steps_cmd = { 'steps', '88', 'repo/ref' },
       in_progress = false,
       status_cmd = { 'status', '88', 'repo/ref' },

--- a/spec/submission_integration_spec.lua
+++ b/spec/submission_integration_spec.lua
@@ -65,6 +65,13 @@ describe('submission integration', function()
         scope_key = function(scope)
           return scope and scope.repo_arg or ''
         end,
+        current_scope = function()
+          return {
+            kind = 'github',
+            host = 'github.com',
+            slug = 'owner/repo',
+          }
+        end,
       }
     end
 


### PR DESCRIPTION
## Problem

forge.nvim had six ad-hoc bufname formats: `forge://pr/new`, `forge://pr/{num}/edit`, `forge://issue/new`, `forge://issue/{num}/edit`, `forge://log/{title}`, `forge://ci/{title}`. The first four collide across repos (`:Forge pr edit 42` in repo A vs `repo=upstream` pulls both to `forge://pr/42/edit`). The last two collide on their default `'ci'` / `'summary'` titles when the same CI run is opened twice — the `pcall` around `nvim_buf_set_name` was silently swallowing the failure, producing unnamed duplicate buffers. Compose/log/ci buffer naming had zero scoping.

## Solution

Single scheme:

```
forge://{host}/{slug}/{resource}/{id-or-action}[/{sub}]
```

- **`scope.bufpath(scope)`** new helper returning `"{host}/{slug}"` or `nil`
- **`compose.lua`** gains a local `resolve_bufpath(ref, forge_name)` that tries the explicit scope first and falls back to `forge.current_scope(forge_name)` via origin remote. All 4 compose open sites use it; `pcall` dropped from `nvim_buf_set_name`. When no scope can be resolved (not in a repo, no detectable remote) compose refuses to open with a warning instead of creating a nameless buffer.
- **`log.lua`** `LogOpts` / `SummaryOpts` drop `title` and gain `scope` + `run_id`. New helpers `log_bufname()` / `summary_bufname()` produce `forge://{host}/{slug}/ci/{run_id}[/log|/job/{job_id}]`. Both `M.open` and `M.open_summary` now look up an existing buffer by name before creating a new one, fixing the duplicate-unnamed-buffer bug.
- **`ops.lua`** 5 callsites (3× `log.open`, 2× `log.open_summary`) thread `scope = run_ref` and `run_id = run.id` through the opts tables; drop the old `title = ...` composition.
- **`pickers.lua`** 1 callsite in the PR checks picker threads `scope = check_ref` and `run_id = run_id`.

Concrete examples:

```
forge://github.com/barrettruth/forge.nvim/pr/42/edit
forge://github.com/barrettruth/forge.nvim/ci/987654321
forge://github.com/barrettruth/forge.nvim/ci/987654321/job/5544
forge://gitlab.com/group/subgroup/project/pr/42/edit
forge://ghe.company.com/team/app/pr/new
```

8 spec files updated: mocks gain `current_scope`, opts assertions use `scope`/`run_id` instead of `title`, literal bufnames updated to the new format. `doc/forge.nvim.txt` compose-section bufname references updated; `PROSPECTIVE_CHANGES.md` line 179's revisit TODO is now addressed.

Breaking: `LogOpts.title` and `SummaryOpts.title` are gone; both now require `scope` + `run_id` (`scope` is optional at the type level to tolerate test stubs with partial context, but production paths all supply it). Existing bufname literals anyone scripted against no longer match.

`scripts/ci.sh` green: stylua / selene / prettier / nix fmt / lua-language-server / vimdoc-language-server / busted (443/0).