### PR TITLE
feat(cmd): make subject completion cache-backed and state-aware

### DIFF
--- a/lua/forge/availability.lua
+++ b/lua/forge/availability.lua
@@ -1,0 +1,90 @@
+local M = {}
+
+local function entry_value(entry)
+  if type(entry) ~= 'table' or type(entry.value) ~= 'table' then
+    return nil
+  end
+  if entry.placeholder or entry.load_more then
+    return nil
+  end
+  return entry.value
+end
+
+local function pr_state(f, entry)
+  local value = entry_value(entry)
+  if not value then
+    return nil
+  end
+  if value.is_draft ~= nil then
+    return {
+      review_decision = '',
+      is_draft = value.is_draft == true,
+    }
+  end
+  return require('forge').pr_state(f, value.num, value.scope)
+end
+
+local function pr_open(entry)
+  return require('forge.picker').pr_toggle_verb(entry) == 'close'
+end
+
+local function merge_permission(info)
+  local permission = ((info or {}).permission or ''):upper()
+  return permission == 'WRITE' or permission == 'ADMIN' or permission == 'MAINTAIN'
+end
+
+function M.pr_can_approve(f, entry)
+  if not pr_open(entry) then
+    return false
+  end
+  local state = pr_state(f, entry)
+  return state == nil or (state.review_decision or ''):upper() ~= 'APPROVED'
+end
+
+function M.pr_can_merge(f, entry)
+  if not pr_open(entry) then
+    return false
+  end
+  local state = pr_state(f, entry)
+  if state and state.is_draft then
+    return false
+  end
+  local value = entry_value(entry)
+  local info = require('forge').repo_info(f, value and value.scope or nil)
+  return merge_permission(info)
+    and type((info or {}).merge_methods) == 'table'
+    and #info.merge_methods > 0
+end
+
+function M.pr_can_toggle_draft(f, entry)
+  return f.capabilities.draft and pr_open(entry)
+end
+
+function M.pr_can_mark_draft(f, entry)
+  if not M.pr_can_toggle_draft(f, entry) then
+    return false
+  end
+  local state = pr_state(f, entry)
+  return not (state and state.is_draft)
+end
+
+function M.pr_can_mark_ready(f, entry)
+  if not M.pr_can_toggle_draft(f, entry) then
+    return false
+  end
+  local state = pr_state(f, entry)
+  return state ~= nil and state.is_draft == true
+end
+
+function M.pr_draft_label(f, entry)
+  if entry == nil then
+    return 'draft/ready'
+  end
+  local state = pr_state(f, entry)
+  if state and state.is_draft then
+    return 'ready'
+  end
+  return 'draft'
+end
+
+return M

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1060,6 +1060,285 @@ local function target_completion_values(prefix)
   return filter(items, prefix)
 end
 
