### PR TITLE
feat: TTL for durable forge caches + per-family refresh verbs

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -406,6 +406,11 @@ PR COMMANDS                                            *forge-pr-commands*
 `:Forge pr ready` {num} [repo=...]                           *:Forge-pr-ready*
     Mark PR `{num}` as ready when supported by the forge.
 
+`:Forge pr refresh` [repo=...]                             *:Forge-pr-refresh*
+    Invalidate the cached PR list so the next picker or list-consuming
+    command fetches fresh data from the forge. Mirrors the PR picker's
+    refresh action.
+
 ISSUE COMMANDS                                      *forge-issue-commands*
 
 `:Forge issue browse` [{num}] [repo=...]                 *:Forge-issue-browse*
@@ -431,6 +436,11 @@ ISSUE COMMANDS                                      *forge-issue-commands*
 `:Forge issue edit` {num} [repo=...]                       *:Forge-issue-edit*
     Open the issue edit compose flow for issue `{num}`.
 
+`:Forge issue refresh` [repo=...]                       *:Forge-issue-refresh*
+    Invalidate the cached issue list so the next picker or
+    list-consuming command fetches fresh data from the forge. Mirrors
+    the issue picker's refresh action.
+
 CI COMMANDS                                            *forge-ci-commands*
 
 `:Forge ci open` {run-id} [repo=...]                          *:Forge-ci-open*
@@ -452,6 +462,11 @@ CI COMMANDS                                            *forge-ci-commands*
     Open CI run `{run-id}` in the browser, or the CI list landing page
     when `{run-id}` is omitted.
 
+`:Forge ci refresh` [repo=...]                             *:Forge-ci-refresh*
+    Invalidate the cached CI run list so the next picker or
+    list-consuming command fetches fresh data from the forge. Mirrors
+    the CI picker's refresh action.
+
 RELEASE COMMANDS                                  *forge-release-commands*
 
 `:Forge release browse` [{tag}] [repo=...]             *:Forge-release-browse*
@@ -460,6 +475,11 @@ RELEASE COMMANDS                                  *forge-release-commands*
 
 `:Forge release delete` {tag} [repo=...]               *:Forge-release-delete*
     Delete release `{tag}`.
+
+`:Forge release refresh` [repo=...]                   *:Forge-release-refresh*
+    Invalidate the cached release list so the next picker or
+    list-consuming command fetches fresh data from the forge. Mirrors
+    the release picker's refresh action.
 
 BROWSE COMMANDS                                    *forge-browse-commands*
 
@@ -507,6 +527,12 @@ REVIEW COMMANDS                                    *forge-review-commands*
     Toggle between patch and file-context view.
 
 CACHE COMMANDS                                      *forge-cache-commands*
+
+Forge keeps short-lived caches for list data (PRs, issues, CI runs,
+releases), PR state, and repository metadata. Entries expire
+automatically; the per-family `refresh` verbs invalidate the cached
+list for that family, and `:Forge clear` is the nuclear option that
+also clears forge detection and git-root resolution.
 
 `:Forge clear`                                                  *:Forge-clear*
     Clear all internal caches (forge detection, repo info, list data).

