### PR TITLE
Make review the canonical PR command surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ without leaving your editor.
 
 ## Features
 
-- Pull request workflows: list, create, checkout, edit, worktree, merge,
-  approve, draft/ready
+- Pull request workflows: list, create, review via configurable adapters
+  (`checkout`, `worktree`, or custom integrations), edit, merge, approve,
+  draft/ready
 - Issue workflows: list, create, edit, browse, close/reopen
 - CI/CD workflows: list runs, filter by status, inspect summaries, stream logs
 - Forge web browsing and file/line permalinks

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -103,6 +103,13 @@ Top-level keys: ~
   `ci.split`        `string?`  (default `nil`, inherits from `split`)
     Split direction for CI views. Overrides the global `split`.
 
+`review`                                                 *forge-config-review*
+  `review.adapter`  `string`  (default `"checkout"`)
+    Default review adapter used by `:Forge review {num}` and the PR picker's
+    primary action. Built-in adapters are `"checkout"`, `"worktree"`, and
+    `"browse"`. Custom adapters can be registered via
+    `require('forge').register_review_adapter()`.
+
 `targets`                                               *forge-config-targets*
   `targets.aliases`      `table<string, string>`  (default `{}`)
     Symbolic target aliases used by the normalized `:Forge` command
@@ -185,9 +192,7 @@ Top-level keys: ~
   Defaults: >lua
       keys = {
         pr = {
-          worktree = '<c-w>',
           ci = '<c-t>',
-          browse = '<c-x>',
           edit = '<c-e>',
           approve = '<c-y>',
           merge = '<c-g>',
@@ -227,9 +232,11 @@ Top-level keys: ~
       }
 <
 
-  `keys.pr` supports secondary bindings for `worktree`, `ci`, `browse`,
-  `edit`, `approve`, `merge`, `create`, `toggle`, `draft`, and `refresh`.
-  The primary PR action remains `<cr>` checkout.
+  `keys.pr` supports secondary bindings for `ci`, `edit`, `approve`,
+  `merge`, `create`, `toggle`, `draft`, and `refresh`.
+  The primary PR action remains `<cr>` review. Its visible label comes from
+  the active review adapter, so the default header still shows `checkout`
+  until `review.adapter` or `adapter=` chooses something else.
 
   `keys.ci` supports secondary bindings for `browse`, `toggle`, filter
   cycling, and `refresh`. The primary CI action remains `<cr>` open.
@@ -302,6 +309,7 @@ COMMAND COMPLETION                                  *forge-command-completion*
     - families are suggested after `:Forge `
     - verbs are suggested after a family such as `:Forge pr `
     - only valid modifiers are suggested for the resolved subcommand
+    - `adapter=` suggests built-in and registered review adapters
     - `repo=` suggests configured aliases, git remotes, and resolved repo
       addresses
     - `branch=` suggests local branches and tags
@@ -345,15 +353,13 @@ PR COMMANDS                                            *forge-pr-commands*
     context. Forge does not remember a hidden "current PR" between
     commands.
 
-`:Forge pr checkout` {num} [repo=...]                     *:Forge-pr-checkout*
-    Check out the branch for PR `{num}`.
-
-`:Forge pr worktree` {num} [repo=...]                     *:Forge-pr-worktree*
-    Fetch PR `{num}` and create a git worktree.
-
-`:Forge pr browse` [{num}] [repo=...]                       *:Forge-pr-browse*
-    Open PR `{num}` in the browser, or the PR list landing page when
-    `{num}` is omitted.
+:Forge review {num} [repo=...] [adapter=...]                   *:Forge-review*
+    Open PR `{num}` through the configured review adapter. When `adapter=` is
+    omitted, Forge uses `review.adapter` (default: `checkout`).
+    Built-in adapters:
+    `checkout`         Check out the branch for PR `{num}`.
+    `worktree`         Fetch PR `{num}` and create a git worktree.
+    `browse`           Open PR `{num}` in the browser.
 
 `:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
     Approve PR `{num}`.
@@ -453,35 +459,14 @@ BROWSE COMMANDS                                    *forge-browse-commands*
 
 REVIEW COMMANDS                                    *forge-review-commands*
 
-`:Forge review branch` [{branch}]                       *:Forge-review-branch*
-    Start a branch review session. Defaults to the current branch and
-    compares it against the detected default base branch.
+Forge treats review as adapter dispatch rather than owning a native review UI.
+Use `:Forge review {num}` for the semantic "review this PR" action, then pick
+an adapter with config or `adapter=...`:
 
-`:Forge review commit` [{sha}]                          *:Forge-review-commit*
-    Start a commit review session. Defaults to the current `HEAD` commit
-    and compares it against its first parent.
-
-`:Forge review end`                                        *:Forge-review-end*
-    End the current review session.
-
-`:Forge review files`                                    *:Forge-review-files*
-    Open the changed-files review index for the active review session.
-
-`:Forge review next-file`                            *:Forge-review-next-file*
-    Open the next file in the active review session, wrapping at the end.
-
-`:Forge review prev-file`                            *:Forge-review-prev-file*
-    Open the previous file in the active review session, wrapping at the
-    beginning.
-
-`:Forge review next-hunk`                            *:Forge-review-next-hunk*
-    Jump to the next hunk in the active review view.
-
-`:Forge review prev-hunk`                            *:Forge-review-prev-hunk*
-    Jump to the previous hunk in the active review view.
-
-`:Forge review toggle`                                  *:Forge-review-toggle*
-    Toggle between patch and file-context view.
+  `:Forge review 42`                     Use `review.adapter`
+  `:Forge review 42 adapter=checkout`   Check out PR `42`
+  `:Forge review 42 adapter=worktree`   Create a worktree for PR `42`
+  `:Forge review 42 adapter=browse`     Open PR `42` in the browser
 
 CACHE COMMANDS                                      *forge-cache-commands*
 
@@ -595,10 +580,11 @@ placeholder row instead of appearing blank.
 PR PICKER ~ Lists PRs/MRs with number, title, author, and relative time.
 
   Action      Default Key    Description ~
-  `checkout`    `<cr>`           Check out the selected PR
-  `worktree`    `<c-w>`          Create worktree from PR
+  `review`      `<cr>`           Open the selected PR through the configured
+                               review adapter. The visible header label uses
+                               the adapter label, so the default appears as
+                               `checkout`.
   `ci`          `<c-t>`          Open CI checks picker for this PR
-  `browse`      `<c-x>`          Open PR in browser
   `edit`        `<c-e>`          Edit the selected PR
   `approve`     `<c-y>`          Approve the selected PR
   `merge`       `<c-g>`          Merge the selected PR
@@ -692,9 +678,9 @@ nested pickers and help docs carry the workflow detail.
 
 CLI parity: ~
 - Explicit forge actions exposed in pickers are also available through
-  `:Forge` when they can be addressed directly: create, edit, browse, close,
-  reopen, checkout, worktree, approve, merge, draft/ready, CI open, and
-  release browse/delete.
+  `:Forge` when they can be addressed directly: review, create, edit, browse,
+  close, reopen, approve, merge, draft/ready, CI open, and release
+  browse/delete.
 - Picker-only actions are the list workflow itself and row-scoped helpers such
   as filter/refresh/load more, nested per-PR checks, and copy-to-clipboard
   helpers.
@@ -1239,8 +1225,8 @@ CALLING FORGE FROM YOUR OWN PICKER             *forge-extending-custom-picker*
 The simplest pattern is to build a master picker in your own config (using
 `fzf-lua`, snacks.nvim, or any backend), list the forge sections you care
 about, and bind each row to `require('forge').open()`. Forge-specific rows
-inherit all built-in actions (checkout, worktree, browse, merge, approve,
-etc.). Non-forge rows can call into whatever you already use for local git.
+inherit all built-in forge actions (review, merge, approve, edit, CI, etc.).
+Non-forge rows can call into whatever you already use for local git.
 >lua
     local forge = require('forge')
     local fzf = require('fzf-lua')
@@ -1277,14 +1263,14 @@ CALLING VERBS DIRECTLY                                 *forge-extending-verbs*
 
 When you already have a PR number, issue number, run id, or commit in hand and
 do not need a picker, call `require('forge.ops')` directly. This is the layer
-`:Forge pr checkout 42` and the PR picker's `<cr>` both dispatch to. >lua
+`:Forge review 42` and the PR picker's `<cr>` both dispatch to. >lua
     local forge = require('forge')
     local ops = require('forge.ops')
     local f = assert(forge.detect(), 'no forge detected')
 
-    ops.pr_browse(f, { num = '42' })
-    ops.pr_checkout(f, { num = '42' })
-    ops.pr_worktree(f, { num = '42' })
+    ops.pr_review(f, { num = '42' })
+    ops.pr_review(f, { num = '42' }, { adapter = 'browse' })
+    ops.pr_review(f, { num = '42' }, { adapter = 'worktree' })
     ops.ci_open(f, { id = '987654321' })
     ops.browse_commit({ commit = 'abc1234' })
     ops.browse_branch('main')
@@ -1381,9 +1367,18 @@ SHARED OPERATIONS: `require('forge.ops')` ~
 `register_action(name, action)`
     Registers a custom root workflow action.
 
+                                             *forge.register_review_adapter()*
+`register_review_adapter(name, adapter)`
+    Registers a custom review adapter.
+
                                                           *forge.run_action()*
 `run_action(name, opts?)`
     Runs a registered action by name.
+
+                                                *forge.review_adapter_names()*
+`review_adapter_names()`
+    Return: ~
+        (`string[]`) Built-in and registered review adapter names
 
                                                   *forge.registered_sources()*
 `registered_sources()`
@@ -1565,8 +1560,7 @@ PUBLIC API: `require('forge.pickers')` ~
                                                *forge.pickers.pr_action_fns()*
 `pr_action_fns(f, num)`
     Returns `table<string, function>`. Action functions for PR `num`,
-    keyed by action name (`"checkout"`, `"worktree"`, `"browse"`, `"ci"`,
-    `"edit"`).
+    keyed by action name (`"review"`, `"ci"`, `"edit"`).
 
                                                  *forge.pickers.issue_close()*
 `issue_close(f, num)`
@@ -1579,10 +1573,11 @@ PUBLIC API: `require('forge.pickers')` ~
 PUBLIC API: `require('forge.ops')` ~                               *forge-ops*
 
 The `ops` module is the verb layer. Each function is the same entry point
-`:Forge` and the built-in pickers dispatch to, so calling `ops.pr_browse(f, {
-num = '42' })` from your config is identical to running `:Forge pr browse 42`
-or pressing `browse` in the PR picker. Functions that take a ref accept either
-a bare id (`num`, `id`, or `tag`) or a normalized table with `scope` and
+`:Forge` and the built-in pickers dispatch to, so calling `ops.pr_review(f, {
+num = '42' }, { adapter = 'browse' })` from your config is identical to
+running `:Forge review 42 adapter=browse` or selecting the equivalent PR
+action from the picker. Functions that take a ref accept either a bare id
+(`num`, `id`, or `tag`) or a normalized table with `scope` and
 `num`/`id`/`tag`.
 
                                                          *forge.ops.pr_list()*
@@ -1597,17 +1592,10 @@ a bare id (`num`, `id`, or `tag`) or a normalized table with `scope` and
 `pr_edit(pr)`
     Opens the PR edit compose buffer for `pr`.
 
-                                                     *forge.ops.pr_checkout()*
-`pr_checkout(f, pr)`
-    Checks out the branch for `pr` via the forge CLI.
-
-                                                       *forge.ops.pr_browse()*
-`pr_browse(f, pr)`
-    Opens `pr` in the browser.
-
-                                                     *forge.ops.pr_worktree()*
-`pr_worktree(f, pr)`
-    Fetches `pr` and creates a git worktree for it.
+                                                       *forge.ops.pr_review()*
+`pr_review(f, pr, opts?)`
+    Opens `pr` through the configured or explicit review adapter. `opts` may
+    include `{ adapter = 'name' }`.
 
                                                            *forge.ops.pr_ci()*
 `pr_ci(f, pr, opts?)`

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -10,6 +10,7 @@ local modifiers = {
   target = { kind = 'value', target = 'location' },
   head = { kind = 'value', target = 'rev' },
   base = { kind = 'value', target = 'rev' },
+  adapter = { kind = 'value' },
   method = { kind = 'value', values = { 'merge', 'squash', 'rebase' } },
   all = { kind = 'flag' },
   draft = { kind = 'flag' },
@@ -33,9 +34,6 @@ local families = {
     name = 'pr',
     surface = 'forge',
     verb_order = {
-      'checkout',
-      'worktree',
-      'browse',
       'close',
       'reopen',
       'create',
@@ -47,18 +45,6 @@ local families = {
       'refresh',
     },
     verbs = {
-      checkout = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
-      },
-      worktree = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
-      },
-      browse = {
-        subject = { kind = 'pr', min = 0, max = 1 },
-        modifiers = { 'repo' },
-      },
       close = {
         subject = { kind = 'pr', min = 1, max = 1 },
         modifiers = { 'repo' },
@@ -94,6 +80,18 @@ local families = {
       refresh = {
         subject = { min = 0, max = 0 },
         modifiers = { 'repo' },
+      },
+    },
+  },
+  {
+    name = 'review',
+    surface = 'forge',
+    default_verb = 'open',
+    verb_order = { 'open' },
+    verbs = {
+      open = {
+        subject = { kind = 'pr', min = 1, max = 1 },
+        modifiers = { 'repo', 'adapter' },
       },
     },
   },
@@ -233,6 +231,9 @@ local function subject_error(family, verb, missing)
   if family == 'issue' then
     return missing and 'missing issue number' or 'too many arguments'
   end
+  if family == 'review' then
+    return missing and 'missing PR number' or 'too many arguments'
+  end
   if family == 'release' then
     return missing and 'missing release tag' or 'too many arguments'
   end
@@ -252,6 +253,9 @@ local function unknown_verb_error(family, verb)
   end
   if family == 'issue' then
     return 'unknown issue action: ' .. verb
+  end
+  if family == 'review' then
+    return 'unknown review action: ' .. verb
   end
   if family == 'release' then
     return 'unknown release action: ' .. verb
@@ -412,22 +416,6 @@ local function dispatch_pr(command)
     ops.pr_edit({ num = num, scope = scope })
     return
   end
-  if command.name == 'checkout' then
-    ops.pr_checkout(f, { num = num, scope = scope })
-    return
-  end
-  if command.name == 'worktree' then
-    ops.pr_worktree(f, { num = num, scope = scope })
-    return
-  end
-  if command.name == 'browse' then
-    if num then
-      ops.pr_browse(f, { num = num, scope = scope })
-    else
-      ops.list_browse(f, 'pr', { scope = scope })
-    end
-    return
-  end
   if command.name == 'approve' then
     ops.pr_approve(f, { num = num, scope = scope })
     return
@@ -458,6 +446,21 @@ local function dispatch_pr(command)
     return
   end
   warn(('unsupported pr action: %s'):format(command.name))
+end
+
+local function dispatch_review(command)
+  if not require_git_or_warn() then
+    return
+  end
+  local f = require_forge_or_warn()
+  if not f then
+    return
+  end
+  local num = command.subjects[1]
+  local scope = resolve_scope_modifier(command, f.name)
+  ops.pr_review(f, { num = num, scope = scope }, {
+    adapter = command.modifiers.adapter ~= true and command.modifiers.adapter or nil,
+  })
 end
 
 local function dispatch_issue(command)
@@ -600,6 +603,7 @@ end
 
 local dispatchers = {
   pr = dispatch_pr,
+  review = dispatch_review,
   issue = dispatch_issue,
   ci = dispatch_ci,
   release = dispatch_release,
@@ -1358,6 +1362,9 @@ local function completion_values(family_name, verb_name, flag_name, prefix)
   end
   if flag_name == 'template' then
     return filter(require('forge').template_slugs(), prefix or '')
+  end
+  if flag_name == 'adapter' then
+    return filter(require('forge').review_adapter_names(), prefix or '')
   end
   if command.modifier_values and command.modifier_values[flag_name] then
     return filter(command.modifier_values[flag_name], prefix or '')

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -6,6 +6,7 @@ local M = {}
 ---@field debug boolean|string?
 ---@field split forge.Split
 ---@field ci forge.CIConfig
+---@field review forge.ReviewConfig
 ---@field sources table<string, forge.SourceConfig>
 ---@field keys forge.KeysConfig|false
 ---@field display forge.DisplayConfig
@@ -14,6 +15,9 @@ local M = {}
 ---@field lines integer
 ---@field split forge.Split?
 ---@field refresh integer
+
+---@class forge.ReviewConfig
+---@field adapter string
 
 ---@class forge.SourceConfig
 ---@field hosts string[]
@@ -26,9 +30,7 @@ local M = {}
 ---@field log forge.LogViewerKeys?
 
 ---@class forge.PRPickerKeys
----@field worktree string|false
 ---@field ci string|false
----@field browse string|false
 ---@field edit string|false
 ---@field approve string|false
 ---@field merge string|false
@@ -95,6 +97,7 @@ local DEFAULTS = {
   debug = false,
   split = 'horizontal',
   ci = { lines = 1000, refresh = 5 },
+  review = { adapter = 'checkout' },
   targets = {
     aliases = {},
   },
@@ -118,9 +121,7 @@ local DEFAULTS = {
   },
   keys = {
     pr = {
-      worktree = '<c-w>',
       ci = '<c-t>',
-      browse = '<c-x>',
       edit = '<c-e>',
       approve = '<c-y>',
       merge = '<c-g>',
@@ -325,8 +326,10 @@ function M.config()
   end, "'horizontal' or 'vertical'")
   vim.validate('forge.display', cfg.display, 'table')
   vim.validate('forge.ci', cfg.ci, 'table')
+  vim.validate('forge.review', cfg.review, 'table')
   vim.validate('forge.ci.lines', cfg.ci.lines, integer_at_least(0), 'integer >= 0')
   vim.validate('forge.ci.refresh', cfg.ci.refresh, integer_at_least(0), 'integer >= 0')
+  vim.validate('forge.review.adapter', cfg.review.adapter, nonempty_string, 'non-empty string')
   vim.validate('forge.targets', cfg.targets, 'table')
   if cfg.ci.split ~= nil then
     vim.validate('forge.ci.split', cfg.ci.split, function(v)
@@ -387,9 +390,7 @@ function M.config()
     if keys.pr ~= nil then
       vim.validate('forge.keys.pr', keys.pr, 'table')
       for _, k in ipairs({
-        'worktree',
         'ci',
-        'browse',
         'edit',
         'approve',
         'merge',

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -6,6 +6,7 @@ local compose_mod = require('forge.compose')
 local config_mod = require('forge.config')
 local context_mod = require('forge.context')
 local format_mod = require('forge.format')
+local review_mod = require('forge.review')
 local scope_mod = require('forge.scope')
 local template_mod = require('forge.template')
 
@@ -21,11 +22,16 @@ end
 M.register_source = M.register
 M.register_context_provider = context_mod.register
 M.register_action = action_mod.register
+M.register_review_adapter = review_mod.register
 M.run_action = action_mod.run
 
 ---@return table<string, forge.Forge>
 function M.registered_sources()
   return sources
+end
+
+function M.review_adapter_names()
+  return review_mod.names()
 end
 
 ---@type table<string, forge.Forge>

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -166,52 +166,10 @@ end
 
 ---@param f forge.Forge
 ---@param pr forge.PRRefLike
-function M.pr_checkout(f, pr)
+---@param opts? table
+function M.pr_review(f, pr, opts)
   pr = normalize_pr_ref(pr)
-  local kind = f.labels.pr_one
-  log.info(('checking out %s #%s...'):format(kind, pr.num))
-  vim.system(f:checkout_cmd(pr.num, pr.scope), { text = true }, function(result)
-    vim.schedule(function()
-      if result.code == 0 then
-        log.info(('checked out %s #%s'):format(kind, pr.num))
-      else
-        log.error(cmd_error(result, 'checkout failed'))
-      end
-    end)
-  end)
-end
-
----@param f forge.Forge
----@param pr forge.PRRefLike
-function M.pr_browse(f, pr)
-  pr = normalize_pr_ref(pr)
-  f:view_web(f.kinds.pr, pr.num, pr.scope)
-end
-
----@param f forge.Forge
----@param pr forge.PRRefLike
-function M.pr_worktree(f, pr)
-  pr = normalize_pr_ref(pr)
-  local kind = f.labels.pr_one
-  local fetch_cmd = f:fetch_pr(pr.num, pr.scope)
-  local branch = fetch_cmd[#fetch_cmd]:match(':(.+)$')
-  if not branch then
-    return
-  end
-  local root = vim.trim(vim.fn.system('git rev-parse --show-toplevel'))
-  local wt_path = vim.fs.normalize(root .. '/../' .. branch)
-  log.info(('fetching %s #%s into worktree...'):format(kind, pr.num))
-  vim.system(fetch_cmd, { text = true }, function()
-    vim.system({ 'git', 'worktree', 'add', wt_path, branch }, { text = true }, function(result)
-      vim.schedule(function()
-        if result.code == 0 then
-          log.info(('worktree at %s'):format(wt_path))
-        else
-          log.error(cmd_error(result, 'worktree failed'))
-        end
-      end)
-    end)
-  end)
+  require('forge.review').open(f, pr, opts)
 end
 
 ---@param f forge.Forge

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -163,14 +163,8 @@ end
 ---@return table<string, function>
 local function pr_action_fns(f, pr)
   return {
-    checkout = function()
-      ops.pr_checkout(f, pr)
-    end,
-    browse = function()
-      ops.pr_browse(f, pr)
-    end,
-    worktree = function()
-      ops.pr_worktree(f, pr)
+    review = function()
+      ops.pr_review(f, pr)
     end,
     ci = function(opts)
       ops.pr_ci(f, pr, opts)
@@ -878,7 +872,7 @@ function M.pr(state, f, opts)
         if load_more_row(entry) then
           return 'load more'
         end
-        return 'checkout'
+        return require('forge.review').label()
       end,
       available = pr_load_more_or_entity,
       fn = function(entry)
@@ -886,18 +880,7 @@ function M.pr(state, f, opts)
           current_limit = entry.next_limit
           prs_stale = true
         elseif entry then
-          pr_action_fns(f, entry.value).checkout()
-        end
-      end,
-    },
-    {
-      name = 'worktree',
-      label = 'worktree',
-      close = false,
-      available = pr_entity_only,
-      fn = function(entry)
-        if entry and not entry.load_more then
-          pr_action_fns(f, entry.value).worktree()
+          pr_action_fns(f, entry.value).review()
         end
       end,
     },
@@ -909,17 +892,6 @@ function M.pr(state, f, opts)
       fn = function(entry)
         if entry and not entry.load_more then
           pr_action_fns(f, entry.value).ci({ back = back_to_list })
-        end
-      end,
-    },
-    {
-      name = 'browse',
-      label = 'web',
-      close = false,
-      available = pr_entity_only,
-      fn = function(entry)
-        if entry and not entry.load_more then
-          ops.pr_browse(f, entry.value)
         end
       end,
     },

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -37,7 +37,7 @@ local function adapter_name(opts)
     return explicit
   end
   local cfg = require('forge').config()
-  local configured = trim(((cfg.review or {}).adapter))
+  local configured = trim((cfg.review or {}).adapter)
   if configured ~= '' then
     return configured
   end
@@ -79,15 +79,19 @@ local function builtins()
         local wt_path = vim.fs.normalize(root .. '/../' .. branch)
         log.info(('fetching %s #%s into worktree...'):format(kind, pr.num))
         vim.system(fetch_cmd, { text = true }, function()
-          vim.system({ 'git', 'worktree', 'add', wt_path, branch }, { text = true }, function(result)
-            vim.schedule(function()
-              if result.code == 0 then
-                log.info(('worktree at %s'):format(wt_path))
-              else
-                log.error(cmd_error(result, 'worktree failed'))
-              end
-            end)
-          end)
+          vim.system(
+            { 'git', 'worktree', 'add', wt_path, branch },
+            { text = true },
+            function(result)
+              vim.schedule(function()
+                if result.code == 0 then
+                  log.info(('worktree at %s'):format(wt_path))
+                else
+                  log.error(cmd_error(result, 'worktree failed'))
+                end
+              end)
+            end
+          )
         end)
       end,
     },

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -1,0 +1,204 @@
+local M = {}
+
+local log = require('forge.logger')
+
+---@type table<string, forge.ReviewAdapter>
+local adapters = {}
+
+local function trim(text)
+  if type(text) ~= 'string' then
+    return ''
+  end
+  return vim.trim(text)
+end
+
+local function cmd_error(result, fallback)
+  local msg = trim(result.stderr or '')
+  if msg == '' then
+    msg = trim(result.stdout or '')
+  end
+  if msg == '' then
+    msg = fallback
+  end
+  return msg
+end
+
+local function normalize_pr_ref(pr)
+  if type(pr) == 'table' then
+    return pr
+  end
+  return { num = pr }
+end
+
+local function adapter_name(opts)
+  opts = opts or {}
+  local explicit = trim(opts.adapter)
+  if explicit ~= '' then
+    return explicit
+  end
+  local cfg = require('forge').config()
+  local configured = trim(((cfg.review or {}).adapter))
+  if configured ~= '' then
+    return configured
+  end
+  return 'checkout'
+end
+
+local function builtins()
+  return {
+    checkout = {
+      label = 'checkout',
+      open = function(ctx)
+        local f = ctx.forge
+        local pr = ctx.pr
+        local kind = f.labels.pr_one
+        log.info(('checking out %s #%s...'):format(kind, pr.num))
+        vim.system(f:checkout_cmd(pr.num, pr.scope), { text = true }, function(result)
+          vim.schedule(function()
+            if result.code == 0 then
+              log.info(('checked out %s #%s'):format(kind, pr.num))
+            else
+              log.error(cmd_error(result, 'checkout failed'))
+            end
+          end)
+        end)
+      end,
+    },
+    worktree = {
+      label = 'worktree',
+      open = function(ctx)
+        local f = ctx.forge
+        local pr = ctx.pr
+        local kind = f.labels.pr_one
+        local fetch_cmd = f:fetch_pr(pr.num, pr.scope)
+        local branch = fetch_cmd[#fetch_cmd]:match(':(.+)$')
+        if not branch then
+          return
+        end
+        local root = trim(vim.fn.system('git rev-parse --show-toplevel'))
+        local wt_path = vim.fs.normalize(root .. '/../' .. branch)
+        log.info(('fetching %s #%s into worktree...'):format(kind, pr.num))
+        vim.system(fetch_cmd, { text = true }, function()
+          vim.system({ 'git', 'worktree', 'add', wt_path, branch }, { text = true }, function(result)
+            vim.schedule(function()
+              if result.code == 0 then
+                log.info(('worktree at %s'):format(wt_path))
+              else
+                log.error(cmd_error(result, 'worktree failed'))
+              end
+            end)
+          end)
+        end)
+      end,
+    },
+    browse = {
+      label = 'web',
+      open = function(ctx)
+        local f = ctx.forge
+        local pr = ctx.pr
+        f:view_web(f.kinds.pr, pr.num, pr.scope)
+      end,
+    },
+  }
+end
+
+function M.register(name, adapter)
+  adapters[name] = adapter
+end
+
+function M.get(name)
+  local adapter = adapters[name]
+  if adapter then
+    return adapter
+  end
+  return builtins()[name]
+end
+
+function M.names()
+  local names = {}
+  local seen = {}
+  for name in pairs(builtins()) do
+    seen[name] = true
+    names[#names + 1] = name
+  end
+  for name in pairs(adapters) do
+    if not seen[name] then
+      names[#names + 1] = name
+    end
+  end
+  table.sort(names)
+  return names
+end
+
+function M.current_name(opts)
+  return adapter_name(opts)
+end
+
+function M.label(opts)
+  local name = adapter_name(opts)
+  local adapter = M.get(name)
+  if not adapter then
+    return name
+  end
+  local label = adapter.label
+  if type(label) == 'string' and label ~= '' then
+    return label
+  end
+  return name
+end
+
+function M.context(f, pr, opts)
+  pr = normalize_pr_ref(pr)
+  opts = opts or {}
+  local ctx = {
+    forge = f,
+    pr = pr,
+    adapter = adapter_name(opts),
+    opts = opts,
+  }
+  local loaded = false
+  local details
+  local err
+  ctx.details = function()
+    if loaded then
+      return details, err
+    end
+    loaded = true
+    if type(f.fetch_pr_details_cmd) ~= 'function' or type(f.parse_pr_details) ~= 'function' then
+      err = 'review details unavailable'
+      return nil, err
+    end
+    local result = vim.system(f:fetch_pr_details_cmd(pr.num, pr.scope), { text = true }):wait()
+    if result.code ~= 0 then
+      err = cmd_error(result, 'failed to load review details')
+      return nil, err
+    end
+    local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+    if not ok or type(json) ~= 'table' then
+      err = 'failed to parse review details'
+      return nil, err
+    end
+    details = f:parse_pr_details(json)
+    if type(details) ~= 'table' then
+      details = {}
+    end
+    if details.url == nil and type(json.url) == 'string' then
+      details.url = json.url
+    end
+    return details
+  end
+  return ctx
+end
+
+function M.open(f, pr, opts)
+  local ctx = M.context(f, pr, opts)
+  local adapter = M.get(ctx.adapter)
+  if not adapter then
+    log.error('unknown review adapter: ' .. ctx.adapter)
+    return false, 'unknown review adapter'
+  end
+  adapter.open(ctx)
+  return true
+end
+
+return M

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -58,6 +58,7 @@
 ---@class forge.PRDetails
 ---@field title string
 ---@field body string
+---@field url string?
 ---@field draft boolean?
 ---@field head_branch string
 ---@field base_branch string
@@ -112,6 +113,17 @@
 ---@field template string?
 ---@field back fun()?
 ---@field scope forge.Scope?
+
+---@class forge.ReviewContext
+---@field forge forge.Forge
+---@field pr forge.PRRef
+---@field adapter string
+---@field opts table
+---@field details fun(): forge.PRDetails?, string?
+
+---@class forge.ReviewAdapter
+---@field label string|fun(ctx: forge.ReviewContext): string?
+---@field open fun(ctx: forge.ReviewContext)
 
 ---@class forge.PRState
 ---@field state string

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -69,6 +69,7 @@ describe('command schema', function()
   it('lists canonical and local command families in order', function()
     assert.same({
       'pr',
+      'review',
       'issue',
       'ci',
       'release',
@@ -82,6 +83,7 @@ describe('command schema', function()
     local issue = cmd.resolve('issue')
     local ci = cmd.resolve('ci')
     local release = cmd.resolve('release')
+    local review = cmd.resolve('review')
     local browse = cmd.resolve('browse')
     local clear = cmd.resolve('clear')
 
@@ -89,6 +91,8 @@ describe('command schema', function()
     assert.is_nil(issue)
     assert.is_nil(ci)
     assert.is_nil(release)
+    assert.equals('open', review.name)
+    assert.is_true(review.implicit)
     assert.equals('open', browse.name)
     assert.is_true(browse.implicit)
     assert.equals('run', clear.name)
@@ -98,8 +102,13 @@ describe('command schema', function()
   it('rejects implicit picker forms and parses explicit direct actions', function()
     local create = assert(cmd.parse({ 'pr', 'create', 'draft' }))
     local open = assert(cmd.parse({ 'ci', 'open', '123' }))
+    local review = assert(cmd.parse({ 'review', '42' }))
     local _, pr_missing = cmd.parse({ 'pr' })
     local _, ci_missing = cmd.parse({ 'ci' })
+    local _, review_missing = cmd.parse({ 'review' })
+    local _, pr_checkout = cmd.parse({ 'pr', 'checkout', '42' })
+    local _, pr_worktree = cmd.parse({ 'pr', 'worktree', '42' })
+    local _, pr_browse = cmd.parse({ 'pr', 'browse' })
     local _, pr_list = cmd.parse({ 'pr', 'list' })
     local _, pr_ci = cmd.parse({ 'pr', 'ci', '42' })
     local _, ci_log = cmd.parse({ 'ci', 'log', '123' })
@@ -113,8 +122,16 @@ describe('command schema', function()
     assert.equals('open', open.name)
     assert.same({ '123' }, open.subjects)
 
+    assert.equals('review', review.family)
+    assert.equals('open', review.name)
+    assert.same({ '42' }, review.subjects)
+
     assert.equals('missing action', pr_missing.message)
     assert.equals('missing action', ci_missing.message)
+    assert.equals('missing PR number', review_missing.message)
+    assert.equals('unknown pr action: checkout', pr_checkout.message)
+    assert.equals('unknown pr action: worktree', pr_worktree.message)
+    assert.equals('unknown pr action: browse', pr_browse.message)
     assert.equals('unknown pr action: list', pr_list.message)
     assert.equals('unknown pr action: ci', pr_ci.message)
     assert.equals('unknown action: log', ci_log.message)
@@ -122,13 +139,10 @@ describe('command schema', function()
   end)
 
   it('accepts argless browse for kind families that have a list landing page', function()
-    local pr = assert(cmd.parse({ 'pr', 'browse' }))
     local issue = assert(cmd.parse({ 'issue', 'browse' }))
     local ci = assert(cmd.parse({ 'ci', 'browse' }))
     local release = assert(cmd.parse({ 'release', 'browse' }))
 
-    assert.equals('browse', pr.name)
-    assert.same({}, pr.subjects)
     assert.equals('browse', issue.name)
     assert.same({}, issue.subjects)
     assert.equals('browse', ci.name)
@@ -136,10 +150,8 @@ describe('command schema', function()
     assert.equals('browse', release.name)
     assert.same({}, release.subjects)
 
-    local pr_with = assert(cmd.parse({ 'pr', 'browse', '42' }))
     local ci_with = assert(cmd.parse({ 'ci', 'browse', '123' }))
     local release_with = assert(cmd.parse({ 'release', 'browse', 'v1.2.3' }))
-    assert.same({ '42' }, pr_with.subjects)
     assert.same({ '123' }, ci_with.subjects)
     assert.same({ 'v1.2.3' }, release_with.subjects)
   end)
@@ -184,13 +196,11 @@ describe('command schema', function()
     assert.same({ 'repo' }, cmd.modifier_names('ci', 'browse'))
     assert.same({ 'repo', 'web', 'blank', 'template' }, cmd.modifier_names('issue', 'create'))
     assert.same({ 'repo', 'method' }, cmd.modifier_names('pr', 'merge'))
+    assert.same({ 'repo', 'adapter' }, cmd.modifier_names('review'))
   end)
 
-  it('keeps direct forge verbs aligned with non-list picker actions', function()
+  it('keeps direct forge verbs aligned with canonical non-list operations', function()
     assert.same({
-      'checkout',
-      'worktree',
-      'browse',
       'close',
       'reopen',
       'create',
@@ -202,6 +212,7 @@ describe('command schema', function()
       'refresh',
     }, cmd.verb_names('pr'))
 
+    assert.same({ 'open' }, cmd.verb_names('review'))
     assert.same(
       { 'browse', 'close', 'reopen', 'create', 'edit', 'refresh' },
       cmd.verb_names('issue')
@@ -250,7 +261,7 @@ describe('command schema', function()
   end)
 
   it('rejects invalid modifiers and duplicate modifiers', function()
-    local _, unknown = cmd.parse({ 'pr', 'checkout', '42', '--wat=1' })
+    local _, unknown = cmd.parse({ 'review', '42', '--wat=1' })
     local _, duplicate = cmd.parse({ 'pr', 'create', 'repo=origin', 'repo=upstream' })
 
     assert.equals('unknown modifier: wat', unknown.message)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -352,6 +352,9 @@ describe(':Forge command', function()
         template_slugs = function()
           return {}
         end,
+        review_adapter_names = function()
+          return { 'browse', 'checkout', 'worktree' }
+        end,
       }
     end
 
@@ -369,18 +372,11 @@ describe(':Forge command', function()
           table.insert(captured.ops_calls, { name = 'pr_edit', pr = pr })
           require('forge').edit_pr(pr.num, pr.scope)
         end,
-        pr_checkout = function(_, pr)
-          table.insert(captured.ops_calls, { name = 'pr_checkout', pr = pr })
-        end,
-        pr_worktree = function(_, pr)
-          table.insert(captured.ops_calls, { name = 'pr_worktree', pr = pr })
+        pr_review = function(_, pr, opts)
+          table.insert(captured.ops_calls, { name = 'pr_review', pr = pr, opts = opts or {} })
         end,
         pr_ci = function(_, pr, opts)
           table.insert(captured.ops_calls, { name = 'pr_ci', pr = pr, opts = opts })
-        end,
-        pr_browse = function(f, pr)
-          table.insert(captured.ops_calls, { name = 'pr_browse', pr = pr })
-          f:view_web(f.kinds.pr, pr.num, pr.scope)
         end,
         pr_approve = function(_, pr)
           table.insert(captured.ops_calls, { name = 'pr_approve', pr = pr })
@@ -556,6 +552,10 @@ describe(':Forge command', function()
   it('warns instead of opening interactive surfaces for missing or UI-only commands', function()
     vim.cmd('Forge')
     vim.cmd('Forge pr')
+    vim.cmd('Forge review')
+    vim.cmd('Forge pr checkout 42')
+    vim.cmd('Forge pr worktree 42')
+    vim.cmd('Forge pr browse 42')
     vim.cmd('Forge ci')
     vim.cmd('Forge release')
     vim.cmd('Forge branches')
@@ -565,6 +565,10 @@ describe(':Forge command', function()
     assert.same({
       'missing command',
       'missing action',
+      'missing PR number',
+      'unknown pr action: checkout',
+      'unknown pr action: worktree',
+      'unknown pr action: browse',
       'missing action',
       'missing action',
       'unknown command: branches',
@@ -671,39 +675,42 @@ describe(':Forge command', function()
   end)
 
   it('dispatches argless kind browse through ops.list_browse', function()
-    vim.cmd('Forge pr browse')
     vim.cmd('Forge issue browse')
     vim.cmd('Forge ci browse')
     vim.cmd('Forge release browse')
 
-    assert.same({ name = 'list_browse', kind = 'pr', opts = {} }, captured.ops_calls[1])
-    assert.same({ name = 'list_browse', kind = 'issue', opts = {} }, captured.ops_calls[2])
-    assert.same({ name = 'list_browse', kind = 'ci', opts = {} }, captured.ops_calls[3])
-    assert.same({ name = 'list_browse', kind = 'release', opts = {} }, captured.ops_calls[4])
-  end)
-
-  it('threads repo= through list_browse for argless kind browse', function()
-    vim.cmd('Forge pr browse repo=upstream')
-
-    assert.equals('list_browse', captured.ops_calls[1].name)
-    assert.equals('pr', captured.ops_calls[1].kind)
-    assert.equals('owner/upstream', captured.ops_calls[1].opts.scope.slug)
+    assert.same({ name = 'list_browse', kind = 'issue', opts = {} }, captured.ops_calls[1])
+    assert.same({ name = 'list_browse', kind = 'ci', opts = {} }, captured.ops_calls[2])
+    assert.same({ name = 'list_browse', kind = 'release', opts = {} }, captured.ops_calls[3])
   end)
 
   it('keeps argful kind browse routed to entity-scoped ops helpers', function()
-    vim.cmd('Forge pr browse 42')
     vim.cmd('Forge issue browse 7')
     vim.cmd('Forge ci browse 99')
     vim.cmd('Forge release browse v1.2.3')
 
-    assert.equals('pr_browse', captured.ops_calls[1].name)
-    assert.equals('42', captured.ops_calls[1].pr.num)
-    assert.equals('issue_browse', captured.ops_calls[2].name)
-    assert.equals('7', captured.ops_calls[2].issue.num)
-    assert.equals('ci_browse', captured.ops_calls[3].name)
-    assert.equals('99', captured.ops_calls[3].run.id)
-    assert.equals('release_browse', captured.ops_calls[4].name)
-    assert.equals('v1.2.3', captured.ops_calls[4].release.tag)
+    assert.equals('issue_browse', captured.ops_calls[1].name)
+    assert.equals('7', captured.ops_calls[1].issue.num)
+    assert.equals('ci_browse', captured.ops_calls[2].name)
+    assert.equals('99', captured.ops_calls[2].run.id)
+    assert.equals('release_browse', captured.ops_calls[3].name)
+    assert.equals('v1.2.3', captured.ops_calls[3].release.tag)
+  end)
+
+  it('dispatches review through forge.ops with adapter overrides', function()
+    vim.cmd('Forge review 42')
+    vim.cmd('Forge review 42 adapter=worktree repo=upstream')
+
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '42', scope = nil },
+      opts = {},
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '42', scope = repo_scope('upstream') },
+      opts = { adapter = 'worktree' },
+    }, captured.ops_calls[2])
   end)
 
   it('passes ex ranges through browse file resolution', function()
@@ -954,6 +961,7 @@ describe(':Forge command', function()
   it('completes families, verbs, and valid canonical modifiers contextually', function()
     local families = vim.fn.getcompletion('Forge ', 'cmdline')
     local pr = vim.fn.getcompletion('Forge pr ', 'cmdline')
+    local review = vim.fn.getcompletion('Forge review ', 'cmdline')
     local issue = vim.fn.getcompletion('Forge issue ', 'cmdline')
     local ci = vim.fn.getcompletion('Forge ci ', 'cmdline')
     local release = vim.fn.getcompletion('Forge release ', 'cmdline')
@@ -961,6 +969,7 @@ describe(':Forge command', function()
     local issue_create = vim.fn.getcompletion('Forge issue create ', 'cmdline')
 
     assert.is_true(vim.tbl_contains(families, 'pr'))
+    assert.is_true(vim.tbl_contains(families, 'review'))
     assert.is_true(vim.tbl_contains(families, 'ci'))
     assert.is_true(vim.tbl_contains(families, 'browse'))
     assert.is_false(vim.tbl_contains(families, 'branches'))
@@ -973,7 +982,12 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(pr, 'draft'))
     assert.is_true(vim.tbl_contains(pr, 'ready'))
     assert.is_true(vim.tbl_contains(pr, 'refresh'))
+    assert.is_false(vim.tbl_contains(pr, 'checkout'))
+    assert.is_false(vim.tbl_contains(pr, 'worktree'))
+    assert.is_false(vim.tbl_contains(pr, 'browse'))
     assert.is_false(vim.tbl_contains(pr, 'ci'))
+    assert.is_true(vim.tbl_contains(review, 'adapter='))
+    assert.is_true(vim.tbl_contains(review, 'repo='))
     assert.is_true(vim.tbl_contains(ci, 'open'))
     assert.is_true(vim.tbl_contains(ci, 'browse'))
     assert.is_true(vim.tbl_contains(ci, 'refresh'))
@@ -1004,6 +1018,7 @@ describe(':Forge command', function()
     local repos = vim.fn.getcompletion('Forge pr create repo=', 'cmdline')
     local revs = vim.fn.getcompletion('Forge browse rev=', 'cmdline')
     local heads = vim.fn.getcompletion('Forge pr create head=', 'cmdline')
+    local adapters = vim.fn.getcompletion('Forge review 42 adapter=', 'cmdline')
 
     assert.is_true(vim.tbl_contains(repos, 'repo=work'))
     assert.is_true(vim.tbl_contains(repos, 'repo=mirror'))
@@ -1019,6 +1034,9 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(heads, 'head=origin@'))
     assert.is_true(vim.tbl_contains(heads, 'head=@main'))
     assert.is_true(vim.tbl_contains(heads, 'head=@deadbee'))
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
   end)
 
   it('does not complete picker-only command families', function()
@@ -1042,6 +1060,7 @@ describe(':Forge command', function()
     local merge = vim.fn.getcompletion('Forge pr merge ', 'cmdline')
     local draft = vim.fn.getcompletion('Forge pr draft ', 'cmdline')
     local ready = vim.fn.getcompletion('Forge pr ready ', 'cmdline')
+    local review = vim.fn.getcompletion('Forge review ', 'cmdline')
 
     assert.is_true(vim.tbl_contains(approve, '101'))
     assert.is_true(vim.tbl_contains(approve, '102'))
@@ -1054,6 +1073,9 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(draft, '102'))
     assert.is_true(vim.tbl_contains(ready, '102'))
     assert.is_false(vim.tbl_contains(ready, '101'))
+    assert.is_true(vim.tbl_contains(review, '101'))
+    assert.is_true(vim.tbl_contains(review, '102'))
+    assert.is_true(vim.tbl_contains(review, '103'))
   end)
 
   it('completes PR reopen subjects from cached closed lists and excludes merged PRs', function()

--- a/spec/config_validation_spec.lua
+++ b/spec/config_validation_spec.lua
@@ -60,11 +60,11 @@ describe('config validation', function()
 
   it('rejects malformed key notation strings', function()
     assert.matches(
-      'forge%.keys%.pr%.browse',
+      'forge%.keys%.pr%.edit',
       config_error({
         keys = {
           pr = {
-            browse = '<not-a-real-key>',
+            edit = '<not-a-real-key>',
           },
         },
       })
@@ -86,7 +86,7 @@ describe('config validation', function()
     vim.g.forge = {
       keys = {
         pr = {
-          browse = '<c-x>',
+          edit = '<c-e>',
         },
         log = {
           refresh = '<leader>r',
@@ -96,8 +96,20 @@ describe('config validation', function()
 
     local cfg = config.config()
 
-    assert.equals('<c-x>', cfg.keys.pr.browse)
+    assert.equals('<c-e>', cfg.keys.pr.edit)
     assert.equals('<leader>r', cfg.keys.log.refresh)
+  end)
+
+  it('accepts a non-empty review adapter name', function()
+    vim.g.forge = {
+      review = {
+        adapter = 'worktree',
+      },
+    }
+
+    local cfg = config.config()
+
+    assert.equals('worktree', cfg.review.adapter)
   end)
 
   it('rejects blank source hosts and non-list host tables', function()

--- a/spec/extensibility_spec.lua
+++ b/spec/extensibility_spec.lua
@@ -36,4 +36,15 @@ describe('extensibility', function()
     assert.equals('route', captured.entry.value)
     assert.equals('current', captured.opts.context)
   end)
+
+  it('registers review adapters through the public API', function()
+    forge.register_review_adapter('custom-test-review', {
+      label = 'custom',
+      open = function(ctx)
+        captured = ctx
+      end,
+    })
+
+    assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'custom-test-review'))
+  end)
 end)

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -122,7 +122,7 @@ describe('fzf picker', function()
         },
       },
       actions = {},
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -143,7 +143,7 @@ describe('fzf picker', function()
         },
       },
       actions = {},
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -169,7 +169,7 @@ describe('fzf picker', function()
         { name = 'browse', label = 'browse', fn = function() end },
         { name = 'filter', label = 'filter', fn = function() end },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -201,7 +201,7 @@ describe('fzf picker', function()
         { name = 'browse', label = 'browse', fn = function() end },
         { name = 'filter', label = 'filter', fn = function() end },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -231,7 +231,7 @@ describe('fzf picker', function()
         { name = 'browse', label = 'browse', fn = function() end },
         { name = 'filter', label = 'filter', fn = function() end },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -309,7 +309,7 @@ describe('fzf picker', function()
           fn = function() end,
         },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -381,7 +381,7 @@ describe('fzf picker', function()
           end,
         },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -721,7 +721,7 @@ describe('fzf picker', function()
           end,
         },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -749,7 +749,7 @@ describe('fzf picker', function()
           end,
         },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)
@@ -874,7 +874,7 @@ describe('fzf picker', function()
           fn = function() end,
         },
       },
-      picker_name = 'pr',
+      picker_name = 'issue',
     })
 
     assert.is_not_nil(captured)

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -43,10 +43,12 @@ describe('config', function()
     vim.g.forge = {
       ci = { lines = 500 },
       display = { icons = { open = '>' } },
+      review = { adapter = 'worktree' },
     }
     local cfg = forge.config()
     assert.equals(500, cfg.ci.lines)
     assert.equals('>', cfg.display.icons.open)
+    assert.equals('worktree', cfg.review.adapter)
     assert.equals('m', cfg.display.icons.merged)
     assert.equals(100, cfg.display.limits.pulls)
   end)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -299,14 +299,8 @@ describe('pickers', function()
     end
     package.preload['forge.ops'] = function()
       return {
-        pr_checkout = function(_, pr)
-          table.insert(op_calls, { name = 'pr_checkout', pr = pr })
-        end,
-        pr_browse = function(_, pr)
-          table.insert(op_calls, { name = 'pr_browse', pr = pr })
-        end,
-        pr_worktree = function(_, pr)
-          table.insert(op_calls, { name = 'pr_worktree', pr = pr })
+        pr_review = function(_, pr, opts)
+          table.insert(op_calls, { name = 'pr_review', pr = pr, opts = opts or {} })
         end,
         pr_ci = function(_, pr, opts)
           table.insert(op_calls, { name = 'pr_ci', pr = pr, opts = opts })
@@ -537,7 +531,6 @@ describe('pickers', function()
     captured.stream(function() end)
     local labels = helpers.action_labels(captured.actions, captured.entries[1])
     assert.equals('checkout', labels.default)
-    assert.equals('worktree', labels.worktree)
     assert.equals('edit', labels.edit)
     assert.equals('approve', labels.approve)
     assert.equals('merge', labels.merge)
@@ -648,8 +641,6 @@ describe('pickers', function()
     assert.is_not_nil(captured)
     assert.equals('checkout', helpers.action_labels(captured.actions, captured.entries[1]).default)
     for _, case in ipairs({
-      { name = 'browse', close = false },
-      { name = 'worktree', close = false },
       { name = 'approve', close = nil },
       { name = 'merge', close = nil },
     }) do
@@ -680,7 +671,11 @@ describe('pickers', function()
     action_by_name('draft').fn(entry)
 
     assert.same({
-      { name = 'pr_checkout', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
+      {
+        name = 'pr_review',
+        pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+        opts = {},
+      },
       { name = 'pr_edit', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
       { name = 'pr_approve', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
       {
@@ -720,9 +715,7 @@ describe('pickers', function()
 
     local labels = helpers.action_labels(captured.actions, captured.entries[1])
     assert.is_nil(labels.default)
-    assert.is_nil(labels.worktree)
     assert.is_nil(labels.ci)
-    assert.is_nil(labels.browse)
     assert.is_nil(labels.edit)
     assert.is_nil(labels.approve)
     assert.is_nil(labels.merge)
@@ -766,9 +759,7 @@ describe('pickers', function()
     assert.equals('error', streamed[1].placeholder_kind)
     local labels = helpers.action_labels(captured.actions, streamed[1])
     assert.is_nil(labels.default)
-    assert.is_nil(labels.worktree)
     assert.is_nil(labels.ci)
-    assert.is_nil(labels.browse)
     assert.is_nil(labels.edit)
     assert.is_nil(labels.approve)
     assert.is_nil(labels.merge)
@@ -1004,9 +995,7 @@ describe('pickers', function()
 
     local labels = helpers.action_labels(captured.actions, captured.entries[3])
     assert.equals('load more', labels.default)
-    assert.is_nil(labels.worktree)
     assert.is_nil(labels.ci)
-    assert.is_nil(labels.browse)
     assert.is_nil(labels.edit)
     assert.is_nil(labels.approve)
     assert.is_nil(labels.merge)


### PR DESCRIPTION
## Problem

Forge's PR Ex surface repeated the same intent through multiple concrete verbs. `:Forge pr checkout`, `:Forge pr worktree`, and `:Forge pr browse` all exposed adapter mechanics directly, even though the plugin's user-facing concept is reviewing a PR.

## Solution

Introduce a review adapter layer and make `:Forge review {num}` the canonical PR command entrypoint. This keeps checkout, worktree, and browser behavior behind adapter dispatch, removes the redundant PR Ex verbs and wrapper ops, updates picker/config/API surfaces to match, and refreshes the specs and vimdoc around the new model. Verification ran with `nix develop .#ci --command busted` and `nix develop .#ci --command vimdoc-language-server check doc/`.