### PR TITLE
feat(cmd): argless :Forge {pr,issue,release} browse opens forge list pages

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -421,8 +421,9 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge pr worktree` {num} [repo=...]                     *:Forge-pr-worktree*
     Fetch PR `{num}` and create a git worktree.
 
-`:Forge pr browse` {num} [repo=...]                         *:Forge-pr-browse*
-    Open PR `{num}` in the browser.
+`:Forge pr browse` [{num}] [repo=...]                       *:Forge-pr-browse*
+    Open PR `{num}` in the browser, or the PR list landing page when
+    `{num}` is omitted.
 
 `:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
     Approve PR `{num}`.
@@ -440,8 +441,9 @@ BANG SEMANTICS                                            *forge-command-bang*
 `:Forge pr ready` {num} [repo=...]                           *:Forge-pr-ready*
     Mark PR `{num}` as ready when supported by the forge.
 
-`:Forge issue browse` {num} [repo=...]                   *:Forge-issue-browse*
-    Open issue `{num}` in the browser.
+`:Forge issue browse` [{num}] [repo=...]                 *:Forge-issue-browse*
+    Open issue `{num}` in the browser, or the issue list landing page
+    when `{num}` is omitted.
 
 `:Forge issue close` {num} [repo=...]                     *:Forge-issue-close*
     Close issue `{num}`.
@@ -472,8 +474,9 @@ BANG SEMANTICS                                            *forge-command-bang*
     opens a refreshing per-job log because `gh` only supports live watch at
     the run level.
 
-`:Forge release browse` {tag} [repo=...]               *:Forge-release-browse*
-    Open release `{tag}` in the browser.
+`:Forge release browse` [{tag}] [repo=...]             *:Forge-release-browse*
+    Open release `{tag}` in the browser, or the releases list landing
+    page when `{tag}` is omitted.
 
 `:Forge release delete` {tag} [repo=...]               *:Forge-release-delete*
     Delete release `{tag}` (with confirmation prompt).
@@ -1675,6 +1678,12 @@ and `num`/`id`/`tag`.
                                                    *forge.ops.release_delete()*
 `release_delete(f, release, opts?)`
     Deletes `release`. `opts`: `{ confirm?, on_success?, on_failure? }`.
