### PR TITLE
feat(term): open terminals in normal mode, hardcode q as close

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -256,14 +256,13 @@ Top-level keys: ~
   `edit`, `approve`, `merge`, `create`, `toggle`, `draft`, and `refresh`.
   The primary PR action remains `<cr>` checkout.
 
-  `keys.ci` supports secondary bindings for `log`, `watch`, `browse`,
-  `toggle`, filter cycling, and `refresh`. The primary CI action remains
-  `<cr>` open.
+  `keys.ci` supports secondary bindings for `browse`, `toggle`, filter
+  cycling, and `refresh`. The primary CI action remains `<cr>` open.
 
   Additional picker groups:
-    `keys.log` supports `close` and `browse` across CI terminal/log views,
-    plus step/error navigation and `refresh` for Forge-managed CI log and
-    summary buffers.
+    `keys.log` supports `browse` across CI terminal/log views, plus
+    step/error navigation and `refresh` for Forge-managed CI log and
+    summary buffers. Closing those views with `q` is hardcoded.
 
 `display`                                               *forge-config-display*
   Controls icons, column widths, and fetch limits used in picker

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -67,7 +67,6 @@ local M = {}
 ---@field refresh string|false
 
 ---@class forge.LogViewerKeys
----@field close string|false
 ---@field next_step string|false
 ---@field prev_step string|false
 ---@field next_error string|false
