### PR TITLE
feat(review): add codediff adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ without leaving your editor.
 ## Features
 
 - Pull request workflows: list, create, review via configurable adapters
-  (`checkout`, `worktree`, `browse`, `diffview`, or custom integrations), edit,
-  merge, approve, draft/ready
+  (`checkout`, `worktree`, `browse`, `diffview`, `codediff`, or custom
+  integrations), edit, merge, approve, draft/ready
 - Issue workflows: list, create, edit, browse, close/reopen
 - CI/CD workflows: list runs, filter by status, inspect summaries, stream logs
 - Forge web browsing and file/line permalinks
@@ -27,6 +27,8 @@ without leaving your editor.
   (`focus:transform-header`). Older `fzf` still works but falls back to the
   initial picker-level header.
 - (Optionally) `diffview.nvim` for `review.adapter = 'diffview'` reviews without
+  checkout
+- (Optionally) `codediff.nvim` for `review.adapter = 'codediff'` reviews without
   checkout
 
 Direct `:Forge` action commands work without `fzf-lua`. Install it only if you

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -107,9 +107,9 @@ Top-level keys: ~
   `review.adapter`  `string`  (default `"checkout"`)
     Default review adapter used by `:Forge review {num}` and the PR picker's
     primary action. Built-in adapters are `"checkout"`, `"worktree"`,
-    `"browse"`, and `"diffview"`. The `diffview` adapter opens
-    `diffview.nvim` against fetched PR refs without checking the branch out.
-    Custom adapters can be registered via
+    `"browse"`, `"diffview"`, and `"codediff"`. The `diffview` and
+    `codediff` adapters open their respective review UIs against fetched PR
+    refs without checking the branch out. Custom adapters can be registered via
     `require('forge').register_review_adapter()`.
 
 `targets`                                               *forge-config-targets*
@@ -364,6 +364,8 @@ PR COMMANDS                                            *forge-pr-commands*
     `browse`           Open PR `{num}` in the browser.
     `diffview`         Open PR `{num}` in `diffview.nvim` using explicit
                        base/head refs.
