### PR TITLE
fix(picker/fzf): bugfix pass — hide/resume opt-out + reload action field index

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -370,7 +370,11 @@ function M.pick(opts)
         def.fn(entry)
       end
       if reloads then
-        fzf_actions[to_fzf_key(key)] = { fn = action_fn, reload = true }
+        fzf_actions[to_fzf_key(key)] = {
+          fn = action_fn,
+          reload = true,
+          field_index = tracked and '{3}' or '{2}',
+        }
       else
         fzf_actions[to_fzf_key(key)] = action_fn
       end

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -379,6 +379,8 @@ function M.pick(opts)
 
   local fzf_exec_opts = {
     fzf_args = fzf_args,
+    no_hide = true,
+    no_resume = true,
     prompt = opts.prompt or '',
     fzf_opts = {
       ['--ansi'] = '',

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -505,6 +505,76 @@ describe('fzf picker', function()
     assert.equals('42', selected.value)
   end)
 
+  it('pins reload actions to the index field so fzf passes just that column', function()
+    local picker = require('forge.picker.fzf')
+    local invoked = 0
+    picker.pick({
+      prompt = 'CI> ',
+      entries = {
+        {
+          display = { { 'run' } },
+          value = { id = '1', status = 'in_progress' },
+        },
+      },
+      entry_source = function()
+        return {
+          {
+            display = { { 'run' } },
+            value = { id = '1', status = 'in_progress' },
+          },
+        }
+      end,
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function(entry)
+            if entry then
+              invoked = invoked + 1
+            end
+          end,
+        },
+      },
+      picker_name = 'ci',
+    })
+
+    assert.is_not_nil(captured)
+    local enter = captured.opts.actions['enter']
+    assert.same('table', type(enter))
+    assert.is_true(enter.reload)
+    assert.equals('{3}', enter.field_index)
+    enter.fn({ '1' })
+    vim.wait(50, function()
+      return invoked == 1
+    end)
+    assert.equals(1, invoked)
+  end)
+
+  it('pins reload actions to field 2 on untracked pickers', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = { { '#42' } },
+          value = '42',
+        },
+      },
+      actions = {
+        {
+          name = 'browse',
+          label = 'browse',
+          close = false,
+          fn = function() end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.equals('{2}', captured.opts.actions['ctrl-x'].field_index)
+  end)
+
   it('resolves selections when fzf-lua returns the full rendered row', function()
     local picker = require('forge.picker.fzf')
     picker.pick({

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -91,6 +91,25 @@ describe('fzf picker', function()
     assert.equals('2', captured.opts.fzf_opts['--accept-nth'])
   end)
 
+  it('opts out of fzf-lua hide and resume so <c-c> fully exits forge pickers', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = { { '#42' } },
+          value = '42',
+        },
+      },
+      actions = {},
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_true(captured.opts.no_hide)
+    assert.is_true(captured.opts.no_resume)
+  end)
+
   it('renders headers with enter, ctrl, and tab labels without to text', function()
     local picker = require('forge.picker.fzf')
     picker.pick({


### PR DESCRIPTION
## Problem

Two picker bugs after #300:

1. `<c-c>` on a forge picker could revive an older fzf-lua session instead of cleanly exiting. fzf-lua's default hide/resume behavior keeps a stack of previously-run pickers and restores the previous one on abort, which conflicts with forge's own back-flow navigation.
2. In the CI picker (and any other picker that uses `entry_source`), every action is registered with `reload = true`. fzf-lua converts those into fzf-level `execute-silent(...)+reload(...)` binds via `shell.stringify_data2(fn, opts, v.field_index or "{+}")`. We never set `field_index`, so fzf expanded the full tab-delimited line. `selected_index` expected the last `\t(%d+)$` to be the index column — true before #300, but #300 appended a per-row header column after the index whenever a dynamic label was present, so the regex either matched the numeric `track_id` at the head or nothing at all. Every reload action (including `<cr>`, `<c-w>`, `<c-x>` in the CI picker) dispatched with `entry = nil` and silently no-oped.

## Solution

Two independent commits on this branch:

1. **`fix(picker/fzf): opt out of fzf-lua hide/resume so <c-c> fully exits`** — pass `no_hide = true` and `no_resume = true` to `fzf_exec`. Forge manages its own picker navigation (back action + picker session) so fzf-lua's hide-stack is unnecessary and actively harmful here.
2. **`fix(picker/fzf): pass only the index field to reload actions`** — set `field_index = tracked and '{3}' or '{2}'` on each reload-mode action. fzf now passes just the index column to `action_fn`, matching what `--accept-nth` already does for non-reload actions, and works identically whether or not the hidden header column is present.

Regression tests added for both: `no_hide`/`no_resume` on any forge picker, and `field_index` plus a dispatch round-trip on tracked/untracked pickers. 502 busted tests, full local CI clean (stylua / selene / prettier / nix fmt / lua-language-server / vimdoc-language-server / busted).

Supersedes #302.
