### PR TITLE
refactor: drop legacy backend wrapper shims

### DIFF
--- a/lua/forge/codeberg.lua
+++ b/lua/forge/codeberg.lua
@@ -1,1 +1,0 @@
-return require('forge.backends.codeberg')

--- a/lua/forge/github.lua
+++ b/lua/forge/github.lua
@@ -1,1 +1,0 @@
-return require('forge.backends.github')

--- a/lua/forge/gitlab.lua
+++ b/lua/forge/gitlab.lua
@@ -1,1 +1,0 @@
-return require('forge.backends.gitlab')

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -174,9 +174,6 @@ local function resolve_source(name)
     return sources[name]
   end
   local ok, mod = pcall(require, 'forge.backends.' .. name)
-  if not ok then
-    ok, mod = pcall(require, 'forge.' .. name)
-  end
   if ok then
     sources[name] = mod
     return mod


### PR DESCRIPTION
## Problem
The built-in forge backends were moved under `lua/forge/backends`, but the old top-level backend modules remained as one-line compatibility wrappers and `resolve_source()` still fell back to those legacy paths. The repo no longer uses the old module names internally, so the extra wrappers and fallback keep obsolete compatibility code alive without serving current in-tree callers.

## Solution
Remove the three legacy wrapper modules and resolve built-in sources only from `forge.backends.*`. Keep the change narrow to the built-in backend loader path and verify it against the source, init, and compose/edit/submission specs that exercise backend loading.