### PR TITLE
refactor: drop bang semantics and y/N prompts

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -14,7 +14,6 @@ CONTENTS                                                 *forge.nvim-contents*
     Target modifiers and defaults......................|forge-target-defaults|
     Command completion..............................|forge-command-completion|
     Syntax and compatibility...................|forge-command-compatibility|
-    Bang semantics............................................|forge-command-bang|
     PR commands..........................................|forge-pr-commands|
     Issue commands....................................|forge-issue-commands|
     CI commands..........................................|forge-ci-commands|
@@ -102,23 +101,6 @@ Top-level keys: ~
   `string`  (default `"horizontal"`)
     Default split direction for terminal views. One of `"horizontal"` or
     `"vertical"`. Individual scopes (e.g. `ci.split`) override this value.
-
-`confirm`                                               *forge-config-confirm*
-  `table`  (default shown below)
-    Confirmation settings for destructive picker actions.
-
-  Defaults: >lua
-      confirm = {
-        branch_delete = true,
-        worktree_delete = true,
-      }
-<
-
-  `branch_delete`   `boolean`  (default `true`)
-    Ask for confirmation before deleting a branch from the branch picker.
-
-  `worktree_delete` `boolean`  (default `true`)
-    Ask for confirmation before deleting a worktree from the worktree picker.
 
 `ci`                                                         *forge-config-ci*
   `ci.lines`        `integer`  (default `1000`)
@@ -376,14 +358,6 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     This includes list navigation, list-scoped filters/refresh, nested per-PR
     checks, and copy helpers.
 
-BANG SEMANTICS                                            *forge-command-bang*
-    `!` is only accepted on mutating commands with an explicit force variant:
-    - `:Forge! pr close`
-    - `:Forge! issue close`
-    - `:Forge! release delete`
-
-    All other `!` forms fail with `E477: No ! allowed`.
-
 PR COMMANDS                                            *forge-pr-commands*
 
 `:Forge pr create` [repo=...] [head=...] [base=...] [draft] [fill] [web]
@@ -485,7 +459,7 @@ RELEASE COMMANDS                                  *forge-release-commands*
     page when `{tag}` is omitted.
 
 `:Forge release delete` {tag} [repo=...]               *:Forge-release-delete*
-    Delete release `{tag}` (with confirmation prompt).
+    Delete release `{tag}`.
 
 BROWSE COMMANDS                                    *forge-browse-commands*
 
@@ -702,8 +676,7 @@ interval.
   `toggle`      `<c-s>`          Cancel the highlighted run when in progress,
                                rerun it when completed; the header hint
                                reflects the current status of the row. No-op
