### PR TITLE
docs(api): annotate ops, init, picker, and action public surfaces

### DIFF
--- a/lua/forge/action.lua
+++ b/lua/forge/action.lua
@@ -1,5 +1,11 @@
 local M = {}
 
+---@class forge.Action
+---@field label string?
+---@field close boolean?
+---@field fn fun(entry: forge.PickerEntry?, opts: table)
+
+---@type table<string, forge.Action>
 local actions = {}
 
 actions.open = {
@@ -21,6 +27,8 @@ actions.open = {
   end,
 }
 
+---@param name string
+---@param action forge.Action|fun(entry: forge.PickerEntry?, opts: table)
 function M.register(name, action)
   if type(action) == 'function' then
     action = { fn = action }
@@ -28,10 +36,17 @@ function M.register(name, action)
   actions[name] = action
 end
 
+---@param name string
+---@return forge.Action?
 function M.get(name)
   return actions[name]
 end
 
+---@param name string
+---@param entry forge.PickerEntry?
+---@param opts? table
+---@return boolean success
+---@return string? error
 function M.run(name, entry, opts)
   local action = actions[name]
   if not action then
@@ -41,6 +56,10 @@ function M.run(name, entry, opts)
   return true
 end
 
+---@param name string
+---@param opts? table
+---@return forge.PickerActionDef?
+---@return string? error
 function M.bind(name, opts)
   local action = actions[name]
   if not action then

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -243,6 +243,7 @@ function M.detect()
 end
 
 ---@param f forge.Forge
+---@param scope? forge.Scope
 ---@return forge.RepoInfo
 function M.repo_info(f, scope)
   local root = git_root()
@@ -293,6 +294,7 @@ function M.clear_cache()
   list_cache = {}
 end
 
+---@param range? { start_line: integer, end_line: integer }
 ---@return string
 function M.file_loc(range)
   local root = git_root()
@@ -335,6 +337,7 @@ function M.file_loc(range)
   return file
 end
 
+---@param scope? forge.Scope
 ---@return string
 function M.remote_web_url(scope)
   if scope then
@@ -353,18 +356,27 @@ function M.remote_web_url(scope)
   return remote
 end
 
+---@param name forge.ScopeKind
+---@param url string
+---@return forge.Scope?
 function M.scope_from_url(name, url)
   return scope_mod.from_url(name, url)
 end
 
+---@param scope forge.Scope?
+---@return string?
 function M.scope_repo_arg(scope)
   return scope_mod.repo_arg(scope)
 end
 
+---@param scope forge.Scope?
+---@return string
 function M.scope_key(scope)
   return scope_mod.key(scope)
 end
 
+---@param name? forge.ScopeKind
+---@return forge.Scope?
 function M.current_scope(name)
   local url = M.remote_web_url()
   if url == '' then
@@ -381,10 +393,15 @@ function M.current_scope(name)
   return scope_mod.from_url(forge_name, url)
 end
 
+---@param scope forge.Scope?
+---@return string?
 function M.remote_name(scope)
   return scope_mod.remote_name(scope)
 end
 
+---@param scope forge.Scope?
+---@param branch string
+---@return string?
 function M.remote_ref(scope, branch)
   return scope_mod.remote_ref(scope, branch)
 end
@@ -576,6 +593,8 @@ function M.edit_pr(num, ref)
   end)
 end
 
+---@param num string
+---@param ref? forge.Scope
 function M.edit_issue(num, ref)
   local log = require('forge.logger')
 
@@ -669,6 +688,7 @@ function M.create_issue(opts)
   compose_mod.open_issue(f, templates and nil or template, ref)
 end
 
+---@return string[]
 function M.template_slugs()
   local f = M.detect()
   if not f then

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -143,19 +143,25 @@ local function location_arg(location)
   return ('%s:%d-%d'):format(location.path, range.start_line, range.end_line)
 end
 
+---@param state? 'open'|'closed'|'all'
+---@param opts? forge.PickerBackOpts
 function M.pr_list(state, opts)
   require('forge').open(state and ('prs.' .. state) or 'prs', opts)
 end
 
+---@param opts? forge.CreatePROpts
 function M.pr_create(opts)
   require('forge').create_pr(opts)
 end
 
+---@param pr forge.PRRefLike
 function M.pr_edit(pr)
   pr = normalize_pr_ref(pr)
   require('forge').edit_pr(pr.num, pr.scope)
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
 function M.pr_checkout(f, pr)
   pr = normalize_pr_ref(pr)
   local kind = f.labels.pr_one
