### PR TITLE
feat(sources): add list_web_url for kind-level web landing pages

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -1113,6 +1113,11 @@ Optional methods: ~
                                         `status` and `conclusion` fields.
   `live_tail_cmd(run_id, job_id?)`     `string[]?` cmd to live-tail a
                                         specific job in a terminal.
+  `list_web_url(kind, scope?)`         `string?` Web URL for the list
+                                        landing page of `kind` (`'pr'`,
+                                        `'issue'`, `'ci'`, `'release'`).
+                                        Return `nil` if the source has no
+                                        such page.
   `list_runs_json_cmd(branch?)`        `string[]` JSON CI list cmd.
                                         If absent, Forge reports that
                                         structured CI data is unavailable

--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -143,6 +143,27 @@ function M:browse_commit(commit, ref)
   vim.ui.open(base .. '/commit/' .. commit)
 end
 
+local LIST_PATHS = {
+  pr = '/pulls',
+  issue = '/issues',
+  ci = '/actions',
+  release = '/releases',
+}
+
+---@param kind forge.WebKind
+---@return string?
+function M:list_web_url(kind, ref)
+  local base = forge.remote_web_url(ref)
+  if not base or base == '' then
+    return nil
+  end
+  local path = LIST_PATHS[kind]
+  if not path then
+    return nil
+  end
+  return base .. path
+end
+
 function M:checkout_cmd(num, ref)
   return { 'tea', 'pr', 'checkout', num, '--repo', repo_arg(ref) }
 end

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -180,6 +180,27 @@ function M:browse_commit(commit, scope)
   open_browse_url(cmd)
 end
 
+local LIST_PATHS = {
+  pr = '/pulls',
+  issue = '/issues',
+  ci = '/actions',
+  release = '/releases',
+}
+
+---@param kind forge.WebKind
+---@return string?
+function M:list_web_url(kind, scope)
+  local base = forge.remote_web_url(scope)
+  if not base or base == '' then
+    return nil
+  end
+  local path = LIST_PATHS[kind]
+  if not path then
+    return nil
+  end
+  return base .. path
+end
+
 function M:checkout_cmd(num, scope)
   local cmd = { 'gh', 'pr', 'checkout', num }
   local repo = nwo(scope)

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -149,6 +149,27 @@ function M:browse_commit(commit, ref)
   vim.ui.open(base .. '/-/commit/' .. commit)
 end
 
+local LIST_PATHS = {
+  pr = '/-/merge_requests',
+  issue = '/-/issues',
+  ci = '/-/pipelines',
+  release = '/-/releases',
+}
+
+---@param kind forge.WebKind
+---@return string?
+function M:list_web_url(kind, ref)
+  local base = forge.remote_web_url(ref)
+  if not base or base == '' then
+    return nil
+  end
+  local path = LIST_PATHS[kind]
+  if not path then
+    return nil
+  end
+  return base .. path
+end
+
 function M:checkout_cmd(num, ref)
   return { 'glab', 'mr', 'checkout', num, '-R', repo_arg(ref) }
 end

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -2,6 +2,8 @@
 
 ---@alias forge.ScopeKind 'github'|'gitlab'|'codeberg'
 
+---@alias forge.WebKind 'pr'|'issue'|'ci'|'release'
+
 ---@class forge.Scope
 ---@field kind forge.ScopeKind
 ---@field host string
@@ -162,6 +164,7 @@
 ---@field summary_json_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
 ---@field watch_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
 ---@field run_status_cmd (fun(self: forge.Forge, id: string, scope?: forge.Scope): string[])?
+---@field list_web_url (fun(self: forge.Forge, kind: forge.WebKind, scope?: forge.Scope): string?)?
 ---@field run_web_url (fun(self: forge.Forge, id: string, scope?: forge.Scope): string?)?
 ---@field job_web_url (fun(self: forge.Forge, run_id: string, job_id: string, scope?: forge.Scope): string?)?
 ---@field live_tail_cmd (fun(self: forge.Forge, run_id: string, job_id: string?, scope?: forge.Scope): string[])?

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -285,6 +285,23 @@ describe('github', function()
     })
     assert.equals('fix(ci): add load more for repo runs (#196)', run.name)
   end)
