### PR TITLE
refactor(cmd): extract completion policy model

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1200,78 +1200,17 @@ local function completion_list(forge_mod, f, kind, states, fetch_state, scope)
     or fetch_completion_list(forge_mod, f, kind, fetch_state or states[1], scope)
 end
 
-local function pr_completion_states(verb)
-  if
-    verb == 'approve'
-    or verb == 'merge'
-    or verb == 'draft'
-    or verb == 'ready'
-    or verb == 'close'
-  then
-    return { 'open', 'all' }, 'open'
-  end
-  if verb == 'reopen' then
-    return { 'closed', 'all' }, 'closed'
-  end
-  return { 'all', 'open', 'closed' }, 'all'
-end
-
-local function issue_completion_states(verb)
-  if verb == 'close' then
-    return { 'open', 'all' }, 'open'
-  end
-  if verb == 'reopen' then
-    return { 'closed', 'all' }, 'closed'
-  end
-  return { 'all', 'open', 'closed' }, 'all'
-end
-
 local function completion_entry(value)
   return { value = value }
 end
 
-local function pr_completion_available(verb, f, entry)
-  local availability = require('forge.availability')
-  local picker = require('forge.picker')
-  if verb == 'approve' then
-    return availability.pr_can_approve(f, entry)
-  end
-  if verb == 'merge' then
-    return availability.pr_can_merge(f, entry)
-  end
-  if verb == 'draft' then
-    return availability.pr_can_mark_draft(f, entry)
-  end
-  if verb == 'ready' then
-    return availability.pr_can_mark_ready(f, entry)
-  end
-  if verb == 'close' then
-    return picker.pr_toggle_verb(entry) == 'close'
-  end
-  if verb == 'reopen' then
-    return picker.pr_toggle_verb(entry) == 'reopen'
-  end
-  return true
-end
-
-local function issue_completion_available(verb, entry)
-  local picker = require('forge.picker')
-  if verb == 'close' then
-    return picker.issue_toggle_verb(entry) == 'close'
-  end
-  if verb == 'reopen' then
-    return picker.issue_toggle_verb(entry) == 'reopen'
-  end
-  return true
-end
-
-local function complete_pr_subjects(verb, state, prefix)
+local function complete_pr_subjects(command, state, prefix, policy)
   local f, forge_mod, scope = completion_forge(state)
   if not f or not forge_mod then
     return {}
   end
-  local states, fetch_state = pr_completion_states(verb)
-  local prs = completion_list(forge_mod, f, 'pr', states, fetch_state, scope)
+  local prs =
+    completion_list(forge_mod, f, 'pr', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.pr_fields or {}
   local items = {}
   local seen = {}
@@ -1283,20 +1222,26 @@ local function complete_pr_subjects(verb, state, prefix)
       state = pr[fields.state],
       is_draft = fields.is_draft and pr[fields.is_draft] or nil,
     })
-    if pr_completion_available(verb, f, entry) then
+    if not policy.available or policy.available(command.name, f, entry) then
       add_completion_candidate(items, seen, num)
     end
   end
   return filter(items, prefix)
 end
 
-local function complete_issue_subjects(verb, state, prefix)
+local function complete_issue_subjects(command, state, prefix, policy)
   local f, forge_mod, scope = completion_forge(state)
   if not f or not forge_mod then
     return {}
   end
-  local states, fetch_state = issue_completion_states(verb)
-  local issues = completion_list(forge_mod, f, 'issue', states, fetch_state, scope)
+  local issues = completion_list(
+    forge_mod,
+    f,
+    'issue',
+    policy.states_to_consult,
+    policy.fetch_state,
+    scope
+  )
   local fields = f.issue_fields or {}
   local items = {}
   local seen = {}
@@ -1307,19 +1252,20 @@ local function complete_issue_subjects(verb, state, prefix)
       scope = scope,
       state = issue[fields.state],
     })
-    if issue_completion_available(verb, entry) then
+    if not policy.available or policy.available(command.name, f, entry) then
       add_completion_candidate(items, seen, num)
     end
   end
   return filter(items, prefix)
 end
 
-local function complete_run_subjects(state, prefix)
+local function complete_run_subjects(state, prefix, policy)
   local f, forge_mod, scope = completion_forge(state)
   if not f or not forge_mod then
     return {}
   end
-  local runs = completion_list(forge_mod, f, 'ci', { 'all' }, 'all', scope)
+  local runs =
+    completion_list(forge_mod, f, 'ci', policy.states_to_consult, policy.fetch_state, scope)
   local items = {}
   local seen = {}
   for _, run in ipairs(runs or {}) do