--- a/lua/forge/cache.lua
+++ b/lua/forge/cache.lua
@@ -1,0 +1,54 @@
+local M = {}
+
+---@class forge.Cache
+---@field get fun(key: string): any?
+---@field set fun(key: string, value: any)
+---@field clear fun(key: string?)
+---@field clear_prefix fun(prefix: string)
+
+---@param ttl_seconds integer
+---@param clock? fun(): integer
+---@return forge.Cache
+function M.new(ttl_seconds, clock)
+  clock = clock or os.time
+  local store = {}
+  local cache = {}
+
+  function cache.get(key)
+    local entry = store[key]
+    if not entry then
+      return nil
+    end
+    if entry.expires_at <= clock() then
+      store[key] = nil
+      return nil
+    end
+    return entry.value
+  end
+
+  function cache.set(key, value)
+    store[key] = { value = value, expires_at = clock() + ttl_seconds }
+  end
+
+  function cache.clear(key)
+    if key then
+      store[key] = nil
+      return
+    end
+    for k in pairs(store) do
+      store[k] = nil
+    end
+  end
+
+  function cache.clear_prefix(prefix)
+    for k in pairs(store) do
+      if k:sub(1, #prefix) == prefix then
+        store[k] = nil
+      end
+    end
+  end
+
+  return cache
+end
+
+return M

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -44,6 +44,7 @@ local families = {
       'merge',
       'draft',
       'ready',
+      'refresh',
     },
     verbs = {
       checkout = {
@@ -90,12 +91,16 @@ local families = {
         subject = { kind = 'pr', min = 1, max = 1 },
         modifiers = { 'repo' },
       },
+      refresh = {
+        subject = { min = 0, max = 0 },
+        modifiers = { 'repo' },
+      },
     },
   },
   {
     name = 'issue',
     surface = 'forge',
-    verb_order = { 'browse', 'close', 'reopen', 'create', 'edit' },
+    verb_order = { 'browse', 'close', 'reopen', 'create', 'edit', 'refresh' },
     verbs = {
       browse = {
         subject = { kind = 'issue', min = 0, max = 1 },
@@ -117,12 +122,16 @@ local families = {
         subject = { kind = 'issue', min = 1, max = 1 },
         modifiers = { 'repo' },
       },
+      refresh = {
+        subject = { min = 0, max = 0 },
+        modifiers = { 'repo' },
+      },
     },
   },
   {
     name = 'ci',
     surface = 'forge',
-    verb_order = { 'open', 'log', 'watch', 'browse' },
+    verb_order = { 'open', 'log', 'watch', 'browse', 'refresh' },
     verbs = {
       open = {
         subject = { kind = 'run', min = 1, max = 1 },
@@ -140,12 +149,16 @@ local families = {
         subject = { kind = 'run', min = 0, max = 1 },
         modifiers = { 'repo' },
       },
+      refresh = {
+        subject = { min = 0, max = 0 },
+        modifiers = { 'repo' },
+      },
     },
   },
   {
     name = 'release',
     surface = 'forge',
-    verb_order = { 'browse', 'delete' },
+    verb_order = { 'browse', 'delete', 'refresh' },
     verbs = {
       browse = {
         subject = { kind = 'release', min = 0, max = 1 },
@@ -153,6 +166,10 @@ local families = {
       },
       delete = {
         subject = { kind = 'release', min = 1, max = 1 },
+        modifiers = { 'repo' },
+      },
+      refresh = {
+        subject = { min = 0, max = 0 },
         modifiers = { 'repo' },
       },
     },
@@ -443,6 +460,11 @@ local function dispatch_pr(command)
     ops.pr_reopen(f, { num = num, scope = scope })
     return
   end
+  if command.name == 'refresh' then
+    require('forge').clear_list_kind('pr')
+    require('forge.logger').info('refreshed ' .. ((f.labels and f.labels.pr) or 'pr') .. ' list')
+    return
+  end
   warn(('unsupported pr action: %s'):format(command.name))
 end
 
@@ -486,6 +508,11 @@ local function dispatch_issue(command)
     ops.issue_reopen(f, { num = num, scope = scope })
     return
   end
+  if command.name == 'refresh' then
+    require('forge').clear_list_kind('issue')
+    require('forge.logger').info('refreshed issue list')
+    return
+  end
   warn(('unsupported issue action: %s'):format(command.name))
 end
 
@@ -519,6 +546,11 @@ local function dispatch_ci(command)
     end
     return
   end
+  if command.name == 'refresh' then
+    require('forge').clear_list_kind('ci')
+    require('forge.logger').info('refreshed CI run list')
+    return
+  end
   warn(('unsupported ci action: %s'):format(command.name))
 end
 
@@ -542,6 +574,11 @@ local function dispatch_release(command)
   end
   if command.name == 'delete' then
     ops.release_delete(f, { tag = tag, scope = scope })
+    return
+  end
+  if command.name == 'refresh' then
+    require('forge').clear_list_kind('release')
+    require('forge.logger').info('refreshed release list')
     return
   end
 end

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local action_mod = require('forge.action')
+local cache_mod = require('forge.cache')
 local client_mod = require('forge.client')
 local compose_mod = require('forge.compose')
 local config_mod = require('forge.config')
@@ -32,17 +33,12 @@ end
 ---@type table<string, forge.Forge>
 local forge_cache = {}
 
----@type table<string, forge.RepoInfo>
-local repo_info_cache = {}
-
----@type table<string, forge.PRState>
-local pr_state_cache = {}
-
 ---@type table<string, string>
 local root_cache = {}
 
----@type table<string, table[]>
-local list_cache = {}
+local repo_info_cache = cache_mod.new(30 * 60)
+local pr_state_cache = cache_mod.new(60)
+local list_cache = cache_mod.new(2 * 60)
 
 local function fn_system_text(cmd)
   local text = vim.trim(vim.fn.system(cmd))
@@ -248,12 +244,15 @@ end
 function M.repo_info(f, scope)
   local root = git_root()
   local key = root and (root .. '|' .. scope_mod.key(scope)) or nil
-  if key and repo_info_cache[key] then
-    return repo_info_cache[key]
+  if key then
+    local cached = repo_info_cache.get(key)
+    if cached ~= nil then
+      return cached
+    end
   end
   local info = f:repo_info(scope)
   if key then
-    repo_info_cache[key] = info
+    repo_info_cache.set(key, info)
   end
   return info
 end
@@ -265,12 +264,15 @@ end
 function M.pr_state(f, num, scope)
   local root = git_root()
   local key = root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
-  if key and pr_state_cache[key] then
-    return pr_state_cache[key]
+  if key then
+    local cached = pr_state_cache.get(key)
+    if cached ~= nil then
+      return cached
+    end
   end
   local state = f:pr_state(num, scope)
   if key then
-    pr_state_cache[key] = state
+    pr_state_cache.set(key, state)
   end
   return state
 end
@@ -280,23 +282,18 @@ end
 function M.clear_pr_state(num, scope)
   local root = git_root()
   if not root then
-    pr_state_cache = {}
+    pr_state_cache.clear()
     return
   end
   if num ~= nil then
-    pr_state_cache[root .. '|' .. scope_mod.key(scope) .. '|' .. num] = nil
+    pr_state_cache.clear(root .. '|' .. scope_mod.key(scope) .. '|' .. num)
     return
   end
   if scope ~= nil then
-    local prefix = root .. '|' .. scope_mod.key(scope) .. '|'
-    for key in pairs(pr_state_cache) do
-      if key:sub(1, #prefix) == prefix then
-        pr_state_cache[key] = nil
-      end
-    end
+    pr_state_cache.clear_prefix(root .. '|' .. scope_mod.key(scope) .. '|')
     return
   end
-  pr_state_cache = {}
+  pr_state_cache.clear()
 end
 
 ---@param kind string
@@ -310,30 +307,32 @@ end
 ---@param key string
 ---@return table[]?
 function M.get_list(key)
-  return list_cache[key]
+  return list_cache.get(key)
 end
 
 ---@param key string
 ---@param data table[]
 function M.set_list(key, data)
-  list_cache[key] = data
+  list_cache.set(key, data)
 end
 
 ---@param key string?
 function M.clear_list(key)
-  if key then
-    list_cache[key] = nil
-  else
-    list_cache = {}
-  end
+  list_cache.clear(key)
+end
+
+---@param kind string
+function M.clear_list_kind(kind)
+  local root = git_root() or ''
+  list_cache.clear_prefix(root .. ':' .. kind .. ':')
 end
 
 function M.clear_cache()
   forge_cache = {}
-  repo_info_cache = {}
-  pr_state_cache = {}
+  repo_info_cache.clear()
+  pr_state_cache.clear()
   root_cache = {}
-  list_cache = {}
+  list_cache.clear()
 end
 
 ---@param range? { start_line: integer, end_line: integer }

--- a/spec/cache_spec.lua
+++ b/spec/cache_spec.lua
@@ -1,0 +1,89 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local cache_mod = require('forge.cache')
+
+describe('forge.cache', function()
+  it('returns nil for missing keys', function()
+    local c = cache_mod.new(60)
+    assert.is_nil(c.get('missing'))
+  end)
+
+  it('returns the stored value while fresh', function()
+    local c = cache_mod.new(60)
+    c.set('k', 'v')
+    assert.equals('v', c.get('k'))
+  end)
+
+  it('expires entries after ttl_seconds', function()
+    local now = 0
+    local c = cache_mod.new(60, function()
+      return now
+    end)
+    c.set('k', 'v')
+    now = 30
+    assert.equals('v', c.get('k'))
+    now = 60
+    assert.is_nil(c.get('k'))
+  end)
+
+  it('evicts expired entries on read', function()
+    local now = 0
+    local c = cache_mod.new(5, function()
+      return now
+    end)
+    c.set('k', 'v')
+    now = 10
+    c.get('k')
+    now = 0
+    assert.is_nil(c.get('k'))
+  end)
+
+  it('treats set as ttl reset', function()
+    local now = 0
+    local c = cache_mod.new(60, function()
+      return now
+    end)
+    c.set('k', 'v1')
+    now = 50
+    c.set('k', 'v2')
+    now = 70
+    assert.equals('v2', c.get('k'))
+    now = 120
+    assert.is_nil(c.get('k'))
+  end)
+
+  it('clear(key) removes only that entry', function()
+    local c = cache_mod.new(60)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.clear('a')
+    assert.is_nil(c.get('a'))
+    assert.equals(2, c.get('b'))
+  end)
+
+  it('clear() without key removes all entries', function()
+    local c = cache_mod.new(60)
+    c.set('a', 1)
+    c.set('b', 2)
+    c.clear()
+    assert.is_nil(c.get('a'))
+    assert.is_nil(c.get('b'))
+  end)
+
+  it('clear_prefix removes matching keys and preserves others', function()
+    local c = cache_mod.new(60)
+    c.set('root:pr:open', 1)
+    c.set('root:pr:closed', 2)
+    c.set('root:issue:open', 3)
+    c.clear_prefix('root:pr:')
+    assert.is_nil(c.get('root:pr:open'))
+    assert.is_nil(c.get('root:pr:closed'))
+    assert.equals(3, c.get('root:issue:open'))
+  end)
+
+  it('allows false values without treating them as missing', function()
+    local c = cache_mod.new(60)
+    c.set('k', false)
+    assert.equals(false, c.get('k'))
+  end)
+end)

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -200,11 +200,43 @@ describe('command schema', function()
       'merge',
       'draft',
       'ready',
+      'refresh',
     }, cmd.verb_names('pr'))
 
-    assert.same({ 'browse', 'close', 'reopen', 'create', 'edit' }, cmd.verb_names('issue'))
-    assert.same({ 'open', 'log', 'watch', 'browse' }, cmd.verb_names('ci'))
-    assert.same({ 'browse', 'delete' }, cmd.verb_names('release'))
+    assert.same(
+      { 'browse', 'close', 'reopen', 'create', 'edit', 'refresh' },
+      cmd.verb_names('issue')
+    )
+    assert.same({ 'open', 'log', 'watch', 'browse', 'refresh' }, cmd.verb_names('ci'))
+    assert.same({ 'browse', 'delete', 'refresh' }, cmd.verb_names('release'))
+  end)
+
+  it('parses argless refresh verbs for all list families', function()
+    local pr = assert(cmd.parse({ 'pr', 'refresh' }))
+    local issue = assert(cmd.parse({ 'issue', 'refresh' }))
+    local ci = assert(cmd.parse({ 'ci', 'refresh' }))
+    local release = assert(cmd.parse({ 'release', 'refresh' }))
+
+    assert.equals('pr', pr.family)
+    assert.equals('refresh', pr.name)
+    assert.same({}, pr.subjects)
+
+    assert.equals('issue', issue.family)
+    assert.equals('refresh', issue.name)
+    assert.same({}, issue.subjects)
+
+    assert.equals('ci', ci.family)
+    assert.equals('refresh', ci.name)
+    assert.same({}, ci.subjects)
+
+    assert.equals('release', release.family)
+    assert.equals('refresh', release.name)
+    assert.same({}, release.subjects)
+  end)
+
+  it('rejects subjects on refresh verbs', function()
+    local _, pr = cmd.parse({ 'pr', 'refresh', '42' })
+    assert.is_not_nil(pr)
   end)
 
   it('keeps legacy browse modifiers separate from canonical ones', function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -171,6 +171,10 @@ describe(':Forge command', function()
         clear_cache = function()
           captured.cleared = true
         end,
+        clear_list_kind = function(kind)
+          captured.cleared_kinds = captured.cleared_kinds or {}
+          table.insert(captured.cleared_kinds, kind)
+        end,
         file_loc = function(range)
           local name = vim.api.nvim_buf_get_name(0)
           if name:match('^%w[%w+.-]*://') then
@@ -792,6 +796,16 @@ describe(':Forge command', function()
     }, captured.ops_calls[3])
   end)
 
+  it('dispatches refresh verbs to forge.clear_list_kind per family', function()
+    vim.cmd('Forge pr refresh')
+    vim.cmd('Forge issue refresh')
+    vim.cmd('Forge ci refresh')
+    vim.cmd('Forge release refresh')
+
+    assert.same({ 'pr', 'issue', 'ci', 'release' }, captured.cleared_kinds)
+    assert.is_nil(captured.cleared)
+  end)
+
   it('completes families, verbs, and valid canonical modifiers contextually', function()
     local families = vim.fn.getcompletion('Forge ', 'cmdline')
     local pr = vim.fn.getcompletion('Forge pr ', 'cmdline')
@@ -813,15 +827,19 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(pr, 'merge'))
     assert.is_true(vim.tbl_contains(pr, 'draft'))
     assert.is_true(vim.tbl_contains(pr, 'ready'))
+    assert.is_true(vim.tbl_contains(pr, 'refresh'))
     assert.is_false(vim.tbl_contains(pr, 'ci'))
     assert.is_true(vim.tbl_contains(ci, 'open'))
     assert.is_true(vim.tbl_contains(ci, 'log'))
     assert.is_true(vim.tbl_contains(ci, 'watch'))
+    assert.is_true(vim.tbl_contains(ci, 'refresh'))
     assert.is_false(vim.tbl_contains(pr, 'state='))
     assert.is_false(vim.tbl_contains(pr, 'repo='))
     assert.is_true(vim.tbl_contains(issue, 'edit'))
+    assert.is_true(vim.tbl_contains(issue, 'refresh'))
     assert.is_true(vim.tbl_contains(release, 'browse'))
     assert.is_true(vim.tbl_contains(release, 'delete'))
+    assert.is_true(vim.tbl_contains(release, 'refresh'))
 
     assert.is_true(vim.tbl_contains(pr_create, 'head='))
     assert.is_true(vim.tbl_contains(pr_create, 'base='))


### PR DESCRIPTION
## Problem

Forge's durable remote-data caches (\`repo_info_cache\`, \`pr_state_cache\`, \`list_cache\`) lived forever until an explicit refresh, a matching mutation action, or session end. As picker/action availability and state-aware completion lean harder on cached data, indefinite staleness becomes a real failure mode rather than an edge case — the current pickers already surface mutation-driven invalidation well, but passive drift (a teammate merged a PR externally, CI was rerun out-of-band) has no automatic remedy. Separately, the CLI surface lacked parity with the picker's per-family refresh action: \`:Forge clear\` was the only Ex-mode invalidation verb and it wipes forge detection and git-root resolution alongside the data caches, which is heavier than the typical refresh use case.

## Solution

Introduce \`lua/forge/cache.lua\` — a small TTL primitive with \`get\`/\`set\`/\`clear\`/\`clear_prefix\` and an injectable clock for deterministic tests. Wrap the three durable caches at per-cache defaults that reflect their actual volatilities: \`repo_info\` 30 minutes, \`pr_state\` 60 seconds, \`list\` 2 minutes. \`forge_cache\` and \`root_cache\` remain plain tables since they're derived from filesystem and remote config rather than remote state; \`picker_session\` is out of scope because it's request coordination, not a data cache. Add per-family refresh verbs (\`:Forge pr refresh\`, \`:Forge issue refresh\`, \`:Forge ci refresh\`, \`:Forge release refresh\`) mirroring the picker's refresh action — each invalidates only its own family's list cache via a new \`forge.clear_list_kind\` helper. \`:Forge clear\` stays as the nuclear reset for when forge detection or git-root need rebuilding. No new config keys: defaults are picked and adjustable in-tree if evidence demands it later. Closes #311.