### PR TITLE
fix(pr-picker): tailor headers for non-entity rows

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -175,7 +175,7 @@ local function render_header_for(actions, bindings, entry)
       )
     end
   end
-  if #parts < 2 then
+  if #parts == 0 then
     return nil
   end
   local separator = utils.ansi_from_hl(hls.separator, '|')
@@ -292,6 +292,9 @@ function M.pick(opts)
         initial_header = render_header_for(actions, bindings, entry)
         break
       end
+    end
+    if not initial_header and entries[1] ~= nil then
+      initial_header = render_header_for(actions, bindings, entries[1])
     end
     if not initial_header then
       initial_header = render_header_for(actions, bindings, nil)

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -7,6 +7,7 @@ local M = {}
 ---@field value any
 ---@field ordinal string?
 ---@field placeholder boolean?
+---@field placeholder_kind? 'empty'|'error'
 ---@field keep_open? boolean
 ---@field force_close boolean?
 
@@ -142,6 +143,21 @@ function M.selected(entry)
     return nil
   end
   return entry
+end
+
+---@param entry forge.PickerEntry?
+---@return 'none'|'entity'|'load_more'|'empty'|'error'
+function M.row_kind(entry)
+  if entry == nil then
+    return 'none'
+  end
+  if rawget(entry, 'load_more') then
+    return 'load_more'
+  end
+  if rawget(entry, 'placeholder') then
+    return rawget(entry, 'placeholder_kind') == 'error' and 'error' or 'empty'
+  end
+  return 'entity'
 end
 
 ---@param def forge.PickerActionDef

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -14,13 +14,15 @@ local next_ci_filter = {
 }
 
 ---@param text string
+---@param kind? 'empty'|'error'
 ---@return forge.PickerEntry
-local function placeholder_entry(text)
+local function placeholder_entry(text, kind)
   return {
     display = { { text, 'ForgeDim' } },
     value = nil,
     ordinal = text,
     placeholder = true,
+    placeholder_kind = kind or 'empty',
   }
 end
 
@@ -50,7 +52,7 @@ local function with_placeholder(entries, text)
   if #entries > 0 then
     return entries
   end
-  return { placeholder_entry(text) }
+  return { placeholder_entry(text, 'empty') }
 end
 
 local function set_clipboard(text)
@@ -191,6 +193,30 @@ end
 
 local function actionable_entry(entry)
   return entry ~= nil and not entry.load_more
+end
+
+local function picker_row_kind(entry)
+  if type(picker.row_kind) ~= 'function' then
+    if entry == nil then
+      return 'none'
+    end
+    if entry.load_more then
+      return 'load_more'
+    end
+    if entry.placeholder then
+      return entry.placeholder_kind == 'error' and 'error' or 'empty'
+    end
+    return 'entity'
+  end
+  return picker.row_kind(entry)
+end
+
+local function entity_row(entry)
+  return picker_row_kind(entry) == 'entity'
+end
+
+local function load_more_row(entry)
+  return picker_row_kind(entry) == 'load_more'
 end
 
 local function pr_open_entry(entry)
@@ -797,7 +823,7 @@ function M.pr(state, f, opts)
         end
         if not ok then
           log.error('failed to fetch ' .. f.labels.pr)
-          emit(placeholder_entry('Failed to fetch ' .. f.labels.pr))
+          emit(placeholder_entry('Failed to fetch ' .. f.labels.pr, 'error'))
           emit(nil)
           return
         end
@@ -860,10 +886,42 @@ function M.pr(state, f, opts)
     return f.capabilities.draft and pr_open_entry(entry)
   end
 
