### PR TITLE
feat(pickers): gate checks open action for skipped and browse-only rows

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -205,6 +205,21 @@ local function issue_toggle_entry(entry)
   return actionable_entry(entry) and picker.issue_toggle_verb(entry) ~= nil
 end
 
+local function check_openable(entry)
+  if not actionable_entry(entry) or entry.placeholder then
+    return false
+  end
+  local c = entry.value
+  if type(c) ~= 'table' then
+    return false
+  end
+  if (c.bucket or ''):lower() == 'skipping' then
+    return false
+  end
+  local run_id = c.run_id or (c.link or ''):match('/actions/runs/(%d+)')
+  return run_id ~= nil
+end
+
 ---@param f forge.Forge
 ---@param pr forge.PRRef
 local function pr_toggle_draft_action(f, pr, opts)
@@ -282,16 +297,8 @@ function M.checks(f, num, filter, cached_checks, opts)
     end
     local c = entry.value
     local run_id = c.run_id or (c.link or ''):match('/actions/runs/(%d+)')
-    if not run_id then
-      log.warn('logs not available, use browse to view')
-      return
-    end
     local job_id = c.job_id or (c.link or ''):match('/job/(%d+)')
     local bucket = (c.bucket or ''):lower()
-    if bucket == 'skipping' then
-      log.warn('no log available - job was not started')
-      return
-    end
     local in_progress = bucket == 'pending'
     local check_ref = c.scope or ref
     if in_progress and f.live_tail_cmd then
@@ -318,6 +325,7 @@ function M.checks(f, num, filter, cached_checks, opts)
     {
       name = 'default',
       label = 'open',
+      available = check_openable,
       fn = open_check,
     },
     {

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1538,7 +1538,7 @@ describe('pickers', function()
     assert.is_nil(toggle.label({ value = { id = '3', status = 'skipped' } }))
   end)
 
-  it('shows a warning when skipped checks have no logs', function()
+  it('gates the open action as unavailable for skipped checks', function()
     local pickers = require('forge.pickers')
     pickers.checks(fake_ci_forge(), '42', 'all', {
       {
@@ -1551,12 +1551,12 @@ describe('pickers', function()
     })
 
     assert.is_not_nil(captured)
-    action_by_name('default').fn(captured.entries[1])
-
-    assert.same({ 'no log available - job was not started' }, logger_messages.warn)
+    local default = action_by_name('default')
+    assert.is_function(default.available)
+    assert.is_false(default.available(captured.entries[1]))
   end)
 
-  it('shows a warning when checks logs are unavailable', function()
+  it('gates the open action as unavailable for checks without an extractable run id', function()
     local pickers = require('forge.pickers')
     pickers.checks(fake_ci_forge(), '42', 'all', {
       {
@@ -1567,9 +1567,21 @@ describe('pickers', function()
     })
 
     assert.is_not_nil(captured)
-    action_by_name('default').fn(captured.entries[1])
+    local default = action_by_name('default')
+    assert.is_function(default.available)
+    assert.is_false(default.available(captured.entries[1]))
+  end)
 
-    assert.same({ 'logs not available, use browse to view' }, logger_messages.warn)
+  it('keeps the open action available for checks with a run id', function()
+    local pickers = require('forge.pickers')
+    pickers.checks(fake_ci_forge(), '42', 'all', {
+      { name = 'lint', bucket = 'pass', link = 'https://example.com/check', run_id = '789' },
+    })
+
+    assert.is_not_nil(captured)
+    local default = action_by_name('default')
+    assert.is_function(default.available)
+    assert.is_true(default.available(captured.entries[1]))
   end)
 
   it('builds checks entries with live display renderers', function()


### PR DESCRIPTION
## Problem

After collapsing checks log/watch into open (#321), the open action is still advertised in the picker header for rows that cannot actually produce a log: skipped checks and checks whose only linkage is an external URL with no extractable run id. Pressing open on those rows fell through to a \`log.warn\` notification (from #320), which is visible but dishonest — the header claims open works when it does not. Users benefit more from a header that reflects the row's real affordances.

## Solution

Gate the default (open) action of the checks picker via the existing \`available\` mechanism. A new \`check_openable(entry)\` predicate returns false for \`bucket == 'skipping'\` and for rows where neither \`c.run_id\` nor a \`/actions/runs/<id>\` match in \`c.link\` is present; on those rows the header drops the open hint and only \`browse\` remains visible. The two internal warning branches inside \`open_check\` are now unreachable from the picker and removed.