### PR TITLE
test(format): verify title column grows dynamically to fit wide titles

### DIFF
--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -247,6 +247,18 @@ describe('format_prs', function()
     assert.truthy(rows[2][2][1]:find(' a much', 1, true))
     assert.truthy(rows[2][2][1]:find('...', 1, true))
   end)
+
+  it('grows the title column to fit wide titles when budget allows', function()
+    local long_title =
+      'a deliberately long pull request title that exceeds the old default preferred width of 45'
+    local rows = forge.format_prs({
+      { number = 1, title = long_title, state = 'OPEN', author = 'alice', created_at = '' },
+    }, fields, false, { width = 200 })
+
+    local title_text = rows[1][2][1]
+    assert.equals(nil, title_text:find('...', 1, true))
+    assert.truthy(title_text:find(long_title, 1, true))
+  end)
 end)
 
 describe('format_issue', function()


### PR DESCRIPTION
## Problem

#325 asks to verify that dynamic title widths still work after \`display.widths\` was removed from config in #326. The change hardcoded the preferred values (45/15/35/25) at the \`format.lua\` call sites but did not touch the elastic-width layout logic, so growth-to-fit should still happen. Nothing in the existing spec suite proves that end of the range — \`format_prs\` only had a narrow-layout truncation test.

## Solution

Add a regression test that hands \`format_prs\` a long-titled PR and a 200-column budget, and asserts the rendered title contains the full original text with no truncation marker. This demonstrates that \`layout.plan\`'s \`grow_once\` phase still expands the title column up to \`column.max\` (set from \`layout.measure\`'s observed max) when space allows. Pairs with the existing \"drops secondary metadata before the primary title in narrow layouts\" test so both elastic ends are covered.

Closes #325.