### PR TITLE
feat(review): add diffview adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ without leaving your editor.
 ## Features
 
 - Pull request workflows: list, create, review via configurable adapters
-  (`checkout`, `worktree`, `browse`, `diffview`, or custom integrations),
-  edit, merge, approve, draft/ready
+  (`checkout`, `worktree`, `browse`, `diffview`, or custom integrations), edit,
+  merge, approve, draft/ready
 - Issue workflows: list, create, edit, browse, close/reopen
 - CI/CD workflows: list runs, filter by status, inspect summaries, stream logs
 - Forge web browsing and file/line permalinks
@@ -26,8 +26,8 @@ without leaving your editor.
   picker workflows; requires `fzf >= 0.40.0` for per-row dynamic action hints
   (`focus:transform-header`). Older `fzf` still works but falls back to the
   initial picker-level header.
-- (Optionally) `diffview.nvim` for `review.adapter = 'diffview'` reviews
-  without checkout
+- (Optionally) `diffview.nvim` for `review.adapter = 'diffview'` reviews without
+  checkout
 
 Direct `:Forge` action commands work without `fzf-lua`. Install it only if you
 want the interactive picker UI.

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ without leaving your editor.
 ## Features
 
 - Pull request workflows: list, create, review via configurable adapters
-  (`checkout`, `worktree`, or custom integrations), edit, merge, approve,
-  draft/ready
+  (`checkout`, `worktree`, `browse`, `diffview`, or custom integrations),
+  edit, merge, approve, draft/ready
 - Issue workflows: list, create, edit, browse, close/reopen
 - CI/CD workflows: list runs, filter by status, inspect summaries, stream logs
 - Forge web browsing and file/line permalinks
@@ -26,6 +26,8 @@ without leaving your editor.
   picker workflows; requires `fzf >= 0.40.0` for per-row dynamic action hints
   (`focus:transform-header`). Older `fzf` still works but falls back to the
   initial picker-level header.
+- (Optionally) `diffview.nvim` for `review.adapter = 'diffview'` reviews
+  without checkout
 
 Direct `:Forge` action commands work without `fzf-lua`. Install it only if you
 want the interactive picker UI.

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -106,8 +106,10 @@ Top-level keys: ~
 `review`                                                 *forge-config-review*
   `review.adapter`  `string`  (default `"checkout"`)
     Default review adapter used by `:Forge review {num}` and the PR picker's
-    primary action. Built-in adapters are `"checkout"`, `"worktree"`, and
-    `"browse"`. Custom adapters can be registered via
+    primary action. Built-in adapters are `"checkout"`, `"worktree"`,
+    `"browse"`, and `"diffview"`. The `diffview` adapter opens
+    `diffview.nvim` against fetched PR refs without checking the branch out.
+    Custom adapters can be registered via
     `require('forge').register_review_adapter()`.
 
 `targets`                                               *forge-config-targets*
@@ -360,6 +362,8 @@ PR COMMANDS                                            *forge-pr-commands*
     `checkout`         Check out the branch for PR `{num}`.
     `worktree`         Fetch PR `{num}` and create a git worktree.
     `browse`           Open PR `{num}` in the browser.