@@ -171,11 +177,15 @@ function M.pr_checkout(f, pr)
   end)
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
 function M.pr_browse(f, pr)
   pr = normalize_pr_ref(pr)
   f:view_web(f.kinds.pr, pr.num, pr.scope)
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
 function M.pr_worktree(f, pr)
   pr = normalize_pr_ref(pr)
   local kind = f.labels.pr_one
@@ -200,6 +210,9 @@ function M.pr_worktree(f, pr)
   end)
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+---@param opts? forge.PickerBackOpts
 function M.pr_ci(f, pr, opts)
   pr = normalize_pr_ref(pr)
   opts = vim.tbl_extend('force', opts or {}, { scope = pr.scope })
@@ -212,6 +225,9 @@ function M.pr_ci(f, pr, opts)
   end
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+---@param opts? forge.OpCallbacks
 function M.pr_close(f, pr, opts)
   pr = normalize_pr_ref(pr)
   run_forge_cmd(
@@ -225,6 +241,9 @@ function M.pr_close(f, pr, opts)
   )
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+---@param opts? forge.OpCallbacks
 function M.pr_reopen(f, pr, opts)
   pr = normalize_pr_ref(pr)
   run_forge_cmd(
@@ -238,6 +257,9 @@ function M.pr_reopen(f, pr, opts)
   )
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+---@param opts? forge.OpCallbacks
 function M.pr_approve(f, pr, opts)
   pr = normalize_pr_ref(pr)
   run_forge_cmd(
@@ -251,6 +273,10 @@ function M.pr_approve(f, pr, opts)
   )
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+---@param method? 'merge'|'squash'|'rebase'
+---@param opts? forge.OpCallbacks
 function M.pr_merge(f, pr, method, opts)
   pr = normalize_pr_ref(pr)
   run_forge_cmd(
@@ -264,6 +290,10 @@ function M.pr_merge(f, pr, method, opts)
   )
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+---@param is_draft boolean
+---@param opts? forge.OpCallbacks
 function M.pr_toggle_draft(f, pr, is_draft, opts)
   pr = normalize_pr_ref(pr)
   local cmd = f:draft_toggle_cmd(pr.num, is_draft, pr.scope)
@@ -281,24 +311,33 @@ function M.pr_toggle_draft(f, pr, is_draft, opts)
   )
 end
 
+---@param state? 'open'|'closed'|'all'
+---@param opts? forge.PickerBackOpts
 function M.issue_list(state, opts)
   require('forge').open(state and ('issues.' .. state) or 'issues', opts)
 end
 
+---@param opts? forge.CreateIssueOpts
 function M.issue_create(opts)
   require('forge').create_issue(opts)
 end
 
+---@param issue forge.IssueRefLike
 function M.issue_edit(issue)
   issue = normalize_issue_ref(issue)
   require('forge').edit_issue(issue.num, issue.scope)
 end
 
+---@param f forge.Forge
+---@param issue forge.IssueRefLike
 function M.issue_browse(f, issue)
   issue = normalize_issue_ref(issue)
   f:view_web(f.kinds.issue, issue.num, issue.scope)
 end
 
+---@param f forge.Forge
+---@param issue forge.IssueRefLike
+---@param opts? forge.OpCallbacks
 function M.issue_close(f, issue, opts)
   issue = normalize_issue_ref(issue)
   run_forge_cmd(
@@ -312,6 +351,9 @@ function M.issue_close(f, issue, opts)
   )
 end
 
+---@param f forge.Forge
+---@param issue forge.IssueRefLike
+---@param opts? forge.OpCallbacks
 function M.issue_reopen(f, issue, opts)
   issue = normalize_issue_ref(issue)
   run_forge_cmd(
@@ -325,11 +367,15 @@ function M.issue_reopen(f, issue, opts)
   )
 end
 
+---@param branch string?
+---@param opts? forge.PickerBackOpts
 function M.ci_list(branch, opts)
   opts = vim.tbl_extend('force', opts or {}, { branch = branch })
   require('forge').open(branch == nil and 'ci.all' or 'ci.current_branch', opts)
 end
 
+---@param f forge.Forge
+---@param run forge.RunRefLike
 function M.ci_log(f, run)
   run = normalize_run_ref(run)
   local run_ref = run.scope
@@ -440,6 +486,9 @@ function M.ci_log(f, run)
   )
 end
 
+---@param f forge.Forge
+---@param run forge.RunRefLike
+---@return boolean
 function M.ci_watch(f, run)
   run = normalize_run_ref(run)
   if not f.watch_cmd then
@@ -469,15 +518,22 @@ function M.ci_watch(f, run)
   return true
 end
 