+
+                                                     *forge.ops.list_browse()*
+`list_browse(f, kind, opts?)`
+    Opens the forge's web list landing page for `kind` (`'pr'`,
+    `'issue'`, `'ci'`, or `'release'`). `opts`: `{ scope? }`. Warns
+    when the source has no such page.
 
                                                     *forge.ops.browse_commit()*
 `browse_commit(opts?)`

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -55,7 +55,7 @@ local families = {
         modifiers = { 'repo' },
       },
       browse = {
-        subject = { kind = 'pr', min = 1, max = 1 },
+        subject = { kind = 'pr', min = 0, max = 1 },
         modifiers = { 'repo' },
       },
       close = {
@@ -99,7 +99,7 @@ local families = {
     verb_order = { 'browse', 'close', 'reopen', 'create', 'edit' },
     verbs = {
       browse = {
-        subject = { kind = 'issue', min = 1, max = 1 },
+        subject = { kind = 'issue', min = 0, max = 1 },
         modifiers = { 'repo' },
       },
       close = {
@@ -142,7 +142,7 @@ local families = {
     verb_order = { 'browse', 'delete' },
     verbs = {
       browse = {
-        subject = { kind = 'release', min = 1, max = 1 },
+        subject = { kind = 'release', min = 0, max = 1 },
         modifiers = { 'repo' },
       },
       delete = {
@@ -407,7 +407,11 @@ local function dispatch_pr(command)
     return
   end
   if command.name == 'browse' then
-    ops.pr_browse(f, { num = num, scope = scope })
+    if num then
+      ops.pr_browse(f, { num = num, scope = scope })
+    else
+      ops.list_browse(f, 'pr', { scope = scope })
+    end
     return
   end
   if command.name == 'approve' then
@@ -458,7 +462,11 @@ local function dispatch_issue(command)
     return
   end
   if command.name == 'browse' then
-    ops.issue_browse(f, { num = num, scope = scope })
+    if num then
+      ops.issue_browse(f, { num = num, scope = scope })
+    else
+      ops.list_browse(f, 'issue', { scope = scope })
+    end
     return
   end
   if command.name == 'edit' then
@@ -507,7 +515,11 @@ local function dispatch_release(command)
   local tag = command.subjects[1]
   local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'browse' then
-    ops.release_browse(f, { tag = tag, scope = scope })
+    if tag then
+      ops.release_browse(f, { tag = tag, scope = scope })
+    else
+      ops.list_browse(f, 'release', { scope = scope })
+    end
     return
   end
   if command.name == 'delete' then

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -507,6 +507,21 @@ function M.release_delete(f, release, opts)
   end)
 end
 
+---@param kind forge.WebKind
+---@param opts? forge.ScopedOpts
+function M.list_browse(f, kind, opts)
+  opts = opts or {}
+  local url = f.list_web_url and f:list_web_url(kind, opts.scope) or nil
+  if not url or url == '' then
+    log.warn(('%s does not support %s landing pages'):format(f.name, kind))
+    return
+  end
+  local _, err = vim.ui.open(url)
+  if err then
+    log.error(err)
+  end
+end
+
 function M.browse_commit(opts)
   require('forge').open('browse.commit', opts)
 end

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -507,6 +507,7 @@ function M.release_delete(f, release, opts)
   end)
 end
 
+---@param f forge.Forge
 ---@param kind forge.WebKind
 ---@param opts? forge.ScopedOpts
 function M.list_browse(f, kind, opts)
@@ -522,10 +523,13 @@ function M.list_browse(f, kind, opts)
   end
 end
 
+---@param opts? { commit?: string, scope?: forge.Scope }
 function M.browse_commit(opts)
   require('forge').open('browse.commit', opts)
 end
 
+---@param opts? forge.ScopedOpts
+---@return boolean
 function M.browse_repo(opts)
   local scope = type(opts) == 'table' and opts.scope or nil
   local url = require('forge').remote_web_url(scope)
@@ -536,14 +540,21 @@ function M.browse_repo(opts)
   return true
 end
 
+---@param branch string?
+---@param opts? forge.ScopedOpts
 function M.browse_branch(branch, opts)
   require('forge').open('browse.branch', vim.tbl_extend('force', opts or {}, { branch = branch }))
 end
 
+---@param opts? forge.ScopedOpts
 function M.browse_contextual(opts)
   require('forge').open('browse.contextual', opts)
 end
 
+---@param f forge.Forge
+---@param location table
+---@param scope? forge.Scope
+---@return boolean
 function M.browse_location(f, location, scope)
   local loc = location_arg(location)
   if not loc then
@@ -553,8 +564,15 @@ function M.browse_location(f, location, scope)
   return true
 end
 
+---@param f forge.Forge
+---@param file_loc string?
+---@param branch string?
+---@param scope? forge.Scope
+---@return boolean
 function M.browse_file(f, file_loc, branch, scope)
-  if trim(file_loc) == '' or trim(branch) == '' then
+  file_loc = trim(file_loc)
+  branch = trim(branch)
+  if file_loc == '' or branch == '' then
     return false
   end
   f:browse(file_loc, branch, scope)

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -117,6 +117,24 @@ describe('command schema', function()
     assert.equals('unknown pr action: ci', pr_ci.message)
   end)
 
+  it('accepts argless browse for kind families that have a list landing page', function()
+    local pr = assert(cmd.parse({ 'pr', 'browse' }))
+    local issue = assert(cmd.parse({ 'issue', 'browse' }))
+    local release = assert(cmd.parse({ 'release', 'browse' }))
+
+    assert.equals('browse', pr.name)
+    assert.same({}, pr.subjects)
+    assert.equals('browse', issue.name)
+    assert.same({}, issue.subjects)
+    assert.equals('browse', release.name)
+    assert.same({}, release.subjects)
+
+    local pr_with = assert(cmd.parse({ 'pr', 'browse', '42' }))
+    local release_with = assert(cmd.parse({ 'release', 'browse', 'v1.2.3' }))
+    assert.same({ '42' }, pr_with.subjects)
+    assert.same({ 'v1.2.3' }, release_with.subjects)
+  end)
+
   it('attaches parsed target-bearing modifiers to normalized commands', function()
     local create = assert(cmd.parse({
       'pr',

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -290,6 +290,9 @@ describe(':Forge command', function()
             { name = 'release_delete', release = release, opts = opts }
           )
         end,
+        list_browse = function(_, kind, opts)
+          table.insert(captured.ops_calls, { name = 'list_browse', kind = kind, opts = opts })
+        end,
         browse_commit = function(opts)
           table.insert(captured.ops_calls, { name = 'browse_commit', opts = opts })
           require('forge').open('browse.commit', opts)
@@ -500,6 +503,37 @@ describe(':Forge command', function()
     }, captured.ops_calls[1])
     assert.equals('browse.commit', captured.opens[1].route)
     assert.equals('abc1234', captured.opens[1].opts.commit)
+  end)
+
+  it('dispatches argless kind browse through ops.list_browse', function()
+    vim.cmd('Forge pr browse')
+    vim.cmd('Forge issue browse')
+    vim.cmd('Forge release browse')
+
+    assert.same({ name = 'list_browse', kind = 'pr', opts = {} }, captured.ops_calls[1])
+    assert.same({ name = 'list_browse', kind = 'issue', opts = {} }, captured.ops_calls[2])
+    assert.same({ name = 'list_browse', kind = 'release', opts = {} }, captured.ops_calls[3])
+  end)
+
+  it('threads repo= through list_browse for argless kind browse', function()
+    vim.cmd('Forge pr browse repo=upstream')
+
+    assert.equals('list_browse', captured.ops_calls[1].name)
+    assert.equals('pr', captured.ops_calls[1].kind)
+    assert.equals('owner/upstream', captured.ops_calls[1].opts.scope.slug)
+  end)
+
+  it('keeps argful kind browse routed to entity-scoped ops helpers', function()
+    vim.cmd('Forge pr browse 42')
+    vim.cmd('Forge issue browse 7')
+    vim.cmd('Forge release browse v1.2.3')
+
+    assert.equals('pr_browse', captured.ops_calls[1].name)
+    assert.equals('42', captured.ops_calls[1].pr.num)
+    assert.equals('issue_browse', captured.ops_calls[2].name)
+    assert.equals('7', captured.ops_calls[2].issue.num)
+    assert.equals('release_browse', captured.ops_calls[3].name)
+    assert.equals('v1.2.3', captured.ops_calls[3].release.tag)
   end)
 
   it('passes ex ranges through browse file resolution', function()

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -5,6 +5,7 @@ describe('shared operations', function()
   local old_system
   local old_fn_system
   local old_ui_select
+  local old_ui_open
   local old_preload
 
   before_each(function()
@@ -17,11 +18,13 @@ describe('shared operations', function()
       summaries = {},
       logs = {},
       terms = {},
+      urls = {},
     }
 
     old_system = vim.system
     old_fn_system = vim.fn.system
     old_ui_select = vim.ui.select
+    old_ui_open = vim.ui.open
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.log'] = package.preload['forge.log'],
@@ -62,6 +65,11 @@ describe('shared operations', function()
 
     vim.ui.select = function(_, _, cb)
       cb('Yes')
+    end
+
+    vim.ui.open = function(url)
+      captured.urls[#captured.urls + 1] = url
+      return {}, nil
     end
 
     package.preload['forge.logger'] = function()
@@ -123,6 +131,7 @@ describe('shared operations', function()
     vim.system = old_system
     vim.fn.system = old_fn_system
     vim.ui.select = old_ui_select
+    vim.ui.open = old_ui_open
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.log'] = old_preload['forge.log']
@@ -396,5 +405,47 @@ describe('shared operations', function()
     assert.is_true(watched)
     assert.same({ 'watch', '88', 'repo/ref' }, captured.terms[1].cmd)
     assert.same({ url = 'https://example.com/runs/88/repo/ref' }, captured.terms[1].opts)
+  end)
+
+  it('list_browse opens the forge list landing page', function()
+    local ops = require('forge.ops')
+    local f = {
+      name = 'github',
+      list_web_url = function(_, kind, scope)
+        return ('https://example.com/%s/%s'):format(scope or 'repo', kind)
+      end,
+    }
+
+    ops.list_browse(f, 'pr', { scope = 'owner/repo' })
+    ops.list_browse(f, 'issue')
+
+    assert.same(
+      { 'https://example.com/owner/repo/pr', 'https://example.com/repo/issue' },
+      captured.urls
+    )
+    assert.same({}, captured.errors)
+  end)
+
+  it('list_browse warns when the source has no landing page for the kind', function()
+    local ops = require('forge.ops')
+    local f = {
+      name = 'codeberg',
+      list_web_url = function()
+        return nil
+      end,
+    }
+
+    ops.list_browse(f, 'release', {})
+
+    assert.same({}, captured.urls)
+    assert.same({ 'codeberg does not support release landing pages' }, captured.infos)
+  end)
+
+  it('list_browse warns when the source has no list_web_url method at all', function()
+    local ops = require('forge.ops')
+    ops.list_browse({ name = 'custom' }, 'ci', {})
+
+    assert.same({}, captured.urls)
+    assert.same({ 'custom does not support ci landing pages' }, captured.infos)
   end)
 end)


### PR DESCRIPTION
## Problem

The `browse` verb on `pr`, `issue`, and `release` requires a subject
(number or tag), so invoking `:Forge pr browse` alone errors out. The
only way to reach a forge's repo-level list page today is the in-editor
picker; there is no command-line path even though every backend can
construct that URL via `list_web_url`.

## Solution

Relax each of the three `browse` subject specs from `min = 1` to
`min = 0, max = 1` and branch each dispatcher on whether a subject was
provided. Argful invocations continue to route through
`ops.{pr,issue,release}_browse` unchanged; argless invocations call
the new `ops.list_browse(f, kind, opts)` helper, which consumes
`f:list_web_url(kind, scope)` and opens the result via `vim.ui.open`.
When a source has no landing page for the kind, `list_browse` warns
with `"<forge> does not support <kind> landing pages"` rather than
constructing a bogus URL. Strictly additive for existing callers.

Closes #286.