@@ -169,7 +168,6 @@ local DEFAULTS = {
       refresh = '<c-r>',
     },
     log = {
-      close = 'q',
       next_step = ']]',
       prev_step = '[[',
       next_error = ']e',
@@ -501,7 +499,6 @@ function M.config()
     if keys.log ~= nil then
       vim.validate('forge.keys.log', keys.log, 'table')
       for _, k in ipairs({
-        'close',
         'next_step',
         'prev_step',
         'next_error',

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -709,9 +709,9 @@ local function setup_keymaps(buf, url, cmd, opts)
       vim.keymap.set('n', key, fn, { buffer = buf, desc = desc })
     end
   end
-  map(keys.close, function()
+  vim.keymap.set('n', 'q', function()
     vim.api.nvim_buf_delete(buf, { force = true })
-  end, 'Close log')
+  end, { buffer = buf, desc = 'Close log' })
   map(keys.next_step, function()
     jump(buf, 'header', 1)
   end, 'Next step')
@@ -1258,9 +1258,9 @@ function M.open_summary(cmd, opts, reuse_buf)
               vim.keymap.set('n', key, fn, { buffer = buf, desc = desc })
             end
           end
-          map(keys.close, function()
+          vim.keymap.set('n', 'q', function()
             vim.api.nvim_buf_delete(buf, { force = true })
-          end, 'Close')
+          end, { buffer = buf, desc = 'Close' })
           map(keys.browse, function()
             local url = opts.url
             local d = buf_data[buf]

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -103,7 +103,6 @@ local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd
 
   require('forge.term').open(cmd, {
     url = url,
-    startinsert = false,
     browse_fn = function(buf)
       local job = summary_job_at_cursor(buf)
       if job and f.job_web_url then

--- a/lua/forge/term.lua
+++ b/lua/forge/term.lua
@@ -17,7 +17,7 @@ function M.open(cmd, opts)
   vim.cmd(prefix .. ' new')
   local buf = vim.api.nvim_get_current_buf()
   vim.fn.termopen(cmd)
-  if opts.startinsert ~= false then
+  if opts.startinsert == true then
     vim.cmd('startinsert')
   end
 
@@ -38,11 +38,9 @@ function M.open(cmd, opts)
       opts.enter_fn(buf)
     end, { buffer = buf, desc = 'Open' })
   end
-  if keys.close ~= false then
-    vim.keymap.set('n', keys.close or 'q', function()
-      vim.api.nvim_buf_delete(buf, { force = true })
-    end, { buffer = buf, desc = 'Close' })
-  end
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end, { buffer = buf, desc = 'Close' })
 end
 
 return M

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -464,7 +464,6 @@ describe('shared operations', function()
     term_opts.browse_fn, term_opts.enter_fn = nil, nil
     assert.same({
       url = 'https://example.com/runs/77/repo/ref',
-      startinsert = false,
     }, term_opts)
   end)
 
@@ -512,7 +511,6 @@ describe('shared operations', function()
     term_opts.browse_fn, term_opts.enter_fn = nil, nil
     assert.same({
       url = 'https://example.com/runs/88/repo/ref',
-      startinsert = false,
     }, term_opts)
     assert.equals('https://example.com/runs/88/jobs/22/repo/ref', browse_url)
     assert.same({ 'check-log', '88', 'true', '22', 'repo/ref' }, captured.logs[1].cmd)

--- a/spec/term_spec.lua
+++ b/spec/term_spec.lua
@@ -42,7 +42,6 @@ describe('term', function()
 
     require('forge.term').open({ 'gh', 'run', 'view', '1' }, {
       url = 'https://example.com/runs/1',
-      startinsert = false,
       browse_fn = function()
         if #opened == 0 then
           return 'https://example.com/runs/1/job/2'
@@ -68,5 +67,60 @@ describe('term', function()
       'https://example.com/runs/1',
     }, opened)
     assert.equals(1, entered)
+  end)
+
+  it('does not enter insert mode by default', function()
+    local insert_count = 0
+
+    vim.fn.termopen = function()
+      return 1
+    end
+    vim.cmd = function(cmd)
+      if cmd == 'startinsert' then
+        insert_count = insert_count + 1
+      end
+      old_cmd(cmd)
+    end
+
+    require('forge.term').open({ 'gh', 'run', 'watch', '1' }, {})
+
+    assert.equals(0, insert_count)
+  end)
+
+  it('enters insert mode when startinsert is explicitly true', function()
+    local insert_count = 0
+
+    vim.fn.termopen = function()
+      return 1
+    end
+    vim.cmd = function(cmd)
+      if cmd == 'startinsert' then
+        insert_count = insert_count + 1
+        return
+      end
+      old_cmd(cmd)
+    end
+
+    require('forge.term').open({ 'gh', 'run', 'watch', '1' }, {
+      startinsert = true,
+    })
+
+    assert.equals(1, insert_count)
+  end)
+
+  it('maps q to close the terminal buffer in normal mode', function()
+    vim.fn.termopen = function()
+      return 1
+    end
+
+    require('forge.term').open({ 'gh', 'run', 'watch', '1' }, {})
+
+    local buf = vim.api.nvim_get_current_buf()
+    local close = vim.fn.maparg('q', 'n', false, true).callback
+    assert.is_function(close)
+
+    close()
+
+    assert.is_false(vim.api.nvim_buf_is_valid(buf))
   end)
 end)


### PR DESCRIPTION
## Problem

Forge's terminal buffers (CI watch, checks live-tail) opened with \`startinsert\`, leaving the cursor in terminal mode. The \`q\` close keymap was only registered in normal mode, so pressing \`q\` right after the buffer opened sent a literal \`q\` to the underlying shell instead of closing the buffer — users had to \`<C-\\><C-n>q\` to get out. The \`keys.log.close\` config key also existed as a customization point for an action (\"close this viewer\") that has a strong cross-vim convention (\`q\` in quickfix, help, diffview, trouble, fugitive) and doesn't benefit from being tunable.

## Solution

Flip \`term.open\`'s default so terminals open in normal mode; callers that genuinely need insert mode can still pass \`startinsert = true\`. Hardcode \`q\` as the close key across terminal, static log, and summary buffers, and remove \`keys.log.close\` from config defaults, validation, and the \`forge.LogViewerKeys\` annotation. The rest of \`keys.log\` (navigation, browse, refresh) stays configurable since those are forge-specific and less conventional. Tests cover the new default (no insert unless requested) and verify \`q\` actually closes the buffer.