+  local function pr_entity_only(entry)
+    return entity_row(entry)
+  end
+
+  local function pr_load_more_or_entity(entry)
+    return entity_row(entry) or load_more_row(entry)
+  end
+
+  local function pr_create_visible(entry)
+    local kind = picker_row_kind(entry)
+    return kind == 'none'
+      or kind == 'load_more'
+      or kind == 'empty'
+      or kind == 'error'
+      or kind == 'entity'
+  end
+
+  local function pr_filter_visible(entry)
+    local kind = picker_row_kind(entry)
+    return kind ~= 'error'
+  end
+
+  local function pr_refresh_visible(_)
+    return true
+  end
+
   local actions = {
     {
       name = 'default',
-      label = 'checkout',
+      label = function(entry)
+        if load_more_row(entry) then
+          return 'load more'
+        end
+        return 'checkout'
+      end,
+      available = pr_load_more_or_entity,
       fn = function(entry)
         if entry and entry.load_more then
           current_limit = entry.next_limit
@@ -877,6 +935,7 @@ function M.pr(state, f, opts)
       name = 'worktree',
       label = 'worktree',
       close = false,
+      available = pr_entity_only,
       fn = function(entry)
         if entry and not entry.load_more then
           pr_action_fns(f, entry.value).worktree()
@@ -887,6 +946,7 @@ function M.pr(state, f, opts)
       name = 'ci',
       label = 'checks',
       reload = false,
+      available = pr_entity_only,
       fn = function(entry)
         if entry and not entry.load_more then
           pr_action_fns(f, entry.value).ci({ back = back_to_list })
@@ -897,6 +957,7 @@ function M.pr(state, f, opts)
       name = 'browse',
       label = 'web',
       close = false,
+      available = pr_entity_only,
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_browse(f, entry.value)
@@ -906,6 +967,7 @@ function M.pr(state, f, opts)
     {
       name = 'edit',
       label = 'edit',
+      available = pr_entity_only,
       fn = function(entry)
         if entry and not entry.load_more then
           pr_action_fns(f, entry.value).edit()
@@ -941,6 +1003,7 @@ function M.pr(state, f, opts)
     {
       name = 'create',
       label = 'create',
+      available = pr_create_visible,
       fn = function()
         ops.pr_create({ back = opts.back, scope = ref })
       end,
@@ -993,6 +1056,7 @@ function M.pr(state, f, opts)
       name = 'filter',
       label = 'filter',
       reload = false,
+      available = pr_filter_visible,
       fn = function()
         M.pr(next_state, f, { limit = current_limit, back = opts.back, scope = ref })
       end,
@@ -1001,6 +1065,7 @@ function M.pr(state, f, opts)
       name = 'refresh',
       label = 'refresh',
       reload = false,
+      available = pr_refresh_visible,
       fn = function()
         clear_state_caches(forge_mod, 'pr', scoped_key(forge_mod, ref))
         forge_mod.clear_pr_state(nil, ref)

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -241,7 +241,7 @@ describe('fzf picker', function()
     )
   end)
 
-  it('suppresses headers for single-action pickers', function()
+  it('renders headers for single-action pickers', function()
     local picker = require('forge.picker.fzf')
     picker.pick({
       prompt = 'Issue Template> ',
@@ -258,7 +258,65 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.is_nil(captured.opts.fzf_opts['--header'])
+    assert.equals(
+      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:use]',
+      captured.opts.fzf_opts['--header']
+    )
+  end)
+
+  it('seeds dynamic headers from placeholder rows when no entity rows exist', function()
+    local picker = require('forge.picker.fzf')
+    picker.pick({
+      prompt = 'Open PRs (0)> ',
+      entries = {
+        {
+          display = { { 'Failed to fetch PRs', 'ForgeDim' } },
+          value = nil,
+          placeholder = true,
+          placeholder_kind = 'error',
+        },
+      },
+      actions = {
+        {
+          name = 'default',
+          label = function(entry)
+            if entry and entry.load_more then
+              return 'load more'
+            end
+            return 'checkout'
+          end,
+          available = function(entry)
+            return entry ~= nil and not entry.placeholder
+          end,
+          fn = function() end,
+        },
+        {
+          name = 'create',
+          label = 'create',
+          fn = function() end,
+        },
+        {
+          name = 'filter',
+          label = 'filter',
+          available = function(entry)
+            return not (entry and entry.placeholder_kind == 'error')
+          end,
+          fn = function() end,
+        },
+        {
+          name = 'refresh',
+          label = 'refresh',
+          fn = function() end,
+        },
+      },
+      picker_name = 'pr',
+    })
+
+    assert.is_not_nil(captured)
+    assert.equals(
+      '[FzfLuaHeaderBind:^A] [FzfLuaHeaderText:create][FzfLuaFzfInfo:|][FzfLuaHeaderBind:^R] [FzfLuaHeaderText:refresh]',
+      captured.opts.fzf_opts['--header']
+    )
   end)
 
   it('binds a hidden back action without adding a header hint', function()
@@ -282,7 +340,10 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.is_nil(captured.opts.fzf_opts['--header'])
+    assert.equals(
+      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:run]',
+      captured.opts.fzf_opts['--header']
+    )
     assert.is_function(captured.opts.actions['ctrl-o'])
 
     captured.opts.actions['ctrl-o']({})
@@ -324,7 +385,10 @@ describe('fzf picker', function()
     })
 
     assert.is_not_nil(captured)
-    assert.is_nil(captured.opts.fzf_opts['--header'])
+    assert.equals(
+      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:open]',
+      captured.opts.fzf_opts['--header']
+    )
     assert.is_function(captured.opts.actions['ctrl-x'])
 
     captured.opts.actions['ctrl-x']({ '1' })

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -643,9 +643,10 @@ describe('pickers', function()
   it('keeps auxiliary PR actions open', function()
     local pickers = require('forge.pickers')
     pickers.pr('open', fake_forge())
+    captured.stream(function() end)
 
     assert.is_not_nil(captured)
-    assert.equals('checkout', action_by_name('default').label)
+    assert.equals('checkout', helpers.action_labels(captured.actions, captured.entries[1]).default)
     for _, case in ipairs({
       { name = 'browse', close = false },
       { name = 'worktree', close = false },
@@ -665,6 +666,9 @@ describe('pickers', function()
     local pickers = require('forge.pickers')
     pickers.pr('open', fake_forge())
     captured.stream(function() end)
+    vim.wait(100, function()
+      return captured.entries[1] ~= nil
+    end)
 
     assert.is_not_nil(captured)
     local entry = captured.entries[1]
@@ -704,6 +708,75 @@ describe('pickers', function()
     assert.equals('Open PRs (0)> ', captured.prompt)
     assert.equals('No open PRs', captured.entries[1].display[1][1])
     assert.is_true(captured.entries[1].placeholder)
+    assert.equals('empty', captured.entries[1].placeholder_kind)
+  end)
+
+  it('shows only global header actions on empty PR rows', function()
+    cache['pr:open'] = {}
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+    captured.stream(function() end)
+
+    local labels = helpers.action_labels(captured.actions, captured.entries[1])
+    assert.is_nil(labels.default)
+    assert.is_nil(labels.worktree)
+    assert.is_nil(labels.ci)
+    assert.is_nil(labels.browse)
+    assert.is_nil(labels.edit)
+    assert.is_nil(labels.approve)
+    assert.is_nil(labels.merge)
+    assert.is_nil(labels.toggle)
+    assert.is_nil(labels.draft)
+    assert.equals('create', labels.create)
+    assert.equals('filter', labels.filter)
+    assert.equals('refresh', labels.refresh)
+  end)
+
+  it('shows only global header actions on PR error rows', function()
+    cache['pr:open'] = nil
+
+    local old_system = vim.system
+    vim.system = function(_, _, cb)
+      if cb then
+        cb({ code = 1, stdout = '', stderr = 'boom' })
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '', stderr = 'boom' }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+    vim.system = old_system
+
+    assert.equals('error', streamed[1].placeholder_kind)
+    local labels = helpers.action_labels(captured.actions, streamed[1])
+    assert.is_nil(labels.default)
+    assert.is_nil(labels.worktree)
+    assert.is_nil(labels.ci)
+    assert.is_nil(labels.browse)
+    assert.is_nil(labels.edit)
+    assert.is_nil(labels.approve)
+    assert.is_nil(labels.merge)
+    assert.is_nil(labels.toggle)
+    assert.is_nil(labels.draft)
+    assert.equals('create', labels.create)
+    assert.is_nil(labels.filter)
+    assert.equals('refresh', labels.refresh)
   end)
 
   it('opens the PR picker immediately on fzf before the fetch completes', function()
@@ -909,6 +982,39 @@ describe('pickers', function()
     )
     assert.equals('Load more...', captured.entries[3].display[1][1])
     assert.is_true(captured.entries[3].load_more)
+  end)
+
+  it('shows only active header actions on PR load more rows', function()
+    vim.g.forge = {
+      display = {
+        limits = {
+          pulls = 2,
+        },
+      },
+    }
+    cache['pr:open'] = {
+      { number = 42, title = 'Newer', state = 'OPEN', author = 'bob', created_at = '' },
+      { number = 13, title = 'Middle', state = 'OPEN', author = 'cora', created_at = '' },
+      { number = 7, title = 'Older', state = 'OPEN', author = 'alice', created_at = '' },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+    captured.stream(function() end)
+
+    local labels = helpers.action_labels(captured.actions, captured.entries[3])
+    assert.equals('load more', labels.default)
+    assert.is_nil(labels.worktree)
+    assert.is_nil(labels.ci)
+    assert.is_nil(labels.browse)
+    assert.is_nil(labels.edit)
+    assert.is_nil(labels.approve)
+    assert.is_nil(labels.merge)
+    assert.is_nil(labels.toggle)
+    assert.is_nil(labels.draft)
+    assert.equals('create', labels.create)
+    assert.equals('filter', labels.filter)
+    assert.equals('refresh', labels.refresh)
   end)
 
   it('fetches more PRs in place when the load more row is activated', function()


### PR DESCRIPTION
## Problem

PR picker headers treated placeholder and load-more rows like normal PR rows, so empty and error states exposed the wrong actions, load-more rows still hinted at checkout, and single-action headers could disappear entirely.

## Solution

Add explicit picker row-kind semantics for PR placeholders, make PR action visibility and labels depend on the current row kind, and seed FZF headers from the first available row so placeholder-only and single-action pickers still render truthful header hints.