@@ -1328,12 +1274,19 @@ local function complete_run_subjects(state, prefix)
   return filter(items, prefix)
 end
 
-local function complete_release_subjects(state, prefix)
+local function complete_release_subjects(state, prefix, policy)
   local f, forge_mod, scope = completion_forge(state)
   if not f or not forge_mod then
     return {}
   end
-  local releases = completion_list(forge_mod, f, 'release', { 'list' }, 'list', scope)
+  local releases = completion_list(
+    forge_mod,
+    f,
+    'release',
+    policy.states_to_consult,
+    policy.fetch_state,
+    scope
+  )
   local fields = f.release_fields or {}
   local items = {}
   local seen = {}
@@ -1348,29 +1301,33 @@ local function completion_values(family_name, verb_name, flag_name, prefix)
   if not command then
     return nil
   end
-  if flag_name == 'repo' then
+  local spec = modifiers[flag_name]
+  local policy = require('forge.completion_policy').modifier_value(command, flag_name, spec)
+  if not policy then
+    return nil
+  end
+  if policy.source == 'repo' then
     return repo_completion_values(prefix or '')
   end
-  if flag_name == 'rev' then
+  if policy.source == 'rev' then
     return ref_completion_values(prefix or '')
   end
-  if flag_name == 'head' or flag_name == 'base' then
+  if policy.source == 'rev_address' then
     return rev_address_completion_values(prefix or '')
   end
-  if flag_name == 'target' then
+  if policy.source == 'target' then
     return target_completion_values(prefix or '')
   end
-  if flag_name == 'template' then
+  if policy.source == 'template' then
     return filter(require('forge').template_slugs(), prefix or '')
   end
-  if flag_name == 'adapter' then
+  if policy.source == 'adapter' then
     return filter(require('forge').review_adapter_names(), prefix or '')
   end
-  if command.modifier_values and command.modifier_values[flag_name] then
+  if policy.source == 'command_values' then
     return filter(command.modifier_values[flag_name], prefix or '')
   end
-  local spec = modifiers[flag_name]
-  if spec and spec.values then
+  if policy.source == 'modifier_values' then
     return filter(spec.values, prefix or '')
   end
   return nil
@@ -1394,17 +1351,21 @@ local function subject_completion_items(command, state, arglead)
       arglead
     )
   end
-  if subject.kind == 'pr' then
-    return complete_pr_subjects(command.name, state, arglead)
+  local policy = require('forge.completion_policy').subject(command)
+  if not policy.allow_empty_prefix and arglead == '' then
+    return {}
   end
-  if subject.kind == 'issue' then
-    return complete_issue_subjects(command.name, state, arglead)
+  if policy.subject_kind == 'pr_number' then
+    return complete_pr_subjects(command, state, arglead, policy)
   end
-  if subject.kind == 'run' then
-    return complete_run_subjects(state, arglead)
+  if policy.subject_kind == 'issue_number' then
+    return complete_issue_subjects(command, state, arglead, policy)
   end
-  if subject.kind == 'release' then
-    return complete_release_subjects(state, arglead)
+  if policy.subject_kind == 'ci_run_id' then
+    return complete_run_subjects(state, arglead, policy)
+  end
+  if policy.subject_kind == 'release_tag' then
+    return complete_release_subjects(state, arglead, policy)
   end
   return {}
 end
@@ -1447,16 +1408,25 @@ function M.complete(arglead, cmdline, _)
   if arg_idx == 2 then
     local command = M.resolve(family_name)
     local state = command and completion_state(command, {}) or { modifiers = {}, subjects = {} }
+    local slot_policy = require('forge.completion_policy').family_slot(command)
     local candidates = {}
