### PR TITLE
fix(pr): stop falling back from checks to repo CI

### DIFF
--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -224,10 +224,9 @@ function M.pr_ci(f, pr, opts)
   local pickers = require('forge.pickers')
   if f.capabilities.per_pr_checks then
     pickers.checks(f, pr.num, nil, nil, opts)
-  else
-    log.debug(('per-%s checks unavailable on %s, showing repo CI'):format(f.labels.pr_one, f.name))
-    pickers.ci(f, nil, nil, opts)
+    return
   end
+  log.warn(('%s does not support %s checks'):format(f.name, f.labels.pr_one))
 end
 
 ---@param f forge.Forge

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -29,6 +29,7 @@ describe('shared operations', function()
       ['forge'] = package.preload['forge'],
       ['forge.log'] = package.preload['forge.log'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.pickers'] = package.preload['forge.pickers'],
       ['forge.term'] = package.preload['forge.term'],
     }
 
@@ -103,6 +104,28 @@ describe('shared operations', function()
       }
     end
 
+    package.preload['forge.pickers'] = function()
+      return {
+        checks = function(f, num, filter, cached_checks, opts)
+          captured.checks = {
+            f = f,
+            num = num,
+            filter = filter,
+            cached_checks = cached_checks,
+            opts = opts,
+          }
+        end,
+        ci = function(f, branch, filter, opts)
+          captured.ci = {
+            f = f,
+            branch = branch,
+            filter = filter,
+            opts = opts,
+          }
+        end,
+      }
+    end
+
     package.preload['forge.term'] = function()
       return {
         open = function(cmd, opts)
@@ -124,6 +147,7 @@ describe('shared operations', function()
     package.loaded['forge.log'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
+    package.loaded['forge.pickers'] = nil
     package.loaded['forge.term'] = nil
   end)
 
@@ -136,13 +160,57 @@ describe('shared operations', function()
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.log'] = old_preload['forge.log']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.pickers'] = old_preload['forge.pickers']
     package.preload['forge.term'] = old_preload['forge.term']
 
     package.loaded['forge'] = nil
     package.loaded['forge.log'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
+    package.loaded['forge.pickers'] = nil
     package.loaded['forge.term'] = nil
+  end)
+
+  it('opens PR checks when the backend supports per-PR checks', function()
+    local ops = require('forge.ops')
+    local f = {
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = {
+        per_pr_checks = true,
+      },
+    }
+
+    ops.pr_ci(f, { num = '42', scope = 'owner/repo' }, { back = 'root' })
+
+    assert.same({
+      f = f,
+      num = '42',
+      filter = nil,
+      cached_checks = nil,
+      opts = {
+        back = 'root',
+        scope = 'owner/repo',
+      },
+    }, captured.checks)
+    assert.is_nil(captured.ci)
+    assert.same({}, captured.infos)
+  end)
+
+  it('warns instead of falling back to repo CI when per-PR checks are unsupported', function()
+    local ops = require('forge.ops')
+
+    ops.pr_ci({
+      name = 'codeberg',
+      labels = { pr_one = 'PR' },
+      capabilities = {
+        per_pr_checks = false,
+      },
+    }, { num = '42', scope = 'owner/repo' }, { back = 'root' })
+
+    assert.is_nil(captured.checks)
+    assert.is_nil(captured.ci)
+    assert.same({ 'codeberg does not support PR checks' }, captured.infos)
   end)
 
   it('runs PR close commands and success callbacks through the shared operation', function()


### PR DESCRIPTION
## Problem
When a backend does not support per-PR checks, the PR \`ci\` action silently falls back to the repo-wide CI picker. That changes the scope of the user's request from PR-specific status to repository-wide runs, which is misleading and effectively incorrect behavior.

## Solution
Keep the existing PR checks path for backends that support per-PR checks, and otherwise warn visibly that PR checks are unsupported instead of opening repo CI. Add focused ops coverage for both the supported and unsupported paths.