### PR TITLE
refactor(pickers): remove unexposed filter_prev action

### DIFF
--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -38,7 +38,6 @@ local M = {}
 ---@field close string|false
 ---@field draft string|false
 ---@field filter string|false
----@field filter_prev string|false
 ---@field refresh string|false
 
 ---@class forge.IssuePickerKeys
@@ -47,7 +46,6 @@ local M = {}
 ---@field close string|false
 ---@field create string|false
 ---@field filter string|false
----@field filter_prev string|false
 ---@field refresh string|false
 
 ---@class forge.CIPickerKeys
@@ -55,7 +53,6 @@ local M = {}
 ---@field watch string|false
 ---@field browse string|false
 ---@field filter string|false
----@field filter_prev string|false
 ---@field failed? string|false
 ---@field passed? string|false
 ---@field running? string|false
@@ -67,7 +64,6 @@ local M = {}
 ---@field yank string|false
 ---@field delete string|false
 ---@field filter string|false
----@field filter_prev string|false
 ---@field refresh string|false
 
 ---@class forge.LogViewerKeys
@@ -148,7 +144,6 @@ local DEFAULTS = {
       close = '<c-s>',
       draft = '<c-d>',
       filter = '<tab>',
-      filter_prev = false,
       refresh = '<c-r>',
     },
     issue = {
@@ -156,7 +151,6 @@ local DEFAULTS = {
       edit = '<c-e>',
       close = '<c-s>',
       filter = '<tab>',
-      filter_prev = false,
       refresh = '<c-r>',
       create = '<c-a>',
     },
@@ -165,7 +159,6 @@ local DEFAULTS = {
       watch = '<c-w>',
       browse = '<c-x>',
       filter = '<tab>',
-      filter_prev = false,
       refresh = '<c-r>',
     },
     release = {
@@ -173,7 +166,6 @@ local DEFAULTS = {
       yank = '<c-y>',
       delete = '<c-d>',
       filter = '<tab>',
-      filter_prev = false,
       refresh = '<c-r>',
     },
     log = {
@@ -463,7 +455,6 @@ function M.config()
         'close',
         'draft',
         'filter',
-        'filter_prev',
         'refresh',
       }) do
         vim.validate('forge.keys.pr.' .. k, keys.pr[k], key_or_false, 'valid key string or false')
@@ -471,7 +462,7 @@ function M.config()
     end
     if keys.issue ~= nil then
       vim.validate('forge.keys.issue', keys.issue, 'table')
-      for _, k in ipairs({ 'browse', 'edit', 'close', 'create', 'filter', 'filter_prev', 'refresh' }) do
+      for _, k in ipairs({ 'browse', 'edit', 'close', 'create', 'filter', 'refresh' }) do
         vim.validate(
           'forge.keys.issue.' .. k,
           keys.issue[k],
@@ -487,7 +478,6 @@ function M.config()
         'watch',
         'browse',
         'filter',
-        'filter_prev',
         'failed',
         'passed',
         'running',
@@ -499,7 +489,7 @@ function M.config()
     end
     if keys.release ~= nil then
       vim.validate('forge.keys.release', keys.release, 'table')
-      for _, k in ipairs({ 'browse', 'yank', 'delete', 'filter', 'filter_prev', 'refresh' }) do
+      for _, k in ipairs({ 'browse', 'yank', 'delete', 'filter', 'refresh' }) do
         vim.validate(
           'forge.keys.release.' .. k,
           keys.release[k],

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -13,13 +13,6 @@ local next_ci_filter = {
   pending = 'all',
 }
 
-local prev_ci_filter = {
-  all = 'pending',
-  fail = 'all',
-  pass = 'fail',
-  pending = 'pass',
-}
-
 ---@param text string
 ---@return forge.PickerEntry
 local function placeholder_entry(text)
@@ -377,19 +370,6 @@ function M.checks(f, num, filter, cached_checks, opts)
       end,
     },
     {
-      name = 'filter_prev',
-      label = 'prev',
-      fn = function()
-        M.checks(
-          f,
-          num,
-          prev_ci_filter[filter] or 'all',
-          current_checks,
-          { back = opts.back, scope = ref }
-        )
-      end,
-    },
-    {
       name = 'failed',
       label = 'failed',
       fn = function()
@@ -637,18 +617,6 @@ function M.ci(f, branch, filter, opts)
       end,
     },
     {
-      name = 'filter_prev',
-      label = 'prev',
-      fn = function()
-        M.ci(
-          f,
-          branch,
-          prev_ci_filter[filter] or 'all',
-          { limit = current_limit, back = opts.back, scope = ref }
-        )
-      end,
-    },
-    {
       name = 'failed',
       label = 'failed',
       fn = function()
@@ -748,7 +716,6 @@ end
 function M.pr(state, f, opts)
   opts = opts or {}
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
-  local prev_state = ({ all = 'closed', open = 'all', closed = 'open' })[state]
   local state_label = ({ all = 'All', open = 'Open', closed = 'Closed' })[state] or state
   local forge_mod = require('forge')
   local cfg = forge_mod.config()
@@ -966,13 +933,6 @@ function M.pr(state, f, opts)
       end,
     },
     {
-      name = 'filter_prev',
-      label = 'prev',
-      fn = function()
-        M.pr(prev_state, f, { limit = current_limit, back = opts.back, scope = ref })
-      end,
-    },
-    {
       name = 'refresh',
       label = 'refresh',
       fn = function()
@@ -1058,7 +1018,6 @@ end
 function M.issue(state, f, opts)
   opts = opts or {}
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
-  local prev_state = ({ all = 'closed', open = 'all', closed = 'open' })[state]
   local state_label = ({ all = 'All', open = 'Open', closed = 'Closed' })[state] or state
   local forge_mod = require('forge')
   local cfg = forge_mod.config()
@@ -1213,13 +1172,6 @@ function M.issue(state, f, opts)
       end,
     },
     {
-      name = 'filter_prev',
-      label = 'prev',
-      fn = function()
-        M.issue(prev_state, f, { limit = current_limit, back = opts.back, scope = ref })
-      end,
-    },
-    {
       name = 'refresh',
       label = 'refresh',
       fn = function()
@@ -1348,7 +1300,6 @@ function M.release(state, f, opts)
   local cache_key = forge_mod.list_key('release', scoped_id('list', scoped_key(forge_mod, ref)))
   local rel_fields = f.release_fields
   local next_state = ({ all = 'draft', draft = 'prerelease', prerelease = 'all' })[state]
-  local prev_state = ({ all = 'prerelease', draft = 'all', prerelease = 'draft' })[state]
   local title = ({ all = 'Releases', draft = 'Draft Releases', prerelease = 'Pre-releases' })[state]
     or 'Releases'
   local live_load_more = picker.backend() == 'fzf-lua'
@@ -1498,13 +1449,6 @@ function M.release(state, f, opts)
       label = 'filter',
       fn = function()
         M.release(next_state, f, { limit = current_limit, back = opts.back, scope = ref })
-      end,
-    },
-    {
-      name = 'filter_prev',
-      label = 'prev',
-      fn = function()
-        M.release(prev_state, f, { limit = current_limit, back = opts.back, scope = ref })
       end,
     },
     {

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -108,7 +108,6 @@ describe('fzf picker', function()
         { name = 'default', label = 'more', fn = function() end },
         { name = 'browse', label = 'browse', fn = function() end },
         { name = 'filter', label = 'filter', fn = function() end },
-        { name = 'filter_prev', label = 'prev', fn = function() end },
       },
       picker_name = 'pr',
     })
@@ -187,7 +186,6 @@ describe('fzf picker', function()
         { name = 'close', label = 'close', fn = function() end },
         { name = 'create', fn = function() end },
         { name = 'filter', label = 'filter', fn = function() end },
-        { name = 'filter_prev', label = 'prev', fn = function() end },
         { name = 'refresh', fn = function() end },
       },
       picker_name = 'issue',

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -438,7 +438,6 @@ describe('pickers', function()
     assert.equals('close', labels.close)
     assert.equals('draft/ready', labels.draft)
     assert.equals('filter', labels.filter)
-    assert.equals('prev', labels.filter_prev)
     assert.equals('refresh', labels.refresh)
   end)
 
@@ -991,7 +990,6 @@ describe('pickers', function()
     assert.equals('toggle', labels.close)
     assert.equals('create', labels.create)
     assert.equals('filter', labels.filter)
-    assert.equals('prev', labels.filter_prev)
     assert.equals('refresh', labels.refresh)
   end)
 
@@ -1890,11 +1888,7 @@ describe('pickers', function()
     assert.equals('Pre-releases (1)> ', captured.prompt)
     assert.equals('v1.1.0-rc1', captured.entries[1].value.tag)
 
-    action_by_name('filter_prev').fn()
-    assert.equals('Draft Releases (1)> ', captured.prompt)
-    assert.equals('v2.0.0-draft', captured.entries[1].value.tag)
-
-    action_by_name('filter_prev').fn()
+    action_by_name('filter').fn()
     assert.equals('Releases (3)> ', captured.prompt)
     assert.equals('v1.0.0', captured.entries[1].value.tag)
 


### PR DESCRIPTION
## Problem

`filter_prev` was registered as an action across all four list pickers (pr, issue, ci, release) and exposed as a configurable key, but defaulted to `false` everywhere — so the action was unreachable under any default configuration. It was never documented, never advertised in picker headers (fzf skips actions with no binding), and nothing else referenced it. The only discoverability was reading the type fields.

## Solution

Remove the action from all five picker action tables, drop the now-dead `prev_ci_filter` table and three `local prev_state = ...` helpers, strip the four `filter_prev = false` defaults, the four validator list entries, and the four LuaCATS `---@field filter_prev` lines. Update tests accordingly — label assertions, the release filter-cycling test (now cycles forward through all three states), and the fzf header regression cases.

Users who want reverse filter cycling can still step through the same set of states by pressing `<tab>` repeatedly; removing the backward option is consistent with the earlier UX decision that led to it being bound to `false` in the first place.