-    for _, verb in ipairs(M.verb_names(family_name)) do
-      candidates[#candidates + 1] = verb
+    if slot_policy.include_verbs then
+      for _, verb in ipairs(M.verb_names(family_name)) do
+        candidates[#candidates + 1] = verb
+      end
     end
     if command then
       if arglead:match('^%-%-') then
-        vim.list_extend(candidates, filtered_modifier_completion_items(command, state, true))
+        if slot_policy.include_modifiers then
+          vim.list_extend(candidates, filtered_modifier_completion_items(command, state, true))
+        end
       else
-        vim.list_extend(candidates, filtered_modifier_completion_items(command, state, false))
-        vim.list_extend(candidates, subject_completion_items(command, state, arglead))
+        if slot_policy.include_modifiers then
+          vim.list_extend(candidates, filtered_modifier_completion_items(command, state, false))
+        end
+        if slot_policy.include_subjects then
+          vim.list_extend(candidates, subject_completion_items(command, state, arglead))
+        end
       end
     end
     return filter(candidates, arglead)
@@ -1473,11 +1443,20 @@ function M.complete(arglead, cmdline, _)
     consumed[#consumed + 1] = words[i]
   end
   local state = completion_state(command, consumed)
+  local slot_policy = require('forge.completion_policy').argument_slot(command, state)
   if arglead:match('^%-%-') then
+    if not slot_policy.include_modifiers then
+      return {}
+    end
     return filter(filtered_modifier_completion_items(command, state, true), arglead)
   end
-  local candidates = filtered_modifier_completion_items(command, state, false)
-  vim.list_extend(candidates, subject_completion_items(command, state, arglead))
+  local candidates = {}
+  if slot_policy.include_modifiers then
+    vim.list_extend(candidates, filtered_modifier_completion_items(command, state, false))
+  end
+  if slot_policy.include_subjects then
+    vim.list_extend(candidates, subject_completion_items(command, state, arglead))
+  end
   return filter(candidates, arglead)
 end
 

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1234,14 +1234,8 @@ local function complete_issue_subjects(command, state, prefix, policy)
   if not f or not forge_mod then
     return {}
   end
-  local issues = completion_list(
-    forge_mod,
-    f,
-    'issue',
-    policy.states_to_consult,
-    policy.fetch_state,
-    scope
-  )
+  local issues =
+    completion_list(forge_mod, f, 'issue', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.issue_fields or {}
   local items = {}
   local seen = {}
@@ -1279,14 +1273,8 @@ local function complete_release_subjects(state, prefix, policy)
   if not f or not forge_mod then
     return {}
   end
-  local releases = completion_list(
-    forge_mod,
-    f,
-    'release',
-    policy.states_to_consult,
-    policy.fetch_state,
-    scope
-  )
+  local releases =
+    completion_list(forge_mod, f, 'release', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.release_fields or {}
   local items = {}
   local seen = {}

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -1,0 +1,211 @@
+local M = {}
+
+local availability = require('forge.availability')
+local picker = require('forge.picker')
+
+local function pr_completion_states(verb)
+  if
+    verb == 'approve'
+    or verb == 'merge'
+    or verb == 'draft'
+    or verb == 'ready'
+    or verb == 'close'
+  then
+    return { 'open', 'all' }, 'open'
+  end
+  if verb == 'reopen' then
+    return { 'closed', 'all' }, 'closed'
+  end
+  return { 'all', 'open', 'closed' }, 'all'
+end
+
+local function issue_completion_states(verb)
+  if verb == 'close' then
+    return { 'open', 'all' }, 'open'
+  end
+  if verb == 'reopen' then
+    return { 'closed', 'all' }, 'closed'
+  end
+  return { 'all', 'open', 'closed' }, 'all'
+end
+
+local function pr_completion_available(verb, f, entry)
+  if verb == 'approve' then
+    return availability.pr_can_approve(f, entry)
+  end
+  if verb == 'merge' then
+    return availability.pr_can_merge(f, entry)
+  end
+  if verb == 'draft' then
+    return availability.pr_can_mark_draft(f, entry)
+  end
+  if verb == 'ready' then
+    return availability.pr_can_mark_ready(f, entry)
+  end
+  if verb == 'close' then
+    return picker.pr_toggle_verb(entry) == 'close'
+  end
+  if verb == 'reopen' then
+    return picker.pr_toggle_verb(entry) == 'reopen'
+  end
+  return true
+end
+
+local function issue_completion_available(verb, _, entry)
+  if verb == 'close' then
+    return picker.issue_toggle_verb(entry) == 'close'
+  end
+  if verb == 'reopen' then
+    return picker.issue_toggle_verb(entry) == 'reopen'
+  end
+  return true
+end
+
+function M.family_slot(command)
+  return {
+    slot_class = 'family',
+    include_verbs = true,
+    include_modifiers = command ~= nil,
+    include_subjects = command ~= nil,
+    static_before_dynamic = true,
+  }
+end
+
+function M.argument_slot(command, _state)
+  return {
+    slot_class = 'argument',
+    include_modifiers = command ~= nil,
+    include_subjects = command ~= nil,
+    static_before_dynamic = true,
+  }
+end
+
+function M.subject(command)
+  local subject = command.subject or { min = 0, max = 0 }
+  if subject.kind == 'pr' then
+    local states, fetch_state = pr_completion_states(command.name)
+    return {
+      slot_class = 'subject',
+      subject_kind = 'pr_number',
+      cmdline_usefulness = 'dynamic_allowed',
+      states_to_consult = states,
+      fetch_state = fetch_state,
+      allow_fetch_on_tab = true,
+      allow_empty_prefix = true,
+      available = pr_completion_available,
+    }
+  end
+  if subject.kind == 'issue' then
+    local states, fetch_state = issue_completion_states(command.name)
+    return {
+      slot_class = 'subject',
+      subject_kind = 'issue_number',
+      cmdline_usefulness = 'dynamic_allowed',
+      states_to_consult = states,
+      fetch_state = fetch_state,
+      allow_fetch_on_tab = true,
+      allow_empty_prefix = true,
+      available = issue_completion_available,
+    }
+  end
+  if subject.kind == 'run' then
+    return {
+      slot_class = 'subject',
+      subject_kind = 'ci_run_id',
+      cmdline_usefulness = 'dynamic_allowed',
+      states_to_consult = { 'all' },
+      fetch_state = 'all',
+      allow_fetch_on_tab = true,
+      allow_empty_prefix = true,
+    }
+  end
+  if subject.kind == 'release' then
+    return {
+      slot_class = 'subject',
+      subject_kind = 'release_tag',
+      cmdline_usefulness = 'dynamic_allowed',
+      states_to_consult = { 'list' },
+      fetch_state = 'list',
+      allow_fetch_on_tab = true,
+      allow_empty_prefix = true,
+    }
+  end
+  return {
+    slot_class = 'subject',
+    subject_kind = 'none',
+    cmdline_usefulness = 'static_only',
+    states_to_consult = {},
+    allow_fetch_on_tab = false,
+    allow_empty_prefix = true,
+  }
+end
+
+function M.modifier_value(command, flag_name, spec)
+  if flag_name == 'repo' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'repo',
+    }
+  end
+  if flag_name == 'rev' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'rev',
+    }
+  end
+  if flag_name == 'head' or flag_name == 'base' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'rev_address',
+    }
+  end
+  if flag_name == 'target' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'target',
+    }
+  end
+  if flag_name == 'template' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'template',
+    }
+  end
+  if flag_name == 'adapter' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'adapter',
+    }
+  end
+  if command.modifier_values and command.modifier_values[flag_name] then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'static_only',
+      allow_empty_prefix = true,
+      source = 'command_values',
+    }
+  end
+  if spec and spec.values then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'static_only',
+      allow_empty_prefix = true,
+      source = 'modifier_values',
+    }
+  end
+  return nil
+end
+
+return M