+
+  it('builds list_web_url for each kind', function()
+    local scope = { web_url = 'https://github.com/owner/repo' }
+    assert.equals('https://github.com/owner/repo/pulls', gh:list_web_url('pr', scope))
+    assert.equals('https://github.com/owner/repo/issues', gh:list_web_url('issue', scope))
+    assert.equals('https://github.com/owner/repo/actions', gh:list_web_url('ci', scope))
+    assert.equals('https://github.com/owner/repo/releases', gh:list_web_url('release', scope))
+  end)
+
+  it('returns nil from list_web_url when base url is empty', function()
+    assert.is_nil(gh:list_web_url('pr', { web_url = '' }))
+  end)
+
+  it('returns nil from list_web_url for unknown kinds', function()
+    local scope = { web_url = 'https://github.com/owner/repo' }
+    assert.is_nil(gh:list_web_url('bogus', scope))
+  end)
 end)
 
 describe('github browse', function()
@@ -615,6 +632,23 @@ describe('gitlab', function()
   it('uses ref as name for non-MR refs', function()
     assert.equals('main', gl:normalize_run({ id = 1, ref = 'main', status = 'running' }).name)
   end)
+
+  it('builds list_web_url for each kind', function()
+    local scope = { web_url = 'https://gitlab.com/group/repo' }
+    assert.equals('https://gitlab.com/group/repo/-/merge_requests', gl:list_web_url('pr', scope))
+    assert.equals('https://gitlab.com/group/repo/-/issues', gl:list_web_url('issue', scope))
+    assert.equals('https://gitlab.com/group/repo/-/pipelines', gl:list_web_url('ci', scope))
+    assert.equals('https://gitlab.com/group/repo/-/releases', gl:list_web_url('release', scope))
+  end)
+
+  it('returns nil from list_web_url when base url is empty', function()
+    assert.is_nil(gl:list_web_url('pr', { web_url = '' }))
+  end)
+
+  it('returns nil from list_web_url for unknown kinds', function()
+    local scope = { web_url = 'https://gitlab.com/group/repo' }
+    assert.is_nil(gl:list_web_url('bogus', scope))
+  end)
 end)
 
 describe('codeberg', function()
@@ -807,5 +841,22 @@ describe('codeberg', function()
       { 'sh', '-c', 'tea releases delete --confirm --repo forgejo/tea-test v1.2.3' },
       cb:delete_release_cmd('v1.2.3', { repo_arg = 'forgejo/tea-test' })
     )
+  end)
+
+  it('builds list_web_url for each kind', function()
+    local scope = { web_url = 'https://codeberg.org/owner/repo' }
+    assert.equals('https://codeberg.org/owner/repo/pulls', cb:list_web_url('pr', scope))
+    assert.equals('https://codeberg.org/owner/repo/issues', cb:list_web_url('issue', scope))
+    assert.equals('https://codeberg.org/owner/repo/actions', cb:list_web_url('ci', scope))
+    assert.equals('https://codeberg.org/owner/repo/releases', cb:list_web_url('release', scope))
+  end)
+
+  it('returns nil from list_web_url when base url is empty', function()
+    assert.is_nil(cb:list_web_url('pr', { web_url = '' }))
+  end)
+
+  it('returns nil from list_web_url for unknown kinds', function()
+    local scope = { web_url = 'https://codeberg.org/owner/repo' }
+    assert.is_nil(cb:list_web_url('bogus', scope))
   end)
 end)


### PR DESCRIPTION
## Problem

The `forge.Forge` interface exposes `view_web`, `browse_release`, and
the `browse_*` helpers but has no way to build the repo-level list
landing page (pulls, issues, CI, releases). Argless
`:Forge pr/issue/release browse` and `:Forge ci browse` both need
that URL, and neither can land cleanly without a single
source-of-truth hook first.

## Solution

Add an optional `list_web_url(kind, scope?)` method to the
`forge.Forge` contract with implementations in `github.lua`,
`gitlab.lua`, and `codeberg.lua`. Each source keeps a file-local
path table for the four `forge.WebKind` values and returns `nil`
when the base URL is empty or the kind is unknown, letting consumers
treat `nil` as "this forge does not support that page" without
per-kind capability flags.

Closes #284.