-                               on skipped runs. Cancellation prompts for
-                               confirmation. GitHub uses `gh run
+                               on skipped runs. GitHub uses `gh run
                                {cancel,rerun}`; GitLab uses `glab ci cancel
                                pipeline` for cancel and `glab api ... /retry`
                                for rerun (retries failed and cancelled jobs
@@ -722,7 +695,7 @@ prerelease badges are shown for forges that support them (GitHub, Codeberg).
   Action      Default Key    Description ~
   `browse`      `<cr>`           Open release in browser
   `yank`        `<c-y>`          Copy release URL to `+` register
-  `delete`      `<c-d>`          Delete release (with confirmation)
+  `delete`      `<c-d>`          Delete release
   `filter`      `<tab>`          Cycle filter: all -> draft -> prerelease
   `refresh`     `<c-r>`          Clear cache and re-fetch
 
@@ -1733,15 +1706,13 @@ a bare id (`num`, `id`, or `tag`) or a normalized table with `scope` and
 
                                                        *forge.ops.ci_cancel()*
 `ci_cancel(f, run, opts?)`
-    Cancels run `run`. Prompts for confirmation unless `opts.confirm == false`.
-    Logs a warning and invokes `opts.on_failure` when the backend does not
-    define `cancel_run_cmd`.
+    Cancels run `run`. Logs a warning and invokes `opts.on_failure` when
+    the backend does not define `cancel_run_cmd`.
 
                                                         *forge.ops.ci_rerun()*
 `ci_rerun(f, run, opts?)`
-    Reruns completed run `run`. No confirmation prompt. Logs a warning and
-    invokes `opts.on_failure` when the backend does not define
-    `rerun_run_cmd`.
+    Reruns completed run `run`. Logs a warning and invokes `opts.on_failure`
+    when the backend does not define `rerun_run_cmd`.
 
                                                        *forge.ops.ci_toggle()*
 `ci_toggle(f, run, opts?)`
@@ -1759,7 +1730,7 @@ a bare id (`num`, `id`, or `tag`) or a normalized table with `scope` and
 
                                                   *forge.ops.release_delete()*
 `release_delete(f, release, opts?)`
-    Deletes `release`. `opts`: `{ confirm?, on_success?, on_failure? }`.
+    Deletes `release`. `opts`: `{ on_success?, on_failure? }`.
 
                                                      *forge.ops.list_browse()*
 `list_browse(f, kind, opts?)`

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -59,7 +59,6 @@ local families = {
         modifiers = { 'repo' },
       },
       close = {
-        bang = true,
         subject = { kind = 'pr', min = 1, max = 1 },
         modifiers = { 'repo' },
       },
@@ -103,7 +102,6 @@ local families = {
         modifiers = { 'repo' },
       },
       close = {
-        bang = true,
         subject = { kind = 'issue', min = 1, max = 1 },
         modifiers = { 'repo' },
       },
@@ -154,7 +152,6 @@ local families = {
         modifiers = { 'repo' },
       },
       delete = {
-        bang = true,
         subject = { kind = 'release', min = 1, max = 1 },
         modifiers = { 'repo' },
       },
@@ -544,7 +541,7 @@ local function dispatch_release(command)
     return
   end
   if command.name == 'delete' then
-    ops.release_delete(f, { tag = tag, scope = scope }, { confirm = not command.bang })
+    ops.release_delete(f, { tag = tag, scope = scope })
     return
   end
 end
@@ -678,11 +675,6 @@ function M.legacy_modifier_names(family_name, verb_name)
   return copy(command.legacy_modifiers or {})
 end
 
-function M.supports_bang(family_name, verb_name)
-  local command = M.resolve(family_name, verb_name)
-  return command ~= nil and command.bang == true
-end
-
 function M.parse(args, opts)
   opts = opts or {}
   if type(args) ~= 'table' or #args == 0 or args[1] == '' then
@@ -713,11 +705,6 @@ function M.parse(args, opts)
       return error_result(unknown_verb_error(family_name, verb_token))
     end
     return error_result(missing_verb_error(family_name))
-  end
-
-  command.bang = opts.bang == true
-  if command.bang and not M.supports_bang(command.family, command.name) then
-    return error_result('E477: No ! allowed', { code = 'E477' })
   end
 
   command.subjects = {}
@@ -841,11 +828,9 @@ function M.run(opts)
     return false
   end
 
-  local command, err = M.parse(split_words(opts.args), { bang = opts.bang })
+  local command, err = M.parse(split_words(opts.args))
   if not command then
-    if err and err.code == 'E477' then
-      vim.api.nvim_err_writeln(err.message)
-    elseif err and err.message then
+    if err and err.message then
       warn(err.message)
     end
     return false

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -546,7 +546,7 @@ end
 
 ---@param f forge.Forge
 ---@param run forge.RunRefLike
----@param opts? forge.OpCallbacks|{ confirm?: boolean }
+---@param opts? forge.OpCallbacks
 function M.ci_cancel(f, run, opts)
   run = normalize_run_ref(run)
   opts = opts or {}
@@ -557,30 +557,15 @@ function M.ci_cancel(f, run, opts)
     end
     return
   end
-  local function do_cancel()
-    run_forge_cmd(
-      'run',
-      run.id,
-      'cancelling',
-      f:cancel_run_cmd(run.id, run.scope),
-      'cancelled',
-      'cancel failed',
-      opts
-    )
-  end
-  if opts.confirm == false then
-    do_cancel()
-    return
-  end
-  vim.ui.select({ 'Yes', 'No' }, {
-    prompt = 'Cancel run #' .. run.id .. '? ',
-  }, function(choice)
-    if choice == 'Yes' then
-      do_cancel()
-    elseif opts.on_cancel then
-      opts.on_cancel()
-    end
-  end)
+  run_forge_cmd(
+    'run',
+    run.id,
+    'cancelling',
+    f:cancel_run_cmd(run.id, run.scope),
+    'cancelled',
+    'cancel failed',
+    opts
+  )
 end
 
 ---@param f forge.Forge
@@ -609,7 +594,7 @@ end
 
 ---@param f forge.Forge
 ---@param run forge.RunRefLike
----@param opts? forge.OpCallbacks|{ confirm?: boolean }
+---@param opts? forge.OpCallbacks
 function M.ci_toggle(f, run, opts)
   run = normalize_run_ref(run)
   opts = opts or {}
@@ -643,34 +628,19 @@ end
 
 ---@param f forge.Forge
 ---@param release forge.ReleaseRefLike
----@param opts? forge.OpCallbacks|{ confirm?: boolean }
+---@param opts? forge.OpCallbacks
 function M.release_delete(f, release, opts)
   release = normalize_release_ref(release)
   opts = opts or {}
-  local function do_delete()
-    run_forge_cmd(
-      'release',
-      release.tag,
-      'deleting',
-      f:delete_release_cmd(release.tag, release.scope),
-      'deleted',
-      'delete failed',
-      opts
-    )
-  end
-  if opts.confirm == false then
-    do_delete()
-    return
-  end
-  vim.ui.select({ 'Yes', 'No' }, {
-    prompt = 'Delete release ' .. release.tag .. '? ',
-  }, function(choice)
-    if choice == 'Yes' then
-      do_delete()
-    elseif opts.on_cancel then
-      opts.on_cancel()
-    end
-  end)
+  run_forge_cmd(
+    'release',
+    release.tag,
+    'deleting',
+    f:delete_release_cmd(release.tag, release.scope),
+    'deleted',
+    'delete failed',
+    opts
+  )
 end
 
 ---@param f forge.Forge

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1424,9 +1424,6 @@ function M.release(state, f, opts)
         ops.release_delete(f, entry.value, {
           on_success = reopen_list,
           on_failure = reopen_list,
-          on_cancel = function()
-            M.release(state, f, { limit = current_limit, back = opts.back, scope = ref })
-          end,
         })
       end,
     },

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -43,7 +43,6 @@
 ---@class forge.OpCallbacks
 ---@field on_success fun()?
 ---@field on_failure fun()?
----@field on_cancel fun()?
 
 ---@class forge.PickerBackOpts: forge.ScopedOpts
 ---@field back fun()?

--- a/plugin/forge.lua
+++ b/plugin/forge.lua
@@ -46,7 +46,6 @@ end
 vim.api.nvim_create_user_command('Forge', function(opts)
   require('forge.cmd').run(opts)
 end, {
-  bang = true,
   bar = true,
   nargs = '*',
   range = true,

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -176,15 +176,6 @@ describe('command schema', function()
     assert.equals('owner/upstream', create.default_targets.base.repo.slug)
   end)
 
-  it('tracks the intended bang matrix', function()
-    assert.is_true(cmd.supports_bang('pr', 'close'))
-    assert.is_true(cmd.supports_bang('issue', 'close'))
-    assert.is_true(cmd.supports_bang('release', 'delete'))
-    assert.is_false(cmd.supports_bang('pr', 'reopen'))
-    assert.is_false(cmd.supports_bang('ci', 'watch'))
-    assert.is_false(cmd.supports_bang('browse'))
-  end)
-
   it('exposes per-verb modifiers for canonical operations', function()
     assert.same(
       { 'repo', 'head', 'base', 'draft', 'fill', 'web' },
@@ -225,13 +216,6 @@ describe('command schema', function()
     local method = cmd.modifier('method')
 
     assert.same({ 'merge', 'squash', 'rebase' }, method.values)
-  end)
-
-  it('rejects unsupported bang before dispatch', function()
-    local _, err = cmd.parse({ 'pr', 'checkout', '42' }, { bang = true })
-
-    assert.equals('E477', err.code)
-    assert.equals('E477: No ! allowed', err.message)
   end)
 
   it('rejects invalid modifiers and duplicate modifiers', function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -704,22 +704,6 @@ describe(':Forge command', function()
     assert.is_nil(captured.opens[1])
   end)
 
-  it('rejects unsupported bang with E477 and no side effects', function()
-    local ok, err = pcall(vim.cmd, 'Forge! pr checkout 42')
-
-    assert.is_false(ok)
-    assert.matches('E477: No ! allowed', err)
-    assert.is_nil(captured.ops_calls[1])
-  end)
-
-  it('allows supported bang on close subcommands', function()
-    vim.cmd('Forge! pr close 42')
-    vim.cmd('Forge! issue close 9')
-
-    assert.same({ name = 'pr_close', pr = { num = '42', scope = nil } }, captured.ops_calls[1])
-    assert.same({ name = 'issue_close', issue = { num = '9', scope = nil } }, captured.ops_calls[2])
-  end)
-
   it('dispatches PR management parity subcommands through forge.ops', function()
     for _, case in ipairs({
       {

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -262,7 +262,7 @@ describe('shared operations', function()
     assert.equals(1, done)
   end)
 
-  it('confirms release deletion before running the shared delete operation', function()
+  it('runs the shared delete operation when deleting a release', function()
     local done = 0
     local ops = require('forge.ops')
     ops.release_delete({
@@ -283,7 +283,7 @@ describe('shared operations', function()
     assert.equals(1, done)
   end)
 
-  it('confirms CI run cancellation before invoking the backend command', function()
+  it('invokes the backend command when cancelling a CI run', function()
     local done = 0
     local ops = require('forge.ops')
     ops.ci_cancel({
@@ -303,27 +303,6 @@ describe('shared operations', function()
 
     assert.same({ 'cancel 77 repo/ref' }, captured.commands)
     assert.equals(1, done)
-  end)
-
-  it('skips cancellation when the user declines the confirmation', function()
-    local cancelled = 0
-    vim.ui.select = function(_, _, cb)
-      cb('No')
-    end
-    local ops = require('forge.ops')
-    ops.ci_cancel({
-      name = 'github',
-      cancel_run_cmd = function(_, id)
-        return { 'cancel', id }
-      end,
-    }, { id = '77', status = 'running' }, {
-      on_cancel = function()
-        cancelled = cancelled + 1
-      end,
-    })
-
-    assert.same({}, captured.commands)
-    assert.equals(1, cancelled)
   end)
 
   it('reports when a backend cannot cancel runs', function()


### PR DESCRIPTION
## Problem

`:Forge!` on close/delete was partly wired: bang was accepted syntactically on `pr close`, `issue close`, and `release delete`, but only `release delete` actually consumed it (to skip a `vim.ui.select` confirmation). The two y/N prompts (in `ops.release_delete` and `ops.ci_cancel`) left the destructive-mutation surface inconsistent, and the `confirm.branch_delete` / `confirm.worktree_delete` config keys were documented but never referenced by any code.

## Solution

Drop all bang handling and both y/N prompts so every destructive `:Forge` verb and ops entrypoint executes immediately and uniformly.

- `lua/forge/cmd.lua`: remove `bang = true` from `pr close`, `issue close`, `release delete`; delete `supports_bang`, the `command.bang` parse step, and the `E477` error path
- `lua/forge/ops.lua`: `release_delete` and `ci_cancel` no longer wrap execution in a `vim.ui.select` Yes/No prompt; `opts.confirm` and `opts.on_cancel` are gone
- `lua/forge/pickers.lua`: drop the now-dead `on_cancel` callback on the release delete action
- `lua/forge/types.lua`: drop `forge.OpCallbacks.on_cancel`
- `plugin/forge.lua`: drop `bang = true` on the `:Forge` user command
- `doc/forge.nvim.txt`: remove `BANG SEMANTICS` section + TOC entry, remove the unimplemented `confirm` config block, drop "with confirmation" notes on `:Forge release delete`, the release picker, and the CI toggle, and drop "Prompts for confirmation" from the `ci_cancel` API docs
- Specs: drop the `supports_bang` / E477 tests, rename the confirm-flavored ops tests, and drop the "user declines" test