+local completion_limits = {
+  pr = 100,
+  issue = 100,
+  ci = 30,
+  release = 30,
+}
+
+local function json_list(cmd)
+  if type(cmd) ~= 'table' then
+    return nil
+  end
+  local result = vim.system(cmd, { text = true }):wait()
+  if result.code ~= 0 then
+    return nil
+  end
+  local ok, data = pcall(vim.json.decode, result.stdout or '[]')
+  if not ok or type(data) ~= 'table' then
+    return nil
+  end
+  return data
+end
+
+local function scoped_id(id, suffix)
+  if suffix ~= nil and suffix ~= '' then
+    return id .. '|' .. suffix
+  end
+  return id
+end
+
+local function completion_scope_key(forge_mod, scope)
+  if type(forge_mod.scope_key) == 'function' then
+    return forge_mod.scope_key(scope)
+  end
+  return ''
+end
+
+local function completion_limit(forge_mod, kind)
+  local cfg = type(forge_mod.config) == 'function' and forge_mod.config() or nil
+  local display = type(cfg) == 'table' and cfg.display or nil
+  local limits = type(display) == 'table' and display.limits or nil
+  if kind == 'pr' then
+    return type(limits) == 'table' and limits.pulls or completion_limits.pr
+  end
+  if kind == 'issue' then
+    return type(limits) == 'table' and limits.issues or completion_limits.issue
+  end
+  if kind == 'ci' then
+    return type(limits) == 'table' and limits.runs or completion_limits.ci
+  end
+  if kind == 'release' then
+    return type(limits) == 'table' and limits.releases or completion_limits.release
+  end
+  return 50
+end
+
+local function completion_scope(forge_mod, f, state)
+  local repo = state.modifiers.repo
+  if type(repo) == 'string' and repo ~= '' then
+    local target = require('forge.target')
+    local resolved = target.resolve_repo(repo, target_parse_opts())
+    if resolved then
+      return target.repo_scope(resolved, f.name)
+    end
+  end
+  if type(forge_mod.current_scope) == 'function' then
+    return forge_mod.current_scope(f.name)
+  end
+  return nil
+end
+
+local function completion_forge(state)
+  local ok, forge_mod = pcall(require, 'forge')
+  if not ok or type(forge_mod) ~= 'table' or type(forge_mod.detect) ~= 'function' then
+    return nil, nil, nil
+  end
+  local f = forge_mod.detect()
+  if not f then
+    return nil, forge_mod, nil
+  end
+  return f, forge_mod, completion_scope(forge_mod, f, state)
+end
+
+local function completion_list_key(forge_mod, kind, state, scope)
+  return forge_mod.list_key(kind, scoped_id(state, completion_scope_key(forge_mod, scope)))
+end
+
+local function cached_completion_list(forge_mod, kind, states, scope)
+  local items = {}
+  local found = false
+  for _, state in ipairs(states) do
+    local cached = forge_mod.get_list(completion_list_key(forge_mod, kind, state, scope))
+    if type(cached) == 'table' then
+      found = true
+      for _, item in ipairs(cached) do
+        items[#items + 1] = item
+      end
+    end
+  end
+  if found then
+    return items
+  end
+  return nil
+end
+
+local function fetch_completion_list(forge_mod, f, kind, state, scope)
+  local limit = completion_limit(forge_mod, kind)
+  local cmd
+  if kind == 'pr' and type(f.list_pr_json_cmd) == 'function' then
+    cmd = f:list_pr_json_cmd(state, limit, scope)
+  elseif kind == 'issue' and type(f.list_issue_json_cmd) == 'function' then
+    cmd = f:list_issue_json_cmd(state, limit, scope)
+  elseif kind == 'ci' and type(f.list_runs_json_cmd) == 'function' then
+    cmd = f:list_runs_json_cmd(state == 'all' and nil or state, scope, limit)
+  elseif kind == 'release' and type(f.list_releases_json_cmd) == 'function' then
+    cmd = f:list_releases_json_cmd(scope, limit)
+  end
+  local data = json_list(cmd)
+  if type(data) ~= 'table' then
+    return {}
+  end
+  if kind == 'ci' and type(f.normalize_run) == 'function' then
+    local normalized = {}
+    for _, item in ipairs(data) do
+      normalized[#normalized + 1] = f:normalize_run(item)
+    end
+    data = normalized
+  end
+  forge_mod.set_list(completion_list_key(forge_mod, kind, state, scope), data)
+  return data
+end
+
+local function completion_list(forge_mod, f, kind, states, fetch_state, scope)
+  return cached_completion_list(forge_mod, kind, states, scope)
+    or fetch_completion_list(forge_mod, f, kind, fetch_state or states[1], scope)
+end
+
+local function pr_completion_states(verb)
+  if
+    verb == 'approve'
+    or verb == 'merge'
+    or verb == 'draft'
+    or verb == 'ready'
+    or verb == 'close'
+  then
+    return { 'open', 'all' }, 'open'
+  end
+  if verb == 'reopen' then
+    return { 'closed', 'all' }, 'closed'
+  end
+  return { 'all', 'open', 'closed' }, 'all'
+end
+
+local function issue_completion_states(verb)
+  if verb == 'close' then
+    return { 'open', 'all' }, 'open'
+  end
+  if verb == 'reopen' then
+    return { 'closed', 'all' }, 'closed'
+  end
+  return { 'all', 'open', 'closed' }, 'all'
+end
+
+local function completion_entry(value)
+  return { value = value }
+end
+
+local function pr_completion_available(verb, f, entry)
+  local availability = require('forge.availability')
+  local picker = require('forge.picker')
+  if verb == 'approve' then
+    return availability.pr_can_approve(f, entry)
+  end
+  if verb == 'merge' then
+    return availability.pr_can_merge(f, entry)
+  end
+  if verb == 'draft' then
+    return availability.pr_can_mark_draft(f, entry)
+  end
+  if verb == 'ready' then
+    return availability.pr_can_mark_ready(f, entry)
+  end
+  if verb == 'close' then
+    return picker.pr_toggle_verb(entry) == 'close'
+  end
+  if verb == 'reopen' then
+    return picker.pr_toggle_verb(entry) == 'reopen'
+  end
+  return true
+end
+
+local function issue_completion_available(verb, entry)
+  local picker = require('forge.picker')
+  if verb == 'close' then
+    return picker.issue_toggle_verb(entry) == 'close'
+  end
+  if verb == 'reopen' then
+    return picker.issue_toggle_verb(entry) == 'reopen'
+  end
+  return true
+end
+
+local function complete_pr_subjects(verb, state, prefix)
+  local f, forge_mod, scope = completion_forge(state)
+  if not f or not forge_mod then
+    return {}
+  end
+  local states, fetch_state = pr_completion_states(verb)
+  local prs = completion_list(forge_mod, f, 'pr', states, fetch_state, scope)
+  local fields = f.pr_fields or {}
+  local items = {}
+  local seen = {}
+  for _, pr in ipairs(prs or {}) do
+    local num = tostring(pr[fields.number] or '')
+    local entry = completion_entry({
+      num = num,
+      scope = scope,
+      state = pr[fields.state],
+      is_draft = fields.is_draft and pr[fields.is_draft] or nil,
+    })
+    if pr_completion_available(verb, f, entry) then
+      add_completion_candidate(items, seen, num)
+    end
+  end
+  return filter(items, prefix)
+end
+
+local function complete_issue_subjects(verb, state, prefix)
+  local f, forge_mod, scope = completion_forge(state)
+  if not f or not forge_mod then
+    return {}
+  end
+  local states, fetch_state = issue_completion_states(verb)
+  local issues = completion_list(forge_mod, f, 'issue', states, fetch_state, scope)
+  local fields = f.issue_fields or {}
+  local items = {}
+  local seen = {}
+  for _, issue in ipairs(issues or {}) do
+    local num = tostring(issue[fields.number] or '')
+    local entry = completion_entry({
+      num = num,
+      scope = scope,
+      state = issue[fields.state],
+    })
+    if issue_completion_available(verb, entry) then
+      add_completion_candidate(items, seen, num)
+    end
+  end
+  return filter(items, prefix)
+end
+
+local function complete_run_subjects(state, prefix)
+  local f, forge_mod, scope = completion_forge(state)
+  if not f or not forge_mod then
+    return {}
+  end
+  local runs = completion_list(forge_mod, f, 'ci', { 'all' }, 'all', scope)
+  local items = {}
+  local seen = {}
+  for _, run in ipairs(runs or {}) do
+    add_completion_candidate(items, seen, tostring(run.id or ''))
+  end
+  return filter(items, prefix)
+end
+
+local function complete_release_subjects(state, prefix)
+  local f, forge_mod, scope = completion_forge(state)
+  if not f or not forge_mod then
+    return {}
+  end
+  local releases = completion_list(forge_mod, f, 'release', { 'list' }, 'list', scope)
+  local fields = f.release_fields or {}
+  local items = {}
+  local seen = {}
+  for _, release in ipairs(releases or {}) do
+    add_completion_candidate(items, seen, tostring(release[fields.tag] or ''))
+  end
+  return filter(items, prefix)
+end
+
 local function completion_values(family_name, verb_name, flag_name, prefix)
   local command = M.resolve(family_name, verb_name)
   if not command then
@@ -1107,6 +1386,18 @@ local function subject_completion_items(command, state, arglead)
       system_lines({ 'git', 'rev-list', '--max-count=20', '--abbrev-commit', 'HEAD' }),
       arglead
     )
+  end
+  if subject.kind == 'pr' then
+    return complete_pr_subjects(command.name, state, arglead)
+  end
+  if subject.kind == 'issue' then
+    return complete_issue_subjects(command.name, state, arglead)
+  end
+  if subject.kind == 'run' then
+    return complete_run_subjects(state, arglead)
+  end
+  if subject.kind == 'release' then
+    return complete_release_subjects(state, arglead)
   end
   return {}
 end
@@ -1167,6 +1458,8 @@ function M.complete(arglead, cmdline, _)
   if not command then
     return {}
   end
+  command.declared_modifiers = command.modifiers or {}
+  command.declared_legacy_modifiers = command.legacy_modifiers or {}
   local rest_index = explicit_verb and 4 or 3
   local consumed = {}
   for i = rest_index, arglead == '' and #words or (#words - 1) do

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local availability = require('forge.availability')
 local layout = require('forge.layout')
 local log = require('forge.logger')
 local ops = require('forge.ops')
@@ -191,10 +192,6 @@ end
 
 local function actionable_entry(entry)
   return entry ~= nil and not entry.load_more
-end
-
-local function pr_open_entry(entry)
-  return actionable_entry(entry) and picker.pr_toggle_verb(entry) == 'close'
 end
 
 local function pr_toggle_entry(entry)
@@ -822,44 +819,6 @@ function M.pr(state, f, opts)
     M.pr(state, f, { limit = current_limit, back = opts.back, scope = ref })
   end
 
-  local function current_pr_state(entry)
-    if not actionable_entry(entry) then
-      return nil
-    end
-    return forge_mod.pr_state(f, entry.value.num, entry.value.scope)
-  end
-
-  local function merge_permission(info)
-    local permission = ((info or {}).permission or ''):upper()
-    return permission == 'WRITE' or permission == 'ADMIN' or permission == 'MAINTAIN'
-  end
-
-  local function pr_approve_entry(entry)
-    if not pr_open_entry(entry) then
-      return false
-    end
-    local pr_state = current_pr_state(entry)
-    return pr_state == nil or (pr_state.review_decision or ''):upper() ~= 'APPROVED'
-  end
-
-  local function pr_merge_entry(entry)
-    if not pr_open_entry(entry) then
-      return false
-    end
-    local pr_state = current_pr_state(entry)
-    if pr_state and pr_state.is_draft then
-      return false
-    end
-    local info = forge_mod.repo_info(f, entry.value.scope)
-    return merge_permission(info)
-      and type((info or {}).merge_methods) == 'table'
-      and #info.merge_methods > 0
-  end
-
-  local function pr_draft_entry(entry)
-    return f.capabilities.draft and pr_open_entry(entry)
-  end
-
   local actions = {
     {
       name = 'default',
@@ -915,7 +874,9 @@ function M.pr(state, f, opts)
     {
       name = 'approve',
       label = 'approve',
-      available = pr_approve_entry,
+      available = function(entry)
+        return availability.pr_can_approve(f, entry)
+      end,
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_approve(f, entry.value, {
@@ -928,7 +889,9 @@ function M.pr(state, f, opts)
     {
       name = 'merge',
       label = 'merge',
-      available = pr_merge_entry,
+      available = function(entry)
+        return availability.pr_can_merge(f, entry)
+      end,
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_merge(f, entry.value, nil, {
@@ -970,16 +933,11 @@ function M.pr(state, f, opts)
     {
       name = 'draft',
       label = function(entry)
-        if entry == nil then
-          return 'draft/ready'
-        end
-        local pr_state = current_pr_state(entry)
-        if pr_state and pr_state.is_draft then
-          return 'ready'
-        end
-        return 'draft'
+        return availability.pr_draft_label(f, entry)
       end,
-      available = pr_draft_entry,
+      available = function(entry)
+        return availability.pr_can_toggle_draft(f, entry)
+      end,
       fn = function(entry)
         if entry and not entry.load_more and f.capabilities.draft then
           pr_toggle_draft_action(f, entry.value, {

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -29,6 +29,28 @@ local function repo_scope(repo)
   }
 end
 
+local function scope_key(scope)
+  if type(scope) ~= 'table' then
+    return ''
+  end
+  return table.concat({
+    scope.kind or '',
+    scope.host or '',
+    scope.slug or '',
+  }, '|')
+end
+
+local function scoped_id(id, suffix)
+  if suffix ~= nil and suffix ~= '' then
+    return id .. '|' .. suffix
+  end
+  return id
+end
+
+local function list_key(kind, id, scope)
+  return kind .. ':' .. scoped_id(id, scope_key(scope))
+end
+
 local function use_named_current_buf(name)
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == name then
@@ -59,29 +81,34 @@ describe(':Forge command', function()
       closed_issues = {},
       browse_calls = {},
       opened_urls = {},
+      system_calls = {},
+      system_responses = {},
+      lists = {},
+      pr_states = {},
+      repo_infos = {},
     }
     old_preload = helpers.capture_preload(preload_modules)
     old_systemlist = vim.fn.systemlist
     old_system = vim.system
     old_ui_open = vim.ui.open
 
+    captured.system_responses = {
+      ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/current.git\n'),
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote'] = helpers.command_result('origin\nupstream\n'),
+      ['git branch --show-current'] = helpers.command_result('main\n'),
+      ['git config branch.main.pushRemote'] = helpers.command_result('', 1),
+      ['git rev-parse --abbrev-ref main@{upstream}'] = helpers.command_result('origin/main\n'),
+      ['git rev-list --max-count=20 --abbrev-commit HEAD'] = helpers.command_result(
+        'deadbee\nabc123\n'
+      ),
+    }
     vim.system = helpers.system_router({
       default = helpers.command_result('', 1),
-      responses = {
-        ['git remote get-url origin'] = helpers.command_result(
-          'git@github.com:owner/current.git\n'
-        ),
-        ['git remote get-url upstream'] = helpers.command_result(
-          'git@github.com:owner/upstream.git\n'
-        ),
-        ['git remote'] = helpers.command_result('origin\nupstream\n'),
-        ['git branch --show-current'] = helpers.command_result('main\n'),
-        ['git config branch.main.pushRemote'] = helpers.command_result('', 1),
-        ['git rev-parse --abbrev-ref main@{upstream}'] = helpers.command_result('origin/main\n'),
-        ['git rev-list --max-count=20 --abbrev-commit HEAD'] = helpers.command_result(
-          'deadbee\nabc123\n'
-        ),
-      },
+      calls = captured.system_calls,
+      responses = captured.system_responses,
     })
     vim.ui.open = function(url)
       table.insert(captured.opened_urls, url)
@@ -106,6 +133,8 @@ describe(':Forge command', function()
             name = 'github',
             capabilities = {
               per_pr_checks = true,
+              draft = true,
+              ci_json = true,
             },
             labels = {
               pr_one = 'PR',
@@ -114,6 +143,112 @@ describe(':Forge command', function()
               pr = 'pr',
               issue = 'issue',
             },
+            pr_fields = {
+              number = 'number',
+              title = 'title',
+              state = 'state',
+              is_draft = 'isDraft',
+            },
+            issue_fields = {
+              number = 'number',
+              title = 'title',
+              state = 'state',
+            },
+            release_fields = {
+              tag = 'tagName',
+              title = 'name',
+              is_draft = 'isDraft',
+              is_prerelease = 'isPrerelease',
+            },
+            list_pr_json_cmd = function(_, state, limit, scope)
+              local cmd = {
+                'gh',
+                'pr',
+                'list',
+                '--limit',
+                tostring(limit),
+                '--state',
+                state,
+                '--json',
+                'number,title,state,isDraft',
+              }
+              local repo = scope and scope.repo_arg or nil
+              if repo then
+                table.insert(cmd, '-R')
+                table.insert(cmd, repo)
+              end
+              return cmd
+            end,
+            list_issue_json_cmd = function(_, state, limit, scope)
+              local cmd = {
+                'gh',
+                'issue',
+                'list',
+                '--limit',
+                tostring(limit),
+                '--state',
+                state,
+                '--json',
+                'number,title,state',
+              }
+              local repo = scope and scope.repo_arg or nil
+              if repo then
+                table.insert(cmd, '-R')
+                table.insert(cmd, repo)
+              end
+              return cmd
+            end,
+            list_runs_json_cmd = function(_, branch, scope, limit)
+              local cmd = {
+                'gh',
+                'run',
+                'list',
+                '--json',
+                'databaseId,name,headBranch,status,conclusion,url',
+                '--limit',
+                tostring(limit),
+              }
+              local repo = scope and scope.repo_arg or nil
+              if repo then
+                table.insert(cmd, '-R')
+                table.insert(cmd, repo)
+              end
+              if branch then
+                table.insert(cmd, '--branch')
+                table.insert(cmd, branch)
+              end
+              return cmd
+            end,
+            list_releases_json_cmd = function(_, scope, limit)
+              local cmd = {
+                'gh',
+                'release',
+                'list',
+                '--json',
+                'tagName,name,isDraft,isPrerelease',
+                '--limit',
+                tostring(limit),
+              }
+              local repo = scope and scope.repo_arg or nil
+              if repo then
+                table.insert(cmd, '-R')
+                table.insert(cmd, repo)
+              end
+              return cmd
+            end,
+            normalize_run = function(_, entry)
+              local status = entry.status or ''
+              if status == 'completed' then
+                status = entry.conclusion or 'unknown'
+              end
+              return {
+                id = tostring(entry.databaseId or ''),
+                name = entry.name or '',
+                branch = entry.headBranch or '',
+                status = status,
+                url = entry.url or '',
+              }
+            end,
             view_web = function(_, kind, num, scope)
               captured.view_web = {
                 kind = kind,
@@ -142,6 +277,9 @@ describe(':Forge command', function()
             branch = 'main',
             head = 'abc123',
           }
+        end,
+        current_scope = function()
+          return repo_scope('current')
         end,
         config = function()
           return {
@@ -174,6 +312,23 @@ describe(':Forge command', function()
         clear_list_kind = function(kind)
           captured.cleared_kinds = captured.cleared_kinds or {}
           table.insert(captured.cleared_kinds, kind)
+        end,
+        scope_key = scope_key,
+        list_key = function(kind, state)
+          return kind .. ':' .. state
+        end,
+        get_list = function(key)
+          return captured.lists[key]
+        end,
+        set_list = function(key, value)
+          captured.lists[key] = value
+        end,
+        pr_state = function(_, num, scope)
+          return captured.pr_states[(scope and scope.slug or 'owner/current') .. '#' .. num] or {}
+        end,
+        repo_info = function(_, scope)
+          return captured.repo_infos[scope and scope.slug or 'owner/current']
+            or { permission = 'WRITE', merge_methods = { 'merge', 'squash', 'rebase' } }
         end,
         file_loc = function(range)
           local name = vim.api.nvim_buf_get_name(0)
@@ -870,5 +1025,114 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(vim.fn.getcompletion('Forge br', 'cmdline'), 'branches'))
     assert.is_false(vim.tbl_contains(vim.fn.getcompletion('Forge comm', 'cmdline'), 'commits'))
     assert.is_false(vim.tbl_contains(vim.fn.getcompletion('Forge work', 'cmdline'), 'worktrees'))
+  end)
+
+  it('completes PR subjects from cached lists with state-aware filtering', function()
+    local scope = repo_scope('current')
+    captured.lists[list_key('pr', 'open', scope)] = {
+      { number = 101, title = 'Ready', state = 'OPEN', isDraft = false },
+      { number = 102, title = 'Draft', state = 'OPEN', isDraft = true },
+      { number = 103, title = 'Approved', state = 'OPEN', isDraft = false },
+    }
+    captured.pr_states['owner/current#101'] = { review_decision = '', is_draft = false }
+    captured.pr_states['owner/current#102'] = { review_decision = '', is_draft = true }
+    captured.pr_states['owner/current#103'] = { review_decision = 'APPROVED', is_draft = false }
+
+    local approve = vim.fn.getcompletion('Forge pr approve ', 'cmdline')
+    local merge = vim.fn.getcompletion('Forge pr merge ', 'cmdline')
+    local draft = vim.fn.getcompletion('Forge pr draft ', 'cmdline')
+    local ready = vim.fn.getcompletion('Forge pr ready ', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(approve, '101'))
+    assert.is_true(vim.tbl_contains(approve, '102'))
+    assert.is_false(vim.tbl_contains(approve, '103'))
+    assert.is_true(vim.tbl_contains(merge, '101'))
+    assert.is_true(vim.tbl_contains(merge, '103'))
+    assert.is_false(vim.tbl_contains(merge, '102'))
+    assert.is_true(vim.tbl_contains(draft, '101'))
+    assert.is_true(vim.tbl_contains(draft, '103'))
+    assert.is_false(vim.tbl_contains(draft, '102'))
+    assert.is_true(vim.tbl_contains(ready, '102'))
+    assert.is_false(vim.tbl_contains(ready, '101'))
+  end)
+
+  it('completes PR reopen subjects from cached closed lists and excludes merged PRs', function()
+    local scope = repo_scope('current')
+    captured.lists[list_key('pr', 'closed', scope)] = {
+      { number = 201, title = 'Closed', state = 'CLOSED' },
+      { number = 202, title = 'Merged', state = 'MERGED' },
+    }
+
+    local reopen = vim.fn.getcompletion('Forge pr reopen ', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(reopen, '201'))
+    assert.is_false(vim.tbl_contains(reopen, '202'))
+  end)
+
+  it('uses explicit repo scope for cached subject completion', function()
+    local current = repo_scope('current')
+    local upstream = repo_scope('upstream')
+    captured.lists[list_key('pr', 'open', current)] = {
+      { number = 301, title = 'Current', state = 'OPEN', isDraft = false },
+    }
+    captured.lists[list_key('pr', 'open', upstream)] = {
+      { number = 302, title = 'Upstream', state = 'OPEN', isDraft = false },
+    }
+
+    local merge = require('forge.cmd').complete('', 'Forge pr merge repo=upstream ', 0)
+
+    assert.is_true(vim.tbl_contains(merge, '302'))
+    assert.is_false(vim.tbl_contains(merge, '301'))
+  end)
+
+  it(
+    'falls back to backend list fetches for dynamic subject completion and caches the result',
+    function()
+      local scope = repo_scope('current')
+      local key = list_key('issue', 'open', scope)
+      captured.system_responses['gh issue list --limit 100 --state open --json number,title,state -R owner/current'] =
+        helpers.command_result('[{"number":7,"title":"Bug","state":"OPEN"}]\n')
+
+      local first = vim.fn.getcompletion('Forge issue close ', 'cmdline')
+      local second = vim.fn.getcompletion('Forge issue close ', 'cmdline')
+
+      assert.is_true(vim.tbl_contains(first, '7'))
+      assert.is_true(vim.tbl_contains(second, '7'))
+      assert.same({
+        { number = 7, title = 'Bug', state = 'OPEN' },
+      }, captured.lists[key])
+      assert.equals(
+        1,
+        vim.iter(captured.system_calls):fold(0, function(acc, item)
+          return acc
+            + (
+              item
+                  == 'gh issue list --limit 100 --state open --json number,title,state -R owner/current'
+                and 1
+              or 0
+            )
+        end)
+      )
+    end
+  )
+
+  it('completes CI run ids and release tags dynamically', function()
+    local scope = repo_scope('current')
+    captured.lists[list_key('ci', 'all', scope)] = {
+      { id = '401', name = 'build', branch = 'main', status = 'success' },
+      { id = '402', name = 'test', branch = 'main', status = 'failure' },
+    }
+    captured.lists[list_key('release', 'list', scope)] = {
+      { tagName = 'v1.0.0', name = 'First' },
+      { tagName = 'v1.1.0', name = 'Second' },
+    }
+
+    local runs = vim.fn.getcompletion('Forge ci open ', 'cmdline')
+    local releases = vim.fn.getcompletion('Forge release delete ', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(runs, '401'))
+    assert.is_true(vim.tbl_contains(runs, '402'))
+    assert.is_true(vim.tbl_contains(releases, 'v1.0.0'))
+    assert.is_true(vim.tbl_contains(releases, 'v1.1.0'))
   end)
 end)


### PR DESCRIPTION
## Problem
Ex completion was still mostly grammar-driven. It could complete repos, refs, and static modifier values, but not real PR, issue, CI, or release subjects, so flows like `:Forge pr merge <Tab>` and `:Forge issue close <Tab>` could not suggest actionable items. The picker already had state- and capability-aware gating for many of these operations, which left the Ex surface drifting away from the picker surface tracked by #314 and #298.

## Solution
Add cache-backed dynamic subject completion for PRs, issues, CI runs, and releases in `forge.cmd`, using existing durable list caches first and falling back to backend list commands when the relevant cache is cold. Resolve completion scope from `repo=` when present and otherwise from the current forge scope so completion reuses the same scoped cache keys as the pickers. Extract shared PR availability helpers into `forge.availability` and use them from both picker action gating and Ex completion filtering so merge / approve / draft / ready suggestions stay aligned with picker behavior. Extend the command specs to cover cache hits, backend fallback, scoped completion, and state-aware filtering across PR, issue, CI, and release subjects.