--- a/spec/completion_policy_spec.lua
+++ b/spec/completion_policy_spec.lua
@@ -1,0 +1,176 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('forge.completion_policy', function()
+  local policy
+  local old_availability
+  local old_picker
+
+  before_each(function()
+    old_availability = package.preload['forge.availability']
+    old_picker = package.preload['forge.picker']
+
+    package.loaded['forge.completion_policy'] = nil
+    package.loaded['forge.availability'] = nil
+    package.loaded['forge.picker'] = nil
+
+    package.preload['forge.availability'] = function()
+      return {
+        pr_can_approve = function(_, entry)
+          return entry.value.approve == true
+        end,
+        pr_can_merge = function(_, entry)
+          return entry.value.merge == true
+        end,
+        pr_can_mark_draft = function(_, entry)
+          return entry.value.draft == true
+        end,
+        pr_can_mark_ready = function(_, entry)
+          return entry.value.ready == true
+        end,
+      }
+    end
+
+    package.preload['forge.picker'] = function()
+      return {
+        pr_toggle_verb = function(entry)
+          return entry and entry.value and entry.value.pr_toggle or nil
+        end,
+        issue_toggle_verb = function(entry)
+          return entry and entry.value and entry.value.issue_toggle or nil
+        end,
+      }
+    end
+
+    policy = require('forge.completion_policy')
+  end)
+
+  after_each(function()
+    package.preload['forge.availability'] = old_availability
+    package.preload['forge.picker'] = old_picker
+
+    package.loaded['forge.completion_policy'] = nil
+    package.loaded['forge.availability'] = nil
+    package.loaded['forge.picker'] = nil
+  end)
+
+  it('returns slot-composition policies for family and argument slots', function()
+    assert.same({
+      slot_class = 'family',
+      include_verbs = true,
+      include_modifiers = false,
+      include_subjects = false,
+      static_before_dynamic = true,
+    }, policy.family_slot(nil))
+
+    assert.same({
+      slot_class = 'family',
+      include_verbs = true,
+      include_modifiers = true,
+      include_subjects = true,
+      static_before_dynamic = true,
+    }, policy.family_slot({ family = 'review', name = 'open' }))
+
+    assert.same({
+      slot_class = 'argument',
+      include_modifiers = true,
+      include_subjects = true,
+      static_before_dynamic = true,
+    }, policy.argument_slot({ family = 'pr', name = 'merge' }, {}))
+  end)
+
+  it('classifies subject policies and cache preferences', function()
+    local merge = policy.subject({ name = 'merge', subject = { kind = 'pr' } })
+    local reopen = policy.subject({ name = 'reopen', subject = { kind = 'pr' } })
+    local issue = policy.subject({ name = 'close', subject = { kind = 'issue' } })
+    local ci = policy.subject({ name = 'open', subject = { kind = 'run' } })
+    local release = policy.subject({ name = 'delete', subject = { kind = 'release' } })
+    local none = policy.subject({ name = 'create', subject = { min = 0, max = 0 } })
+
+    assert.equals('pr_number', merge.subject_kind)
+    assert.same({ 'open', 'all' }, merge.states_to_consult)
+    assert.equals('open', merge.fetch_state)
+    assert.is_true(merge.allow_fetch_on_tab)
+    assert.is_true(merge.allow_empty_prefix)
+
+    assert.equals('pr_number', reopen.subject_kind)
+    assert.same({ 'closed', 'all' }, reopen.states_to_consult)
+    assert.equals('closed', reopen.fetch_state)
+
+    assert.equals('issue_number', issue.subject_kind)
+    assert.same({ 'open', 'all' }, issue.states_to_consult)
+    assert.equals('open', issue.fetch_state)
+
+    assert.equals('ci_run_id', ci.subject_kind)
+    assert.same({ 'all' }, ci.states_to_consult)
+    assert.equals('all', ci.fetch_state)
+
+    assert.equals('release_tag', release.subject_kind)
+    assert.same({ 'list' }, release.states_to_consult)
+    assert.equals('list', release.fetch_state)
+
+    assert.equals('none', none.subject_kind)
+    assert.same({}, none.states_to_consult)
+    assert.is_false(none.allow_fetch_on_tab)
+  end)
+
+  it('reuses picker-aligned availability helpers for subject policies', function()
+    local merge = policy.subject({ name = 'merge', subject = { kind = 'pr' } })
+    local close = policy.subject({ name = 'close', subject = { kind = 'pr' } })
+    local issue = policy.subject({ name = 'reopen', subject = { kind = 'issue' } })
+
+    assert.is_true(merge.available('merge', {}, { value = { merge = true } }))
+    assert.is_false(merge.available('merge', {}, { value = { merge = false } }))
+
+    assert.is_true(close.available('close', {}, { value = { pr_toggle = 'close' } }))
+    assert.is_false(close.available('close', {}, { value = { pr_toggle = 'reopen' } }))
+
+    assert.is_true(issue.available('reopen', {}, { value = { issue_toggle = 'reopen' } }))
+    assert.is_false(issue.available('reopen', {}, { value = { issue_toggle = 'close' } }))
+  end)
+
+  it('classifies local and static modifier-value policies', function()
+    local command = {
+      modifier_values = {
+        adapter = { 'browse' },
+        state = { 'open', 'closed' },
+      },
+    }
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'repo',
+    }, policy.modifier_value(command, 'repo'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'rev_address',
+    }, policy.modifier_value(command, 'head'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'adapter',
+    }, policy.modifier_value(command, 'adapter'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'static_only',
+      allow_empty_prefix = true,
+      source = 'command_values',
+    }, policy.modifier_value(command, 'state'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'static_only',
+      allow_empty_prefix = true,
+      source = 'modifier_values',
+    }, policy.modifier_value(command, 'method', { values = { 'merge', 'squash', 'rebase' } }))
+
+    assert.is_nil(policy.modifier_value(command, 'missing'))
+  end)
+end)


### PR DESCRIPTION
## Problem
Cmdline completion policy is currently split across `forge.cmd`, picker availability helpers, and picker semantics, which makes the stock Ex surface easy to drift as the cmdline contract evolves. Closes #338.

## Solution
Extract `lua/forge/completion_policy.lua` as the shared stock-cmdline policy source, route `forge.cmd` subject and modifier-value completion decisions through it, and add focused specs for the new policy module.