### PR TITLE
fix(picker/fzf): pass only the index field to reload actions

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -370,7 +370,11 @@ function M.pick(opts)
         def.fn(entry)
       end
       if reloads then
-        fzf_actions[to_fzf_key(key)] = { fn = action_fn, reload = true }
+        fzf_actions[to_fzf_key(key)] = {
+          fn = action_fn,
+          reload = true,
+          field_index = tracked and '{3}' or '{2}',
+        }
       else
         fzf_actions[to_fzf_key(key)] = action_fn
       end
@@ -379,6 +383,8 @@ function M.pick(opts)
 
   local fzf_exec_opts = {
     fzf_args = fzf_args,
+    no_hide = true,
+    no_resume = true,
     prompt = opts.prompt or '',
     fzf_opts = {
       ['--ansi'] = '',

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -141,6 +141,28 @@ describe('fzf picker', function()
     assert.is_nil(captured.opts.fzf_opts['--header'])
   end)
 
+  it('disables fzf-lua hide and resume for forge-managed picker transitions', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Open Issues> ',
+      entries = {
+        {
+          display = { { '#7' } },
+          value = '7',
+        },
+      },
+      actions = {
+        { name = 'default', label = 'open', fn = function() end },
+        { name = 'filter', label = 'filter', fn = function() end },
+      },
+      picker_name = 'issue',
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_true(captured.opts.no_hide)
+    assert.is_true(captured.opts.no_resume)
+  end)
+
   it('binds a hidden back action without adding a header hint', function()
     local picker = require('forge.picker.fzf')
     local back_calls = 0
@@ -484,6 +506,76 @@ describe('fzf picker', function()
     assert.is_nil(captured.opts.actions['ctrl-x'].noclose)
     captured.opts.actions['ctrl-x'].fn({ '1' })
     assert.equals('42', selected.value)
+  end)
+
+  it('pins reload actions to the index field so fzf passes just that column', function()
+    local picker = require('forge.picker.fzf')
+    local invoked = 0
+    picker.pick({
+      prompt = 'CI> ',
+      entries = {
+        {
+          display = { { 'run' } },
+          value = { id = '1', status = 'in_progress' },
+        },
+      },
+      entry_source = function()
+        return {
+          {
+            display = { { 'run' } },
+            value = { id = '1', status = 'in_progress' },
+          },
+        }
+      end,
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(entry)
+            if entry then
+              invoked = invoked + 1
+            end
+          end,
+        },
+      },
+      picker_name = 'ci',
+    })
+
+    assert.is_not_nil(captured)
+    local enter = captured.opts.actions['enter']
+    assert.same('table', type(enter))
+    assert.is_true(enter.reload)
+    assert.equals('{3}', enter.field_index)
+    enter.fn({ '1' })
+    vim.wait(50, function()
+      return invoked == 1
+    end)
+    assert.equals(1, invoked)
+  end)
+
+  it('pins reload actions to field 2 on untracked pickers', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = { { '#42' } },
+          value = '42',
+        },
+      },
+      actions = {
+        {
+          name = 'browse',
+          label = 'browse',
+          close = false,
+          fn = function() end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.equals('{2}', captured.opts.actions['ctrl-x'].field_index)
   end)
 
   it('resolves selections when fzf-lua returns the full rendered row', function()


### PR DESCRIPTION
## Problem

After #300 merged, the user-reported symptoms in the CI picker:

- `<c-x>` (browse): does nothing, picker stays open.
- `<c-w>` (watch): does nothing, picker closes.
- `<cr>` (open): does nothing, picker stays open.

Root cause: the CI picker uses `entry_source`, which makes `action_reloads(def)` return true for every action. fzf-lua converts reload-mode actions into fzf-level `execute-silent(...)+reload(...)` binds via `shell.stringify_data2(fn, opts, v.field_index or "{+}")`. We never set `field_index`, so the `{+}` placeholder fires and fzf passes the full tab-delimited line to `action_fn`.

`selected_index` expects the index column to be the last tab-delimited field. That assumption held before #300 because the line layout was `track_id<TAB>text<TAB>index`. #300 appended a per-row header column (`text<TAB>index<TAB>header` untracked, `track_id<TAB>text<TAB>index<TAB>header` tracked) whenever at least one action declared a dynamic label, so the `\t(%d+)$` regex stopped matching the index and started either matching the numeric `track_id` or nothing at all. Every reload action in the CI picker dispatched with `entry = nil`, and the `def.fn` guards returned early. The different visible behaviors per key (`<c-x>` stays / `<c-w>` closes / `<cr>` stays) are just the `close` field branching; all three fail to dispatch.

## Solution

Set `field_index` on every reload-mode action to the index column: `"{3}"` when `tracked`, `"{2}"` when not. fzf now passes just the index string to `action_fn`, `selected_index` parses it correctly, and `entries[idx]` resolves the right entry. This matches what `--accept-nth` already does for non-reload actions, and works identically whether the hidden header column is present or not.

Two regression tests added in `spec/fzf_picker_spec.lua`: one on a tracked CI picker asserting `field_index == '{3}'` and a successful dispatch round-trip; one on an untracked PR picker asserting `field_index == '{2}'`. 502 busted tests pass; stylua / selene / prettier / nix fmt / lua-language-server / vimdoc-language-server clean.
