### PR TITLE
fix(picker): cache pr details for action gating

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -35,6 +35,9 @@ local forge_cache = {}
 ---@type table<string, forge.RepoInfo>
 local repo_info_cache = {}
 
+---@type table<string, forge.PRState>
+local pr_state_cache = {}
+
 ---@type table<string, string>
 local root_cache = {}
 
@@ -255,6 +258,47 @@ function M.repo_info(f, scope)
   return info
 end
 
+---@param f forge.Forge
+---@param num string
+---@param scope? forge.Scope
+---@return forge.PRState
+function M.pr_state(f, num, scope)
+  local root = git_root()
+  local key = root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
+  if key and pr_state_cache[key] then
+    return pr_state_cache[key]
+  end
+  local state = f:pr_state(num, scope)
+  if key then
+    pr_state_cache[key] = state
+  end
+  return state
+end
+
+---@param num? string
+---@param scope? forge.Scope
+function M.clear_pr_state(num, scope)
+  local root = git_root()
+  if not root then
+    pr_state_cache = {}
+    return
+  end
+  if num ~= nil then
+    pr_state_cache[root .. '|' .. scope_mod.key(scope) .. '|' .. num] = nil
+    return
+  end
+  if scope ~= nil then
+    local prefix = root .. '|' .. scope_mod.key(scope) .. '|'
+    for key in pairs(pr_state_cache) do
+      if key:sub(1, #prefix) == prefix then
+        pr_state_cache[key] = nil
+      end
+    end
+    return
+  end
+  pr_state_cache = {}
+end
+
 ---@param kind string
 ---@param state string
 ---@return string
@@ -287,6 +331,7 @@ end
 function M.clear_cache()
   forge_cache = {}
   repo_info_cache = {}
+  pr_state_cache = {}
   root_cache = {}
   list_cache = {}
 end

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -211,7 +211,7 @@ local function pr_toggle_draft_action(f, pr, opts)
   opts = opts or {}
   local is_draft = rawget(pr, 'is_draft')
   if is_draft == nil then
-    local pr_state = f:pr_state(pr.num, pr.scope)
+    local pr_state = require('forge').pr_state(f, pr.num, pr.scope)
     is_draft = pr_state.is_draft == true
   end
   ops.pr_toggle_draft(f, pr, is_draft, opts)
@@ -831,11 +831,50 @@ function M.pr(state, f, opts)
 
   local function reopen_list()
     clear_state_caches(forge_mod, 'pr', scoped_key(forge_mod, ref))
+    forge_mod.clear_pr_state(nil, ref)
     M.pr(state, f, { limit = current_limit, back = opts.back, scope = ref })
   end
 
   local function back_to_list()
     M.pr(state, f, { limit = current_limit, back = opts.back, scope = ref })
+  end
+
+  local function current_pr_state(entry)
+    if not actionable_entry(entry) then
+      return nil
+    end
+    return forge_mod.pr_state(f, entry.value.num, entry.value.scope)
+  end
+
+  local function merge_permission(info)
+    local permission = ((info or {}).permission or ''):upper()
+    return permission == 'WRITE' or permission == 'ADMIN' or permission == 'MAINTAIN'
+  end
+
+  local function pr_approve_entry(entry)
+    if not pr_open_entry(entry) then
+      return false
+    end
+    local pr_state = current_pr_state(entry)
+    return pr_state == nil or (pr_state.review_decision or ''):upper() ~= 'APPROVED'
+  end
+
+  local function pr_merge_entry(entry)
+    if not pr_open_entry(entry) then
+      return false
+    end
+    local pr_state = current_pr_state(entry)
+    if pr_state and pr_state.is_draft then
+      return false
+    end
+    local info = forge_mod.repo_info(f, entry.value.scope)
+    return merge_permission(info)
+      and type((info or {}).merge_methods) == 'table'
+      and #info.merge_methods > 0
+  end
+
+  local function pr_draft_entry(entry)
+    return f.capabilities.draft and pr_open_entry(entry)
   end
 
   local actions = {
@@ -893,7 +932,7 @@ function M.pr(state, f, opts)
     {
       name = 'approve',
       label = 'approve',
-      available = pr_open_entry,
+      available = pr_approve_entry,
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_approve(f, entry.value, {
@@ -906,7 +945,7 @@ function M.pr(state, f, opts)
     {
       name = 'merge',
       label = 'merge',
-      available = pr_open_entry,
+      available = pr_merge_entry,
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_merge(f, entry.value, nil, {
@@ -947,10 +986,17 @@ function M.pr(state, f, opts)
     },
     {
       name = 'draft',
-      label = 'draft/ready',
-      available = function(entry)
-        return f.capabilities.draft and pr_open_entry(entry)
+      label = function(entry)
+        if entry == nil then
+          return 'draft/ready'
+        end
+        local pr_state = current_pr_state(entry)
+        if pr_state and pr_state.is_draft then
+          return 'ready'
+        end
+        return 'draft'
       end,
+      available = pr_draft_entry,
       fn = function(entry)
         if entry and not entry.load_more and f.capabilities.draft then
           pr_toggle_draft_action(f, entry.value, {
@@ -974,6 +1020,7 @@ function M.pr(state, f, opts)
       reload = false,
       fn = function()
         clear_state_caches(forge_mod, 'pr', scoped_key(forge_mod, ref))
+        forge_mod.clear_pr_state(nil, ref)
         M.pr(state, f, { limit = current_limit, back = opts.back, scope = ref })
       end,
     },

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -136,6 +136,71 @@ describe('file_loc', function()
   end)
 end)
 
+describe('pr_state cache', function()
+  after_each(function()
+    forge.clear_cache()
+  end)
+
+  it('caches PR state lookups per repo, scope, and number', function()
+    local calls = 0
+    local fake = {
+      pr_state = function(_, num, scope)
+        calls = calls + 1
+        return {
+          state = 'OPEN',
+          mergeable = 'UNKNOWN',
+          review_decision = num .. '|' .. (scope and scope.slug or ''),
+          is_draft = false,
+        }
+      end,
+    }
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'barrettruth/forge.nvim',
+    }
+
+    local first = forge.pr_state(fake, '42', scope)
+    local second = forge.pr_state(fake, '42', scope)
+
+    assert.equals(1, calls)
+    assert.same(first, second)
+  end)
+
+  it('clears scoped PR state entries without touching other scopes', function()
+    local calls = 0
+    local fake = {
+      pr_state = function(_, num, scope)
+        calls = calls + 1
+        return {
+          state = 'OPEN',
+          mergeable = 'UNKNOWN',
+          review_decision = num .. '|' .. (scope and scope.slug or ''),
+          is_draft = false,
+        }
+      end,
+    }
+    local left = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'barrettruth/forge.nvim',
+    }
+    local right = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'barrettruth/example.nvim',
+    }
+
+    forge.pr_state(fake, '42', left)
+    forge.pr_state(fake, '42', right)
+    forge.clear_pr_state(nil, left)
+    forge.pr_state(fake, '42', left)
+    forge.pr_state(fake, '42', right)
+
+    assert.equals(3, calls)
+  end)
+end)
+
 describe('format_pr', function()
   local fields = {
     number = 'number',

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -28,11 +28,12 @@ local loaded_modules = {
   'forge.pickers',
 }
 
-local function fake_forge()
+local function fake_forge(opts)
+  opts = opts or {}
   return {
     labels = { pr = 'PRs', pr_one = 'PR' },
     kinds = { pr = 'pull_request' },
-    capabilities = { draft = true },
+    capabilities = opts.capabilities or { draft = true },
     pr_fields = {
       number = 'number',
       title = 'title',
@@ -40,15 +41,27 @@ local function fake_forge()
       author = 'author',
       created_at = 'created_at',
     },
-    repo_info = function()
-      return {
-        permission = 'WRITE',
-        merge_methods = { 'merge' },
-      }
+    repo_info = function(_, scope)
+      if type(opts.repo_info) == 'function' then
+        return opts.repo_info(scope)
+      end
+      return opts.repo_info
+        or {
+          permission = 'WRITE',
+          merge_methods = { 'merge' },
+        }
     end,
-    pr_state = function()
+    pr_state = function(_, num, scope)
+      if type(opts.pr_state) == 'function' then
+        return opts.pr_state(num, scope)
+      end
+      if type(opts.pr_states) == 'table' and opts.pr_states[num] then
+        return opts.pr_states[num]
+      end
       return {
         state = 'OPEN',
+        mergeable = 'UNKNOWN',
+        review_decision = '',
         is_draft = false,
       }
     end,
@@ -481,6 +494,10 @@ describe('pickers', function()
         repo_info = function(f)
           return f:repo_info()
         end,
+        pr_state = function(f, num, scope)
+          return f:pr_state(num, scope)
+        end,
+        clear_pr_state = function() end,
         create_issue = function(...)
           issue_create_calls = issue_create_calls + 1
           issue_create_opts = select(1, ...)
@@ -526,7 +543,7 @@ describe('pickers', function()
     assert.equals('merge', labels.merge)
     assert.equals('create', labels.create)
     assert.equals('close', labels.toggle)
-    assert.equals('draft/ready', labels.draft)
+    assert.equals('draft', labels.draft)
     assert.equals('filter', labels.filter)
     assert.equals('refresh', labels.refresh)
   end)
@@ -554,6 +571,73 @@ describe('pickers', function()
     assert.is_nil(merged_labels.merge)
     assert.is_nil(merged_labels.toggle)
     assert.is_nil(merged_labels.draft)
+  end)
+
+  it('uses cached PR details to tighten approve, merge, and draft labels', function()
+    cache['pr:open'] = {
+      {
+        number = 42,
+        title = 'Already approved',
+        state = 'OPEN',
+        author = 'alice',
+        created_at = '',
+      },
+      { number = 41, title = 'Draft PR', state = 'OPEN', author = 'bob', created_at = '' },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.pr(
+      'open',
+      fake_forge({
+        pr_states = {
+          ['42'] = {
+            state = 'OPEN',
+            mergeable = 'UNKNOWN',
+            review_decision = 'APPROVED',
+            is_draft = false,
+          },
+          ['41'] = {
+            state = 'OPEN',
+            mergeable = 'UNKNOWN',
+            review_decision = '',
+            is_draft = true,
+          },
+        },
+      })
+    )
+    captured.stream(function() end)
+
+    local approved_labels = helpers.action_labels(captured.actions, captured.entries[1])
+    assert.is_nil(approved_labels.approve)
+    assert.equals('merge', approved_labels.merge)
+    assert.equals('draft', approved_labels.draft)
+
+    local draft_labels = helpers.action_labels(captured.actions, captured.entries[2])
+    assert.equals('approve', draft_labels.approve)
+    assert.is_nil(draft_labels.merge)
+    assert.equals('ready', draft_labels.draft)
+  end)
+
+  it('hides merge when repo permissions do not allow it', function()
+    cache['pr:open'] = {
+      { number = 40, title = 'Read-only repo', state = 'OPEN', author = 'carol', created_at = '' },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.pr(
+      'open',
+      fake_forge({
+        repo_info = function()
+          return { permission = 'READ', merge_methods = { 'merge' } }
+        end,
+      })
+    )
+    captured.stream(function() end)
+
+    local labels = helpers.action_labels(captured.actions, captured.entries[1])
+    assert.equals('approve', labels.approve)
+    assert.is_nil(labels.merge)
+    assert.equals('draft', labels.draft)
   end)
 
   it('keeps auxiliary PR actions open', function()


### PR DESCRIPTION
## Problem

The row-state gating pass still cannot make strict PR decisions for actions like approve, merge, and draft/ready because the picker does not retain enough detail from the list rows alone.

## Solution

Add a small cached PR-state lookup in `forge.init` and use it to tighten the PR picker affordances. Approve now disappears once the PR is already approved, merge respects draft state and repo merge capability, and the draft action resolves to the right visible verb while reusing the same cached detail lookup.
