### PR TITLE
fix(picker): centralize action availability

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -349,6 +349,9 @@ function M.pick(opts)
       local reloads = action_reloads(def)
       local action_fn = function(selected)
         if not selected[1] then
+          if not picker_mod.available(def, nil) then
+            return
+          end
           if reloads and picker_mod.closes(def) then
             local utils = require('fzf-lua.utils')
             local win = type(utils.fzf_winobj) == 'function' and utils.fzf_winobj() or nil
@@ -368,6 +371,9 @@ function M.pick(opts)
         end
         local idx = selected_index(selected[1])
         local entry = picker_mod.selected(idx and entries[idx] or nil)
+        if not picker_mod.available(def, entry) then
+          return
+        end
         if reloads and entry and rawget(entry, 'load_more') and tracked and idx then
           track_redirect = {
             source_id = track_id(entry, idx),

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -11,10 +11,12 @@ local M = {}
 ---@field force_close boolean?
 
 ---@alias forge.PickerActionLabel string|fun(entry: forge.PickerEntry?): string?
+---@alias forge.PickerActionAvailability boolean|fun(entry: forge.PickerEntry?): boolean?
 
 ---@class forge.PickerActionDef
 ---@field name string
 ---@field label forge.PickerActionLabel?
+---@field available forge.PickerActionAvailability?
 ---@field close boolean?
 ---@field reload boolean?
 ---@field fn fun(entry: forge.PickerEntry?)
@@ -183,8 +185,26 @@ end
 
 ---@param def forge.PickerActionDef
 ---@param entry forge.PickerEntry?
+---@return boolean
+function M.available(def, entry)
+  local available = rawget(def, 'available')
+  if type(available) == 'function' then
+    local ok, result = pcall(available, entry)
+    return ok and result ~= false
+  end
+  if available ~= nil then
+    return available ~= false
+  end
+  return true
+end
+
+---@param def forge.PickerActionDef
+---@param entry forge.PickerEntry?
 ---@return string?
 function M.resolve_label(def, entry)
+  if not M.available(def, entry) then
+    return nil
+  end
   local label = rawget(def, 'label')
   if type(label) == 'function' then
     local ok, result = pcall(label, entry)
@@ -202,7 +222,7 @@ end
 ---@param def forge.PickerActionDef
 ---@return boolean
 function M.has_dynamic_label(def)
-  return type(rawget(def, 'label')) == 'function'
+  return type(rawget(def, 'label')) == 'function' or type(rawget(def, 'available')) == 'function'
 end
 
 ---@param entry forge.PickerEntry?

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -290,6 +290,50 @@ describe('fzf picker', function()
     assert.equals(1, back_calls)
   end)
 
+  it('skips unavailable actions without closing the picker', function()
+    local picker = require('forge.picker.fzf')
+    local calls = 0
+    picker.pick({
+      prompt = 'PRs> ',
+      entries = {
+        {
+          display = { { '#42' } },
+          value = { num = '42', state = 'OPEN' },
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = 'open',
+          fn = function()
+            calls = calls + 1
+          end,
+        },
+        {
+          name = 'browse',
+          label = 'browse',
+          available = function()
+            return false
+          end,
+          fn = function()
+            calls = calls + 10
+          end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.is_nil(captured.opts.fzf_opts['--header'])
+    assert.is_function(captured.opts.actions['ctrl-x'])
+
+    captured.opts.actions['ctrl-x']({ '1' })
+
+    assert.equals(0, calls)
+    assert.equals(0, close_calls)
+    assert.equals(0, ctx_clears)
+  end)
+
   it('renders the issue filter hint when the action is labeled', function()
     local picker = require('forge.picker.fzf')
     picker.pick({

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -33,10 +33,16 @@ end
 
 function M.action_labels(actions, entry)
   local labels = {}
+  local ok, picker = pcall(require, 'forge.picker')
   for _, def in ipairs(actions or {}) do
-    local label = def.label
-    if type(label) == 'function' then
-      label = label(entry)
+    local label
+    if ok and type(picker.resolve_label) == 'function' then
+      label = picker.resolve_label(def, entry)
+    else
+      label = def.label
+      if type(label) == 'function' then
+        label = label(entry)
+      end
     end
     labels[def.name] = label
   end

--- a/spec/picker_init_spec.lua
+++ b/spec/picker_init_spec.lua
@@ -121,6 +121,18 @@ describe('forge.picker.resolve_label', function()
     assert.equals('merge', picker.resolve_label({ name = 'merge', label = 'merge' }))
   end)
 
+  it('hides labels when the action is unavailable', function()
+    local def = {
+      name = 'merge',
+      label = 'merge',
+      available = function()
+        return false
+      end,
+    }
+
+    assert.is_nil(picker.resolve_label(def, { value = { state = 'OPEN' } }))
+  end)
+
   it('invokes function labels with the entry', function()
     local captured
     local def = {
@@ -145,9 +157,40 @@ describe('forge.picker.resolve_label', function()
     assert.is_nil(picker.resolve_label(def, nil))
   end)
 
+  it('treats availability function failures as unavailable', function()
+    local def = {
+      name = 'toggle',
+      label = 'close',
+      available = function()
+        error('boom')
+      end,
+    }
+
+    assert.is_nil(picker.resolve_label(def, nil))
+    assert.is_false(picker.available(def, nil))
+  end)
+
+  it('resolves static and dynamic availability', function()
+    assert.is_true(picker.available({ name = 'a' }, nil))
+    assert.is_false(picker.available({ name = 'b', available = false }, nil))
+    assert.is_true(picker.available({
+      name = 'c',
+      available = function(entry)
+        return entry ~= nil
+      end,
+    }, { value = 1 }))
+    assert.is_false(picker.available({
+      name = 'd',
+      available = function(entry)
+        return entry ~= nil
+      end,
+    }, nil))
+  end)
+
   it('reports dynamic labels', function()
     assert.is_true(picker.has_dynamic_label({ name = 'a', label = function() end }))
     assert.is_false(picker.has_dynamic_label({ name = 'b', label = 'static' }))
-    assert.is_false(picker.has_dynamic_label({ name = 'c' }))
+    assert.is_true(picker.has_dynamic_label({ name = 'c', available = function() end }))
+    assert.is_false(picker.has_dynamic_label({ name = 'd' }))
   end)
 end)


### PR DESCRIPTION
## Problem

Picker actions can currently hide their labels without becoming truly unavailable. That lets the header drift from the actual executable action surface and makes future conditional-action work harder to share across pickers and command completion.

## Solution

Add explicit picker action availability resolution, make labels availability-aware, and have the fzf picker refuse unavailable actions at dispatch time. The picker specs now cover both the availability helpers and the execution path so later per-surface gating can build on one consistent mechanism.
