### PR TITLE
feat(cmd): keep release tags dynamic in stock cmdline

### DIFF
--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -3,32 +3,6 @@ local M = {}
 local availability = require('forge.availability')
 local picker = require('forge.picker')
 
-local function pr_completion_states(verb)
-  if
-    verb == 'approve'
-    or verb == 'merge'
-    or verb == 'draft'
-    or verb == 'ready'
-    or verb == 'close'
-  then
-    return { 'open', 'all' }, 'open'
-  end
-  if verb == 'reopen' then
-    return { 'closed', 'all' }, 'closed'
-  end
-  return { 'all', 'open', 'closed' }, 'all'
-end
-
-local function issue_completion_states(verb)
-  if verb == 'close' then
-    return { 'open', 'all' }, 'open'
-  end
-  if verb == 'reopen' then
-    return { 'closed', 'all' }, 'closed'
-  end
-  return { 'all', 'open', 'closed' }, 'all'
-end
-
 local function pr_completion_available(verb, f, entry)
   if verb == 'approve' then
     return availability.pr_can_approve(f, entry)
@@ -71,7 +45,19 @@ function M.family_slot(command)
   }
 end
 
-function M.argument_slot(command, _state)
+local function release_delete_subject_slot(state)
+  return type(state) == 'table' and #(state.subjects or {}) == 0
+end
+
+function M.argument_slot(command, state)
+  if command and command.family == 'release' and command.name == 'delete' then
+    return {
+      slot_class = 'argument',
+      include_modifiers = not release_delete_subject_slot(state),
+      include_subjects = true,
+      static_before_dynamic = true,
+    }
+  end
   return {
     slot_class = 'argument',
     include_modifiers = command ~= nil,

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -1179,7 +1179,8 @@ describe(':Forge command', function()
 
     local open = vim.fn.getcompletion('Forge ci open ', 'cmdline')
     local browse = vim.fn.getcompletion('Forge ci browse ', 'cmdline')
-    local releases = vim.fn.getcompletion('Forge release delete ', 'cmdline')
+    local release_browse = vim.fn.getcompletion('Forge release browse ', 'cmdline')
+    local release_delete = vim.fn.getcompletion('Forge release delete ', 'cmdline')
 
     assert.is_true(vim.tbl_contains(open, 'repo='))
     assert.is_true(vim.tbl_contains(browse, 'repo='))
@@ -1187,12 +1188,66 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(open, '402'))
     assert.is_false(vim.tbl_contains(browse, '401'))
     assert.is_false(vim.tbl_contains(browse, '402'))
-    assert.is_true(vim.tbl_contains(releases, 'v1.0.0'))
-    assert.is_true(vim.tbl_contains(releases, 'v1.1.0'))
+    assert.equals('repo=', release_browse[1])
+    assert.is_true(vim.tbl_contains(release_browse, 'v1.0.0'))
+    assert.is_true(vim.tbl_contains(release_browse, 'v1.1.0'))
+    assert.is_false(vim.tbl_contains(release_delete, 'repo='))
+    assert.is_true(vim.tbl_contains(release_delete, 'v1.0.0'))
+    assert.is_true(vim.tbl_contains(release_delete, 'v1.1.0'))
     assert.equals(
       0,
       vim.iter(captured.get_list_calls):fold(0, function(acc, key)
         return acc + (key:match('^ci:') and 1 or 0)
+      end)
+    )
+  end)
+
+  it('fetches release tags on explicit completion when the release cache is cold', function()
+    local scope = repo_scope('current')
+    local key = list_key('release', 'list', scope)
+    captured.system_responses['gh release list --json tagName,name,isDraft,isPrerelease --limit 30 -R owner/current'] =
+      helpers.command_result('[{"tagName":"v2.0.0","name":"Second"}]\n')
+
+    local first = vim.fn.getcompletion('Forge release browse ', 'cmdline')
+    local second = vim.fn.getcompletion('Forge release browse ', 'cmdline')
+    local narrowed = vim.fn.getcompletion('Forge release delete v2', 'cmdline')
+
+    assert.equals('repo=', first[1])
+    assert.is_true(vim.tbl_contains(first, 'v2.0.0'))
+    assert.is_true(vim.tbl_contains(second, 'v2.0.0'))
+    assert.same({ 'v2.0.0' }, narrowed)
+    assert.same({
+      { tagName = 'v2.0.0', name = 'Second' },
+    }, captured.lists[key])
+    assert.equals(
+      1,
+      vim.iter(captured.system_calls):fold(0, function(acc, item)
+        return acc
+          + (
+            item
+                == 'gh release list --json tagName,name,isDraft,isPrerelease --limit 30 -R owner/current'
+              and 1
+            or 0
+          )
+      end)
+    )
+  end)
+
+  it('does not fetch release tags while completing the repo= subtree', function()
+    local repos = vim.fn.getcompletion('Forge release browse repo=', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(repos, 'repo=mirror'))
+    assert.is_true(vim.tbl_contains(repos, 'repo=origin'))
+    assert.equals(
+      0,
+      vim.iter(captured.system_calls):fold(0, function(acc, item)
+        return acc + (item:match('^gh release list') and 1 or 0)
+      end)
+    )
+    assert.equals(
+      0,
+      vim.iter(captured.get_list_calls):fold(0, function(acc, key)
+        return acc + (key:match('^release:') and 1 or 0)
       end)
     )
   end)

--- a/spec/completion_policy_spec.lua
+++ b/spec/completion_policy_spec.lua
@@ -76,6 +76,30 @@ describe('forge.completion_policy', function()
       include_subjects = true,
       static_before_dynamic = true,
     }, policy.argument_slot({ family = 'pr', name = 'merge' }, {}))
+
+    assert.same({
+      slot_class = 'argument',
+      include_modifiers = true,
+      include_subjects = true,
+      static_before_dynamic = true,
+    }, policy.argument_slot({ family = 'release', name = 'browse' }, { subjects = {} }))
+
+    assert.same({
+      slot_class = 'argument',
+      include_modifiers = false,
+      include_subjects = true,
+      static_before_dynamic = true,
+    }, policy.argument_slot({ family = 'release', name = 'delete' }, { subjects = {} }))
+
+    assert.same({
+      slot_class = 'argument',
+      include_modifiers = true,
+      include_subjects = true,
+      static_before_dynamic = true,
+    }, policy.argument_slot(
+      { family = 'release', name = 'delete' },
+      { subjects = { 'v1.0.0' } }
+    ))
   end)
 
   it('classifies numeric subject suppression and release cache preferences', function()


### PR DESCRIPTION
## Problem
The stock Ex cmdline still needs one dynamic subject exception after numeric completion is suppressed: release tags remain meaningful enough to complete, but their mixed-slot behavior needs to stay minimal and explicit. Closes #340.

## Solution
Keep release tags dynamically completable for `release browse` and `release delete`, preserve `repo=` ahead of tags on `release browse`, narrow `release delete` to tag-only completion at the subject slot, and add focused specs for cache-first fetch behavior and repo-subtree fetch suppression.