### PR TITLE
fix: redraw before notify and warn on unsupported capability paths

### DIFF
--- a/lua/forge/logger.lua
+++ b/lua/forge/logger.lua
@@ -19,8 +19,8 @@ end
 
 local function notify(msg, level)
   local run = function()
-    vim.notify('[forge]: ' .. msg, level)
     vim.cmd.redraw()
+    vim.notify('[forge]: ' .. msg, level)
   end
   if vim.in_fast_event() then
     vim.schedule(run)

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -283,13 +283,13 @@ function M.checks(f, num, filter, cached_checks, opts)
     local c = entry.value
     local run_id = c.run_id or (c.link or ''):match('/actions/runs/(%d+)')
     if not run_id then
-      log.info('logs not available, use browse to view')
+      log.warn('logs not available, use browse to view')
       return
     end
     local job_id = c.job_id or (c.link or ''):match('/job/(%d+)')
     local bucket = (c.bucket or ''):lower()
     if bucket == 'skipping' then
-      log.info('no log available - job was not started')
+      log.warn('no log available - job was not started')
       return
     end
     local in_progress = bucket == 'pending'
@@ -447,7 +447,7 @@ function M.checks(f, num, filter, cached_checks, opts)
       end,
     })
   else
-    log.info('structured checks not available for this forge')
+    log.warn('structured checks not available for this forge')
   end
 end
 
@@ -706,7 +706,7 @@ function M.ci(f, branch, filter, opts)
       stream = stream_runs,
     })
   elseif f.list_runs_cmd then
-    log.info('structured CI data not available for this forge')
+    log.warn('structured CI data not available for this forge')
   end
 end
 

--- a/spec/logger_spec.lua
+++ b/spec/logger_spec.lua
@@ -54,8 +54,8 @@ describe('logger', function()
     scheduled[1]()
 
     assert.same({
-      { msg = '[forge]: fast', level = vim.log.levels.INFO },
       { redraw = true },
+      { msg = '[forge]: fast', level = vim.log.levels.INFO },
     }, notified)
   end)
 
@@ -68,8 +68,8 @@ describe('logger', function()
 
     assert.equals(0, #scheduled)
     assert.same({
-      { msg = '[forge]: slow', level = vim.log.levels.WARN },
       { redraw = true },
+      { msg = '[forge]: slow', level = vim.log.levels.WARN },
     }, notified)
   end)
 end)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1559,7 +1559,7 @@ describe('pickers', function()
     assert.is_nil(toggle.label({ value = { id = '3', status = 'skipped' } }))
   end)
 
-  it('shows an info notification when skipped checks have no logs', function()
+  it('shows a warning when skipped checks have no logs', function()
     local pickers = require('forge.pickers')
     pickers.checks(fake_ci_forge(), '42', 'all', {
       {
@@ -1574,7 +1574,23 @@ describe('pickers', function()
     assert.is_not_nil(captured)
     action_by_name('log').fn(captured.entries[1])
 
-    assert.same({ 'no log available - job was not started' }, logger_messages.info)
+    assert.same({ 'no log available - job was not started' }, logger_messages.warn)
+  end)
+
+  it('shows a warning when checks logs are unavailable', function()
+    local pickers = require('forge.pickers')
+    pickers.checks(fake_ci_forge(), '42', 'all', {
+      {
+        name = 'lint',
+        link = 'https://example.com/checks/456',
+        bucket = 'pass',
+      },
+    })
+
+    assert.is_not_nil(captured)
+    action_by_name('log').fn(captured.entries[1])
+
+    assert.same({ 'logs not available, use browse to view' }, logger_messages.warn)
   end)
 
   it('builds checks entries with live display renderers', function()
@@ -1608,6 +1624,24 @@ describe('pickers', function()
 
     assert.is_not_nil(captured)
     assert.equals('Failed CI for main> ', captured.prompt)
+  end)
+
+  it('warns when structured checks are unavailable for a forge', function()
+    local pickers = require('forge.pickers')
+    pickers.checks({ labels = { pr_one = 'PR' } }, '42', 'all')
+
+    assert.same({ 'structured checks not available for this forge' }, logger_messages.warn)
+  end)
+
+  it('warns when structured CI data is unavailable for a forge', function()
+    local pickers = require('forge.pickers')
+    pickers.ci({
+      list_runs_cmd = function()
+        return { 'runs' }
+      end,
+    }, 'main', 'all')
+
+    assert.same({ 'structured CI data not available for this forge' }, logger_messages.warn)
   end)
 
   it('marks CI state jumps and refresh as hard reopen actions', function()


### PR DESCRIPTION
## Problem

In fzf-lua terminal mode, top-level warnings and picker-local notifications were easy to miss. Two underlying issues: the logger was calling `vim.notify` and then `vim.cmd.redraw()`, which is the exact ordering Neovim docs warn about (`:help :echo-redraw`) because a later redraw can wipe the message. Separately, several picker-level capability failures were emitted as `info` rather than `warn`, so genuine lack-of-support conditions were presented at the lowest severity.

## Solution

Flip the logger to redraw before notifying so the message lands after the terminal settles, and upgrade four capability-failure paths in `lua/forge/pickers.lua` from `info` to `warn`: missing check log URL, skipped-check job, no structured checks support, and no structured CI support. Specs updated accordingly and two new picker specs cover the unsupported structured-checks and structured-CI branches. Closes #281 and #291.