+---@param state? 'all'|'draft'|'prerelease'
+---@param opts? forge.PickerBackOpts
 function M.release_list(state, opts)
   require('forge').open(state and ('releases.' .. state) or 'releases', opts)
 end
 
+---@param f forge.Forge
+---@param release forge.ReleaseRefLike
 function M.release_browse(f, release)
   release = normalize_release_ref(release)
   f:browse_release(release.tag, release.scope)
 end
 
+---@param f forge.Forge
+---@param release forge.ReleaseRefLike
+---@param opts? forge.OpCallbacks|{ confirm?: boolean }
 function M.release_delete(f, release, opts)
   release = normalize_release_ref(release)
   opts = opts or {}

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -13,6 +13,7 @@ local M = {}
 ---@class forge.PickerActionDef
 ---@field name string
 ---@field label string?
+---@field close boolean?
 ---@field fn fun(entry: forge.PickerEntry?)
 
 ---@class forge.PickerOpts
@@ -165,6 +166,9 @@ function M.selected(entry)
   return entry
 end
 
+---@param def forge.PickerActionDef
+---@param entry forge.PickerEntry?
+---@return boolean
 function M.closes(def, entry)
   if entry and entry.keep_open then
     return false

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -26,10 +26,24 @@
 ---@field tag string
 ---@field scope forge.Scope?
 
+---@class forge.RunRef
+---@field id string
+---@field scope forge.Scope?
+---@field status string?
+---@field url string?
+
 ---@alias forge.PRRefLike forge.PRRef|string
+---@alias forge.IssueRefLike forge.IssueRef|string
+---@alias forge.ReleaseRefLike forge.ReleaseRef|string
+---@alias forge.RunRefLike forge.RunRef|string
 
 ---@class forge.ScopedOpts
 ---@field scope forge.Scope?
+
+---@class forge.OpCallbacks
+---@field on_success fun()?
+---@field on_failure fun()?
+---@field on_cancel fun()?
 
 ---@class forge.PickerBackOpts: forge.ScopedOpts
 ---@field back fun()?
@@ -172,7 +186,7 @@
 ---@field list_runs_cmd fun(self: forge.Forge, branch: string?, scope?: forge.Scope): string
 ---@field normalize_run fun(self: forge.Forge, entry: table): forge.CIRun
 ---@field run_log_cmd fun(self: forge.Forge, id: string, failed_only: boolean, scope?: forge.Scope): string[]
----@field merge_cmd fun(self: forge.Forge, num: string, method: string, scope?: forge.Scope): string[]
+---@field merge_cmd fun(self: forge.Forge, num: string, method: string?, scope?: forge.Scope): string[]
 ---@field approve_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field repo_info fun(self: forge.Forge, scope?: forge.Scope): forge.RepoInfo
 ---@field pr_state fun(self: forge.Forge, num: string, scope?: forge.Scope): forge.PRState


### PR DESCRIPTION
## Problem

Large swaths of the public API lacked LuaCATS annotations, making it
hard for LSP-driven workflows to validate calls into `forge.ops`,
`forge.init`, `forge.picker`, and `forge.action`. The annotation pass
also exposed that `forge.Forge.merge_cmd` declared `method: string`
even though every backend already handles nil.

## Solution

Add `---@param` / `---@return` annotations to public functions across
those modules:

- `ops.lua` — the 24 entity-ops (`pr_list`, `pr_create`, `pr_edit`,
  `pr_checkout`, `pr_browse`, `pr_worktree`, `pr_ci`, `pr_close`,
  `pr_reopen`, `pr_approve`, `pr_merge`, `pr_toggle_draft`, the four
  `issue_*`, `ci_list`, `ci_log`, `ci_watch`, and the three
  `release_*`)
- `init.lua` — scope forwarders (`scope_from_url`, `scope_repo_arg`,
  `scope_key`, `current_scope`, `remote_name`, `remote_ref`), cache
  helpers (`list_key`, `repo_info`), `file_loc`, `remote_web_url`,
  `edit_issue`, and `template_slugs`
- `picker/init.lua` — `M.closes` plus a missing `close?` field on
  `forge.PickerActionDef` (already used across `pickers.lua` but not
  previously declared)
- `action.lua` — `register`/`get`/`run`/`bind` plus a new
  `forge.Action` class

Add four ref-like aliases (`forge.IssueRefLike`,
`forge.ReleaseRefLike`, `forge.RunRef`, `forge.RunRefLike`) and a
shared `forge.OpCallbacks` class to capture the common
`{ on_success, on_failure, on_cancel }` pattern. Align `merge_cmd`'s
`method` parameter with its actual nil-tolerant behavior.

No runtime change; selene, luals, vimdoc-language-server, and busted
stay green.
