### PR TITLE
fix(picker/fzf): respect fzf-lua header highlights

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -629,8 +629,8 @@ current buffer. Lists: PRs/MRs, Issues, CI/CD, Browse, Releases. Items that
 require a forge are hidden when no forge is detected. Browse file and line
 targets require a named buffer on a branch.
 
-When using fzf-lua, picker headers use fzf-lua's `FzfLuaHeaderBind` and
-`FzfLuaHeaderText` highlight groups. Headers emphasize primary item actions;
+When using fzf-lua, picker headers follow fzf-lua's configured header bind,
+text, and info highlights. Headers emphasize primary item actions;
 list controls remain available but are not all shown. Prompts show workflow
 context, primary action, and item count. Empty data pickers render a
 placeholder row instead of appearing blank.

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -13,6 +13,17 @@ local function strip_bg_ansi(text)
   return (text:gsub('\27%[48;2;%d+;%d+;%d+m', ''):gsub('\27%[48;5;%d+m', ''))
 end
 
+local function header_hls()
+  local ok, config = pcall(require, 'fzf-lua.config')
+  local hls = ok and type(config.globals) == 'table' and config.globals.hls or nil
+  local fzf_hls = type(hls) == 'table' and hls.fzf or nil
+  return {
+    bind = type(hls) == 'table' and hls.header_bind or 'FzfLuaHeaderBind',
+    text = type(hls) == 'table' and hls.header_text or 'FzfLuaHeaderText',
+    separator = type(fzf_hls) == 'table' and fzf_hls.info or 'FzfLuaFzfInfo',
+  }
+end
+
 ---@param key string
 ---@return string
 local function to_fzf_key(key)
@@ -139,6 +150,7 @@ end
 local function render_header_for(actions, bindings, entry)
   local picker_mod = require('forge.picker')
   local utils = require('fzf-lua.utils')
+  local hls = header_hls()
   local parts = {}
   local seen_keys = {}
   for _, def in ipairs(actions) do
@@ -150,8 +162,8 @@ local function render_header_for(actions, bindings, entry)
       table.insert(
         parts,
         ('%s %s'):format(
-          utils.ansi_from_hl('FzfLuaHeaderBind', header_key),
-          utils.ansi_from_hl('FzfLuaHeaderText', label)
+          utils.ansi_from_hl(hls.bind, header_key),
+          utils.ansi_from_hl(hls.text, label)
         )
       )
     end
@@ -159,7 +171,7 @@ local function render_header_for(actions, bindings, entry)
   if #parts < 2 then
     return nil
   end
-  return table.concat(parts, '|')
+  return table.concat(parts, utils.ansi_from_hl(hls.separator, ' · '))
 end
 
 ---@param actions forge.PickerActionDef[]

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -2,11 +2,33 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 local close_calls = 0
 local ctx_clears = 0
+local fzf_config = {
+  globals = {
+    hls = {
+      header_bind = 'FzfLuaHeaderBind',
+      header_text = 'FzfLuaHeaderText',
+      fzf = {
+        info = 'FzfLuaFzfInfo',
+      },
+    },
+  },
+}
+
+package.preload['fzf-lua.config'] = function()
+  return fzf_config
+end
 
 package.preload['fzf-lua.utils'] = function()
   return {
     ansi_from_hl = function(group, text)
-      if group == 'FzfLuaHeaderBind' or group == 'FzfLuaHeaderText' then
+      if
+        group == 'FzfLuaHeaderBind'
+        or group == 'FzfLuaHeaderText'
+        or group == 'FzfLuaFzfInfo'
+        or group == 'ForgeTestHeaderBind'
+        or group == 'ForgeTestHeaderText'
+        or group == 'ForgeTestHeaderSep'
+      then
         return ('[%s:%s]'):format(group, text)
       end
       if group == 'ForgeBranch' or group == 'ForgeBranchCurrent' or group == 'ForgeMerged' then
@@ -62,7 +84,11 @@ describe('fzf picker', function()
     package.loaded['forge'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.picker.fzf'] = nil
+    package.loaded['fzf-lua.config'] = nil
     vim.g.forge = nil
+    fzf_config.globals.hls.header_bind = 'FzfLuaHeaderBind'
+    fzf_config.globals.hls.header_text = 'FzfLuaHeaderText'
+    fzf_config.globals.hls.fzf.info = 'FzfLuaFzfInfo'
   end)
 
   it('renders highlighted segments when ansi_from_hl returns extra values', function()
@@ -133,11 +159,43 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:more]|[FzfLuaHeaderBind:^X] [FzfLuaHeaderText:browse]|[FzfLuaHeaderBind:<tab>] [FzfLuaHeaderText:filter]',
+      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:more][FzfLuaFzfInfo: · ][FzfLuaHeaderBind:^X] [FzfLuaHeaderText:browse][FzfLuaFzfInfo: · ][FzfLuaHeaderBind:<tab>] [FzfLuaHeaderText:filter]',
       captured.opts.fzf_opts['--header']
     )
     assert.is_nil(captured.opts.fzf_opts['--header']:match(' to '))
     assert.is_function(captured.opts.actions.tab)
+  end)
+
+  it('uses resolved fzf-lua header highlight config for binds, labels, and separators', function()
+    fzf_config.globals.hls.header_bind = 'ForgeTestHeaderBind'
+    fzf_config.globals.hls.header_text = 'ForgeTestHeaderText'
+    fzf_config.globals.hls.fzf.info = 'ForgeTestHeaderSep'
+
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = {
+            { '#42', 'ForgeNumber' },
+            { ' fix api drift ' },
+          },
+          value = '42',
+        },
+      },
+      actions = {
+        { name = 'default', label = 'more', fn = function() end },
+        { name = 'browse', label = 'browse', fn = function() end },
+        { name = 'filter', label = 'filter', fn = function() end },
+      },
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.equals(
+      '[ForgeTestHeaderBind:<cr>] [ForgeTestHeaderText:more][ForgeTestHeaderSep: · ][ForgeTestHeaderBind:^X] [ForgeTestHeaderText:browse][ForgeTestHeaderSep: · ][ForgeTestHeaderBind:<tab>] [ForgeTestHeaderText:filter]',
+      captured.opts.fzf_opts['--header']
+    )
   end)
 
   it('suppresses headers for single-action pickers', function()
@@ -212,7 +270,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:open]|[FzfLuaHeaderBind:^S] [FzfLuaHeaderText:close]|[FzfLuaHeaderBind:<tab>] [FzfLuaHeaderText:filter]',
+      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:open][FzfLuaFzfInfo: · ][FzfLuaHeaderBind:^S] [FzfLuaHeaderText:close][FzfLuaFzfInfo: · ][FzfLuaHeaderBind:<tab>] [FzfLuaHeaderText:filter]',
       captured.opts.fzf_opts['--header']
     )
   end)


### PR DESCRIPTION
## Problem
forge picker headers hardcoded the default `FzfLuaHeaderBind` and `FzfLuaHeaderText` groups and joined action hints with raw `|` separators. That made the header styling feel harsher than native fzf-lua pickers and prevented forge from following user or theme overrides applied through fzf-lua's resolved highlight config.

## Solution
Resolve the active fzf-lua header highlight roles from `fzf-lua.config` when rendering forge picker headers, and render separators with fzf-lua's info highlight using a softer ` · ` separator. The picker specs were updated to cover the new separator treatment and verify that forge respects resolved fzf-lua header highlight configuration, and the help text was adjusted to describe the configured bind/text/info highlight behavior.