+    `codediff`         Open PR `{num}` in `codediff.nvim` using explicit
+                       base/head refs.
 
 `:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
     Approve PR `{num}`.
@@ -472,6 +474,7 @@ an adapter with config or `adapter=...`:
   `:Forge review 42 adapter=worktree`   Create a worktree for PR `42`
   `:Forge review 42 adapter=browse`     Open PR `42` in the browser
   `:Forge review 42 adapter=diffview`   Open PR `42` in `diffview.nvim`
+  `:Forge review 42 adapter=codediff`   Open PR `42` in `codediff.nvim`
 
 CACHE COMMANDS                                      *forge-cache-commands*
 
@@ -1179,7 +1182,8 @@ Reports on: ~
 - Forge CLI availability (`gh`, `glab`, `tea`)
 - Interactive picker UI backend (`fzf-lua`) availability
 - tree-sitter `yaml` parser availability
-- Built-in external review adapter availability (`diffview.nvim`)
+- Built-in external review adapter availability (`diffview.nvim`,
+  `codediff.nvim`)
 - Configured review adapter availability
 - Custom registered sources and their CLI availability
 

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -1,5 +1,17 @@
 local M = {}
 
+local function codediff_status()
+  if vim.fn.exists(':CodeDiff') ~= 2 then
+    return false, false
+  end
+  local ok, installer = pcall(require, 'codediff.core.installer')
+  if not ok then
+    return true, true
+  end
+  local needs_update = type(installer.needs_update) == 'function' and installer.needs_update()
+  return true, not needs_update
+end
+
 local review_integrations = {
   diffview = {
     available = function()
@@ -74,7 +86,29 @@ function M.check()
       vim.health.info(integration.info)
     end
   end
-  if configured_adapter ~= '' and not review_integrations[configured_adapter] then
+
+  local has_codediff, codediff_ready = codediff_status()
+  if has_codediff then
+    if codediff_ready then
+      vim.health.ok('codediff.nvim found (adapter=codediff available)')
+    elseif configured_adapter == 'codediff' then
+      vim.health.warn(
+        'codediff.nvim found but libvscode-diff needs install/update (:CodeDiff install or first use)'
+      )
+    else
+      vim.health.info('codediff.nvim found but libvscode-diff needs install/update')
+    end
+  elseif configured_adapter == 'codediff' then
+    vim.health.warn('codediff.nvim not found (review.adapter=codediff unavailable)')
+  else
+    vim.health.info('codediff.nvim not found (adapter=codediff unavailable)')
+  end
+
+  if
+    configured_adapter ~= ''
+    and configured_adapter ~= 'codediff'
+    and not review_integrations[configured_adapter]
+  then
     if review_names[configured_adapter] then
       vim.health.ok('configured review adapter "' .. configured_adapter .. '" available')
     else

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -20,6 +20,10 @@ local function diffview_available()
   return vim.fn.exists(':DiffviewOpen') == 2
 end
 
+local function codediff_available()
+  return vim.fn.exists(':CodeDiff') == 2
+end
+
 local function trim(text)
   if type(text) ~= 'string' then
     return ''
@@ -89,6 +93,13 @@ end
 local function open_diffview(range)
   return pcall(vim.api.nvim_cmd, {
     cmd = 'DiffviewOpen',
+    args = { range },
+  }, {})
+end
+
+local function open_codediff(range)
+  return pcall(vim.api.nvim_cmd, {
+    cmd = 'CodeDiff',
     args = { range },
   }, {})
 end
@@ -198,6 +209,45 @@ local function builtins()
               return
             end
             local ok, open_err = open_diffview(base .. '...' .. head)
+            if not ok then
+              log.error(open_err)
+            end
+          end)
+        end)
+      end,
+    },
+    codediff = {
+      label = 'codediff',
+      open = function(ctx)
+        if not codediff_available() then
+          log.error('codediff.nvim not found')
+          return
+        end
+        local details, err = ctx.details()
+        if not details then
+          log.error(err or 'failed to load review details')
+          return
+        end
+        local base = base_ref(ctx, details)
+        if not base then
+          log.error('review base unavailable')
+          return
+        end
+        local head = review_head_ref(ctx.pr)
+        local fetch_cmd, fetch_err = fetch_head_cmd(ctx.forge, ctx.pr, head)
+        if not fetch_cmd then
+          log.error(fetch_err or 'review fetch unavailable')
+          return
+        end
+        local kind = ctx.forge.labels.pr_one
+        log.info(('opening %s #%s in codediff...'):format(kind, ctx.pr.num))
+        vim.system(fetch_cmd, { text = true }, function(result)
+          vim.schedule(function()
+            if result.code ~= 0 then
+              log.error(cmd_error(result, 'review fetch failed'))
+              return
+            end
+            local ok, open_err = open_codediff(base .. '...' .. head)
             if not ok then
               log.error(open_err)
             end

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -355,7 +355,7 @@ describe(':Forge command', function()
           return {}
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
         end,
       }
     end
@@ -1038,6 +1038,7 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(heads, 'head=@deadbee'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=codediff'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
   end)

--- a/spec/extensibility_spec.lua
+++ b/spec/extensibility_spec.lua
@@ -45,6 +45,7 @@ describe('extensibility', function()
       end,
     })
 
+    assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'codediff'))
     assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'diffview'))
     assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'custom-test-review'))
   end)

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -30,6 +30,7 @@ describe('health', function()
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.picker'] = package.preload['forge.picker'],
+      ['codediff.core.installer'] = package.preload['codediff.core.installer'],
       ['fzf-lua'] = package.preload['fzf-lua'],
     }
 
@@ -40,7 +41,7 @@ describe('health', function()
       return 0
     end
     vim.fn.exists = function(name)
-      if name == ':DiffviewOpen' then
+      if name == ':DiffviewOpen' or name == ':CodeDiff' then
         return 0
       end
       return old_exists(name)
@@ -76,10 +77,18 @@ describe('health', function()
           }
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
         end,
         registered_sources = function()
           return {}
+        end,
+      }
+    end
+
+    package.preload['codediff.core.installer'] = function()
+      return {
+        needs_update = function()
+          return false
         end,
       }
     end
@@ -115,10 +124,12 @@ describe('health', function()
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.picker'] = old_preload['forge.picker']
+    package.preload['codediff.core.installer'] = old_preload['codediff.core.installer']
     package.preload['fzf-lua'] = old_preload['fzf-lua']
 
     package.loaded['forge'] = nil
     package.loaded['forge.picker'] = nil
+    package.loaded['codediff.core.installer'] = nil
     package.loaded['forge.health'] = nil
     package.loaded['fzf-lua'] = nil
   end)
@@ -133,6 +144,9 @@ describe('health', function()
     assert.is_true(vim.tbl_contains(captured.oks, 'fzf-lua found (interactive picker UI enabled)'))
     assert.is_true(
       vim.tbl_contains(captured.infos, 'diffview.nvim not found (adapter=diffview unavailable)')
+    )
+    assert.is_true(
+      vim.tbl_contains(captured.infos, 'codediff.nvim not found (adapter=codediff unavailable)')
     )
     assert.is_true(
       vim.tbl_contains(
@@ -184,6 +198,104 @@ describe('health', function()
       vim.tbl_contains(
         captured.warns,
         'review.adapter=diffview but diffview.nvim is not available (:DiffviewOpen missing)'
+      )
+    )
+  end)
+
+  it('reports codediff as available when the command and library are ready', function()
+    vim.fn.exists = function(name)
+      if name == ':CodeDiff' then
+        return 2
+      end
+      if name == ':DiffviewOpen' then
+        return 0
+      end
+      return old_exists(name)
+    end
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(
+      vim.tbl_contains(captured.oks, 'codediff.nvim found (adapter=codediff available)')
+    )
+  end)
+
+  it('warns when codediff is configured but unavailable', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            review = {
+              adapter = 'codediff',
+            },
+          }
+        end,
+        review_adapter_names = function()
+          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
+        end,
+        registered_sources = function()
+          return {}
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(
+      vim.tbl_contains(
+        captured.warns,
+        'codediff.nvim not found (review.adapter=codediff unavailable)'
+      )
+    )
+  end)
+
+  it('warns when codediff is configured but its library needs install or update', function()
+    vim.fn.exists = function(name)
+      if name == ':CodeDiff' then
+        return 2
+      end
+      if name == ':DiffviewOpen' then
+        return 0
+      end
+      return old_exists(name)
+    end
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            review = {
+              adapter = 'codediff',
+            },
+          }
+        end,
+        review_adapter_names = function()
+          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
+        end,
+        registered_sources = function()
+          return {}
+        end,
+      }
+    end
+    package.preload['codediff.core.installer'] = function()
+      return {
+        needs_update = function()
+          return true
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+    package.loaded['codediff.core.installer'] = nil
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(
+      vim.tbl_contains(
+        captured.warns,
+        'codediff.nvim found but libvscode-diff needs install/update (:CodeDiff install or first use)'
       )
     )
   end)

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -34,7 +34,7 @@ describe('review adapters', function()
       },
     })
     vim.fn.exists = function(name)
-      if name == ':DiffviewOpen' then
+      if name == ':DiffviewOpen' or name == ':CodeDiff' then
         return 2
       end
       return old_exists(name)
@@ -92,6 +92,12 @@ describe('review adapters', function()
     local review = require('forge.review')
 
     assert.is_true(vim.tbl_contains(review.names(), 'diffview'))
+  end)
+
+  it('lists codediff among built-in review adapters', function()
+    local review = require('forge.review')
+
+    assert.is_true(vim.tbl_contains(review.names(), 'codediff'))
   end)
 
   it('opens diffview review against fetched PR refs', function()
@@ -163,5 +169,76 @@ describe('review adapters', function()
     assert.same({}, captured.calls)
     assert.same({}, captured.cmds)
     assert.same({ 'diffview.nvim not found' }, captured.errors)
+  end)
+
+  it('opens codediff review against fetched PR refs', function()
+    local review = require('forge.review')
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/current',
+    }
+
+    review.open({
+      labels = { pr_one = 'PR' },
+      fetch_pr = function(_, num, ref)
+        assert.equals('42', num)
+        assert.same(scope, ref)
+        return { 'git', 'fetch', 'origin', 'pull/42/head:pr-42' }
+      end,
+      fetch_pr_details_cmd = function(_, num, ref)
+        assert.equals('42', num)
+        assert.same(scope, ref)
+        return { 'details', num }
+      end,
+      parse_pr_details = function()
+        return { base_branch = 'main' }
+      end,
+    }, { num = '42', scope = scope }, { adapter = 'codediff' })
+
+    assert.same({
+      'details 42',
+      'git fetch origin +pull/42/head:refs/forge/review/github/github.com/owner/current/pr/42',
+    }, captured.calls)
+    assert.same({
+      {
+        cmd = {
+          cmd = 'CodeDiff',
+          args = { 'origin/main...refs/forge/review/github/github.com/owner/current/pr/42' },
+        },
+        opts = {},
+      },
+    }, captured.cmds)
+    assert.same({ 'opening PR #42 in codediff...' }, captured.infos)
+    assert.same({}, captured.errors)
+  end)
+
+  it('reports missing codediff.nvim before loading review details', function()
+    vim.fn.exists = function(name)
+      if name == ':CodeDiff' then
+        return 0
+      end
+      return old_exists(name)
+    end
+    package.loaded['forge.review'] = nil
+
+    local review = require('forge.review')
+
+    review.open({
+      labels = { pr_one = 'PR' },
+      fetch_pr = function()
+        error('should not fetch')
+      end,
+      fetch_pr_details_cmd = function()
+        error('should not load details')
+      end,
+      parse_pr_details = function()
+        return {}
+      end,
+    }, { num = '42' }, { adapter = 'codediff' })
+
+    assert.same({}, captured.calls)
+    assert.same({}, captured.cmds)
+    assert.same({ 'codediff.nvim not found' }, captured.errors)
   end)
 end)


### PR DESCRIPTION
## Problem

Forge's built-in review adapters cover checkout, worktree, browse, and diffview, but users still need custom glue to open pull requests directly in `codediff.nvim` without switching their checkout.

## Solution

Add a built-in `codediff` adapter that fetches the PR head into Forge-managed refs and opens `:CodeDiff <base>...<head>` against explicit base/head refs without creating a worktree or checking the branch out.

Surface codediff availability in `:checkhealth forge.nvim`, including warnings when `review.adapter = 'codediff'` is configured but `codediff.nvim` is missing or its `libvscode-diff` install still needs setup.

Document the adapter and extend the review, health, and command completion specs to cover it.

Locally verified with changed-file `stylua`, changed-file `selene`, `prettier --check README.md`, `vimdoc-language-server check doc/`, `lua-language-server --check lua`, and `busted` (`557 successes / 0 failures / 0 errors`).

Closes #346