+    `diffview`         Open PR `{num}` in `diffview.nvim` using explicit
+                       base/head refs.
 
 `:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
     Approve PR `{num}`.
@@ -467,6 +471,7 @@ an adapter with config or `adapter=...`:
   `:Forge review 42 adapter=checkout`   Check out PR `42`
   `:Forge review 42 adapter=worktree`   Create a worktree for PR `42`
   `:Forge review 42 adapter=browse`     Open PR `42` in the browser
+  `:Forge review 42 adapter=diffview`   Open PR `42` in `diffview.nvim`
 
 CACHE COMMANDS                                      *forge-cache-commands*
 
@@ -1174,6 +1179,8 @@ Reports on: ~
 - Forge CLI availability (`gh`, `glab`, `tea`)
 - Interactive picker UI backend (`fzf-lua`) availability
 - tree-sitter `yaml` parser availability
+- Built-in external review adapter availability (`diffview.nvim`)
+- Configured review adapter availability
 - Custom registered sources and their CLI availability
 
 ==============================================================================

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -1,7 +1,18 @@
 local M = {}
 
+local review_integrations = {
+  diffview = {
+    available = function()
+      return vim.fn.exists(':DiffviewOpen') == 2
+    end,
+    ok = 'diffview.nvim found (adapter=diffview available)',
+    info = 'diffview.nvim not found (adapter=diffview unavailable)',
+    warn = 'review.adapter=diffview but diffview.nvim is not available (:DiffviewOpen missing)',
+  },
+}
+
 function M.check()
-  vim.health.start('forge.nvim')
+  vim.health.start('Core tools')
 
   if vim.fn.executable('git') == 1 then
     vim.health.ok('git found')
@@ -9,6 +20,7 @@ function M.check()
     vim.health.error('git not found')
   end
 
+  vim.health.start('Forge CLIs')
   local clis = {
     { 'gh', 'GitHub' },
     { 'glab', 'GitLab' },
@@ -22,15 +34,17 @@ function M.check()
     end
   end
 
+  vim.health.start('Interactive picker UI')
   local ok = pcall(require, 'fzf-lua')
   if ok then
     vim.health.ok('fzf-lua found (interactive picker UI enabled)')
   else
-    vim.health.warn(
+    vim.health.info(
       'fzf-lua not found (interactive picker UI disabled; direct :Forge commands still available)'
     )
   end
 
+  vim.health.start('Tree-sitter')
   local has_yaml = pcall(vim.treesitter.language.inspect, 'yaml')
   if has_yaml then
     vim.health.ok('tree-sitter yaml parser found')
@@ -39,6 +53,36 @@ function M.check()
   end
 
   local forge_mod = require('forge')
+  local configured_adapter = vim.trim((((forge_mod.config() or {}).review or {}).adapter or ''))
+  local review_names = {}
+  for _, name in ipairs((forge_mod.review_adapter_names and forge_mod.review_adapter_names()) or {}) do
+    review_names[name] = true
+  end
+
+  vim.health.start('Review adapters')
+  for name, integration in pairs(review_integrations) do
+    local available = integration.available()
+    if configured_adapter == name then
+      if available then
+        vim.health.ok(integration.ok)
+      else
+        vim.health.warn(integration.warn)
+      end
+    elseif available then
+      vim.health.ok(integration.ok)
+    else
+      vim.health.info(integration.info)
+    end
+  end
+  if configured_adapter ~= '' and not review_integrations[configured_adapter] then
+    if review_names[configured_adapter] then
+      vim.health.ok('configured review adapter "' .. configured_adapter .. '" available')
+    else
+      vim.health.warn('configured review adapter "' .. configured_adapter .. '" is not registered')
+    end
+  end
+
+  vim.health.start('Registered sources')
   for name, source in pairs(forge_mod.registered_sources()) do
     if name ~= 'github' and name ~= 'gitlab' and name ~= 'codeberg' then
       if vim.fn.executable(source.cli) == 1 then

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -5,6 +5,21 @@ local log = require('forge.logger')
 ---@type table<string, forge.ReviewAdapter>
 local adapters = {}
 
+local function sanitize_ref_path(text)
+  if type(text) ~= 'string' then
+    return ''
+  end
+  local sanitized = text:gsub('[^%w%._/-]', '-')
+  sanitized = sanitized:gsub('/+', '/')
+  sanitized = sanitized:gsub('^/+', '')
+  sanitized = sanitized:gsub('/+$', '')
+  return sanitized
+end
+
+local function diffview_available()
+  return vim.fn.exists(':DiffviewOpen') == 2
+end
+
 local function trim(text)
   if type(text) ~= 'string' then
     return ''
@@ -28,6 +43,54 @@ local function normalize_pr_ref(pr)
     return pr
   end
   return { num = pr }
+end
+
+local function review_head_ref(pr)
+  local scope = pr.scope or {}
+  local parts = {
+    'refs/forge/review',
+    sanitize_ref_path(scope.kind or 'repo'),
+    sanitize_ref_path(scope.host or 'local'),
+    sanitize_ref_path(scope.slug or 'current'),
+    'pr',
+    sanitize_ref_path(pr.num),
+  }
+  return table.concat(parts, '/')
+end
+
+local function fetch_head_cmd(f, pr, target)
+  if type(f.fetch_pr) ~= 'function' then
+    return nil, 'review fetch unavailable'
+  end
+  local cmd = vim.deepcopy(f:fetch_pr(pr.num, pr.scope))
+  local refspec = type(cmd) == 'table' and cmd[#cmd] or nil
+  local source = type(refspec) == 'string' and refspec:match('^([^:]+):[^:]+$') or nil
+  if not source then
+    return nil, 'review fetch unavailable'
+  end
+  cmd[#cmd] = '+' .. source .. ':' .. target
+  return cmd
+end
+
+local function base_ref(ctx, details)
+  local forge = require('forge')
+  local branch = trim(details.base_branch)
+  if branch == '' then
+    return nil
+  end
+  local scope = ctx.pr.scope
+  local ref = forge.remote_ref(scope, branch)
+  if ref and ref ~= '' then
+    return ref
+  end
+  return 'origin/' .. branch
+end
+
+local function open_diffview(range)
+  return pcall(vim.api.nvim_cmd, {
+    cmd = 'DiffviewOpen',
+    args = { range },
+  }, {})
 end
 
 local function adapter_name(opts)
@@ -101,6 +164,45 @@ local function builtins()
         local f = ctx.forge
         local pr = ctx.pr
         f:view_web(f.kinds.pr, pr.num, pr.scope)
+      end,
+    },
+    diffview = {
+      label = 'diffview',
+      open = function(ctx)
+        if not diffview_available() then
+          log.error('diffview.nvim not found')
+          return
+        end
+        local details, err = ctx.details()
+        if not details then
+          log.error(err or 'failed to load review details')
+          return
+        end
+        local base = base_ref(ctx, details)
+        if not base then
+          log.error('review base unavailable')
+          return
+        end
+        local head = review_head_ref(ctx.pr)
+        local fetch_cmd, fetch_err = fetch_head_cmd(ctx.forge, ctx.pr, head)
+        if not fetch_cmd then
+          log.error(fetch_err or 'review fetch unavailable')
+          return
+        end
+        local kind = ctx.forge.labels.pr_one
+        log.info(('opening %s #%s in diffview...'):format(kind, ctx.pr.num))
+        vim.system(fetch_cmd, { text = true }, function(result)
+          vim.schedule(function()
+            if result.code ~= 0 then
+              log.error(cmd_error(result, 'review fetch failed'))
+              return
+            end
+            local ok, open_err = open_diffview(base .. '...' .. head)
+            if not ok then
+              log.error(open_err)
+            end
+          end)
+        end)
       end,
     },
   }

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -353,7 +353,7 @@ describe(':Forge command', function()
           return {}
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'worktree' }
+          return { 'browse', 'checkout', 'diffview', 'worktree' }
         end,
       }
     end
@@ -1036,6 +1036,7 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(heads, 'head=@deadbee'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
   end)
 

--- a/spec/extensibility_spec.lua
+++ b/spec/extensibility_spec.lua
@@ -45,6 +45,7 @@ describe('extensibility', function()
       end,
     })
 
+    assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'diffview'))
     assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'custom-test-review'))
   end)
 end)

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -131,7 +131,9 @@ describe('health', function()
     assert.is_true(vim.tbl_contains(captured.oks, 'git found'))
     assert.is_true(vim.tbl_contains(captured.oks, 'configured review adapter "checkout" available'))
     assert.is_true(vim.tbl_contains(captured.oks, 'fzf-lua found (interactive picker UI enabled)'))
-    assert.is_true(vim.tbl_contains(captured.infos, 'diffview.nvim not found (adapter=diffview unavailable)'))
+    assert.is_true(
+      vim.tbl_contains(captured.infos, 'diffview.nvim not found (adapter=diffview unavailable)')
+    )
     assert.is_true(
       vim.tbl_contains(
         captured.errors,

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -3,6 +3,7 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 describe('health', function()
   local captured
   local old_executable
+  local old_exists
   local old_health
   local old_inspect
   local old_preload
@@ -17,6 +18,7 @@ describe('health', function()
     }
 
     old_executable = vim.fn.executable
+    old_exists = vim.fn.exists
     old_health = {
       start = vim.health.start,
       ok = vim.health.ok,
@@ -36,6 +38,12 @@ describe('health', function()
         return 1
       end
       return 0
+    end
+    vim.fn.exists = function(name)
+      if name == ':DiffviewOpen' then
+        return 0
+      end
+      return old_exists(name)
     end
 
     vim.health.start = function(msg)
@@ -60,6 +68,16 @@ describe('health', function()
 
     package.preload['forge'] = function()
       return {
+        config = function()
+          return {
+            review = {
+              adapter = 'checkout',
+            },
+          }
+        end,
+        review_adapter_names = function()
+          return { 'browse', 'checkout', 'diffview', 'worktree' }
+        end,
         registered_sources = function()
           return {}
         end,
@@ -87,6 +105,7 @@ describe('health', function()
 
   after_each(function()
     vim.fn.executable = old_executable
+    vim.fn.exists = old_exists
     vim.health.start = old_health.start
     vim.health.ok = old_health.ok
     vim.health.info = old_health.info
@@ -107,9 +126,12 @@ describe('health', function()
   it('reports a missing yaml parser as a health error', function()
     require('forge.health').check()
 
-    assert.same({ 'forge.nvim' }, captured.starts)
+    assert.is_true(vim.tbl_contains(captured.starts, 'Core tools'))
+    assert.is_true(vim.tbl_contains(captured.starts, 'Review adapters'))
     assert.is_true(vim.tbl_contains(captured.oks, 'git found'))
+    assert.is_true(vim.tbl_contains(captured.oks, 'configured review adapter "checkout" available'))
     assert.is_true(vim.tbl_contains(captured.oks, 'fzf-lua found (interactive picker UI enabled)'))
+    assert.is_true(vim.tbl_contains(captured.infos, 'diffview.nvim not found (adapter=diffview unavailable)'))
     assert.is_true(
       vim.tbl_contains(
         captured.errors,
@@ -118,7 +140,7 @@ describe('health', function()
     )
   end)
 
-  it('warns when the interactive picker UI backend is unavailable', function()
+  it('reports missing optional interactive picker UI as info', function()
     package.preload['fzf-lua'] = nil
     package.loaded['fzf-lua'] = nil
     package.loaded['forge.health'] = nil
@@ -127,8 +149,39 @@ describe('health', function()
 
     assert.is_true(
       vim.tbl_contains(
-        captured.warns,
+        captured.infos,
         'fzf-lua not found (interactive picker UI disabled; direct :Forge commands still available)'
+      )
+    )
+  end)
+
+  it('warns when the configured diffview adapter is unavailable', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            review = {
+              adapter = 'diffview',
+            },
+          }
+        end,
+        review_adapter_names = function()
+          return { 'browse', 'checkout', 'diffview', 'worktree' }
+        end,
+        registered_sources = function()
+          return {}
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(
+      vim.tbl_contains(
+        captured.warns,
+        'review.adapter=diffview but diffview.nvim is not available (:DiffviewOpen missing)'
       )
     )
   end)

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -1,0 +1,167 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+describe('review adapters', function()
+  local captured
+  local old_preload
+  local old_system
+  local old_exists
+  local old_nvim_cmd
+  local old_schedule
+
+  before_each(function()
+    captured = {
+      calls = {},
+      cmds = {},
+      infos = {},
+      errors = {},
+    }
+    old_preload = helpers.capture_preload({ 'forge', 'forge.logger' })
+    old_system = vim.system
+    old_exists = vim.fn.exists
+    old_nvim_cmd = vim.api.nvim_cmd
+    old_schedule = vim.schedule
+
+    vim.system = helpers.system_router({
+      default = helpers.command_result('', 1),
+      calls = captured.calls,
+      responses = {
+        ['details 42'] = helpers.command_result('{}'),
+        ['git fetch origin +pull/42/head:refs/forge/review/github/github.com/owner/current/pr/42'] = helpers.command_result(
+          ''
+        ),
+      },
+    })
+    vim.fn.exists = function(name)
+      if name == ':DiffviewOpen' then
+        return 2
+      end
+      return old_exists(name)
+    end
+    vim.api.nvim_cmd = function(cmd, opts)
+      table.insert(captured.cmds, { cmd = cmd, opts = opts })
+    end
+    vim.schedule = function(fn)
+      fn()
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return { review = { adapter = 'checkout' } }
+        end,
+        remote_ref = function(_, branch)
+          return 'origin/' .. branch
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
+        error = function(msg)
+          table.insert(captured.errors, msg)
+        end,
+        warn = function() end,
+        debug = function() end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.review'] = nil
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.fn.exists = old_exists
+    vim.api.nvim_cmd = old_nvim_cmd
+    vim.schedule = old_schedule
+
+    helpers.restore_preload(old_preload)
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.review'] = nil
+  end)
+
+  it('lists diffview among built-in review adapters', function()
+    local review = require('forge.review')
+
+    assert.is_true(vim.tbl_contains(review.names(), 'diffview'))
+  end)
+
+  it('opens diffview review against fetched PR refs', function()
+    local review = require('forge.review')
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/current',
+    }
+
+    review.open({
+      labels = { pr_one = 'PR' },
+      fetch_pr = function(_, num, ref)
+        assert.equals('42', num)
+        assert.same(scope, ref)
+        return { 'git', 'fetch', 'origin', 'pull/42/head:pr-42' }
+      end,
+      fetch_pr_details_cmd = function(_, num, ref)
+        assert.equals('42', num)
+        assert.same(scope, ref)
+        return { 'details', num }
+      end,
+      parse_pr_details = function()
+        return { base_branch = 'main' }
+      end,
+    }, { num = '42', scope = scope }, { adapter = 'diffview' })
+
+    assert.same({
+      'details 42',
+      'git fetch origin +pull/42/head:refs/forge/review/github/github.com/owner/current/pr/42',
+    }, captured.calls)
+    assert.same({
+      {
+        cmd = {
+          cmd = 'DiffviewOpen',
+          args = { 'origin/main...refs/forge/review/github/github.com/owner/current/pr/42' },
+        },
+        opts = {},
+      },
+    }, captured.cmds)
+    assert.same({ 'opening PR #42 in diffview...' }, captured.infos)
+    assert.same({}, captured.errors)
+  end)
+
+  it('reports missing diffview.nvim before loading review details', function()
+    vim.fn.exists = function(name)
+      if name == ':DiffviewOpen' then
+        return 0
+      end
+      return old_exists(name)
+    end
+    package.loaded['forge.review'] = nil
+
+    local review = require('forge.review')
+
+    review.open({
+      labels = { pr_one = 'PR' },
+      fetch_pr = function()
+        error('should not fetch')
+      end,
+      fetch_pr_details_cmd = function()
+        error('should not load details')
+      end,
+      parse_pr_details = function()
+        return {}
+      end,
+    }, { num = '42' }, { adapter = 'diffview' })
+
+    assert.same({}, captured.calls)
+    assert.same({}, captured.cmds)
+    assert.same({ 'diffview.nvim not found' }, captured.errors)
+  end)
+end)


### PR DESCRIPTION
## Problem

Forge has the canonical `:Forge review` command surface now, but it still needs a first real external adapter to prove the no-checkout review path in the main repo. `diffview.nvim` is the simplest first built-in integration for that model and is tracked in #347.

## Solution

Add a built-in `diffview` review adapter that fetches the PR head into a hidden Forge ref and opens `:DiffviewOpen <base>...<head>` without checking the branch out.

Update health reporting so built-in external review adapters are surfaced cleanly, optional integrations stay informational, and a configured-but-missing `diffview` adapter warns.

Document the adapter in the README and vimdoc, add focused review/health/completion specs, and verify with `nix develop /home/barrett/dev/forge.nvim#ci --command busted` plus `nix develop /home/barrett/dev/forge.nvim#ci --command vimdoc-language-server check /home/barrett/dev/forge.nvim/doc/`.

Closes #347