### PR TITLE
feat(review): add diffs adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ without leaving your editor.
 ## Features
 
 - Pull request workflows: list, create, review via configurable adapters
-  (`checkout`, `worktree`, `browse`, `diffview`, `codediff`, or custom
+  (`checkout`, `worktree`, `browse`, `diffview`, `codediff`, `diffs`, or custom
   integrations), edit, merge, approve, draft/ready
 - Issue workflows: list, create, edit, browse, close/reopen
 - CI/CD workflows: list runs, filter by status, inspect summaries, stream logs
@@ -29,6 +29,8 @@ without leaving your editor.
 - (Optionally) `diffview.nvim` for `review.adapter = 'diffview'` reviews without
   checkout
 - (Optionally) `codediff.nvim` for `review.adapter = 'codediff'` reviews without
+  checkout
+- (Optionally) `diffs.nvim` for `review.adapter = 'diffs'` reviews without
   checkout
 
 Direct `:Forge` action commands work without `fzf-lua`. Install it only if you

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -107,10 +107,10 @@ Top-level keys: ~
   `review.adapter`  `string`  (default `"checkout"`)
     Default review adapter used by `:Forge review {num}` and the PR picker's
     primary action. Built-in adapters are `"checkout"`, `"worktree"`,
-    `"browse"`, `"diffview"`, and `"codediff"`. The `diffview` and
-    `codediff` adapters open their respective review UIs against fetched PR
-    refs without checking the branch out. Custom adapters can be registered via
-    `require('forge').register_review_adapter()`.
+    `"browse"`, `"diffview"`, `"codediff"`, and `"diffs"`. The `diffview`,
+    `codediff`, and `diffs` adapters open their respective review UIs against
+    fetched PR refs without checking the branch out. Custom adapters can be
+    registered via `require('forge').register_review_adapter()`.
 
 `targets`                                               *forge-config-targets*
   `targets.aliases`      `table<string, string>`  (default `{}`)
@@ -366,6 +366,8 @@ PR COMMANDS                                            *forge-pr-commands*
                        base/head refs.
     `codediff`         Open PR `{num}` in `codediff.nvim` using explicit
                        base/head refs.
+    `diffs`            Open PR `{num}` in `diffs.nvim` using explicit
+                       base/head refs.
 
 `:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
     Approve PR `{num}`.
@@ -475,6 +477,7 @@ an adapter with config or `adapter=...`:
   `:Forge review 42 adapter=browse`     Open PR `42` in the browser
   `:Forge review 42 adapter=diffview`   Open PR `42` in `diffview.nvim`
   `:Forge review 42 adapter=codediff`   Open PR `42` in `codediff.nvim`
+  `:Forge review 42 adapter=diffs`      Open PR `42` in `diffs.nvim`
 
 CACHE COMMANDS                                      *forge-cache-commands*
 
@@ -1183,7 +1186,7 @@ Reports on: ~
 - Interactive picker UI backend (`fzf-lua`) availability
 - tree-sitter `yaml` parser availability
 - Built-in external review adapter availability (`diffview.nvim`,
-  `codediff.nvim`)
+  `codediff.nvim`, `diffs.nvim`)
 - Configured review adapter availability
 - Custom registered sources and their CLI availability
 

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -21,6 +21,14 @@ local review_integrations = {
     info = 'diffview.nvim not found (adapter=diffview unavailable)',
     warn = 'review.adapter=diffview but diffview.nvim is not available (:DiffviewOpen missing)',
   },
+  diffs = {
+    available = function()
+      return vim.fn.exists(':Greview') == 2
+    end,
+    ok = 'diffs.nvim found (adapter=diffs available)',
+    info = 'diffs.nvim not found (adapter=diffs unavailable)',
+    warn = 'review.adapter=diffs but diffs.nvim is not available (:Greview missing)',
+  },
 }
 
 function M.check()

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -24,6 +24,10 @@ local function codediff_available()
   return vim.fn.exists(':CodeDiff') == 2
 end
 
+local function diffs_available()
+  return vim.fn.exists(':Greview') == 2
+end
+
 local function trim(text)
   if type(text) ~= 'string' then
     return ''
@@ -100,6 +104,13 @@ end
 local function open_codediff(range)
   return pcall(vim.api.nvim_cmd, {
     cmd = 'CodeDiff',
+    args = { range },
+  }, {})
+end
+
+local function open_diffs(range)
+  return pcall(vim.api.nvim_cmd, {
+    cmd = 'Greview',
     args = { range },
   }, {})
 end
@@ -248,6 +259,45 @@ local function builtins()
               return
             end
             local ok, open_err = open_codediff(base .. '...' .. head)
+            if not ok then
+              log.error(open_err)
+            end
+          end)
+        end)
+      end,
+    },
+    diffs = {
+      label = 'diffs',
+      open = function(ctx)
+        if not diffs_available() then
+          log.error('diffs.nvim not found')
+          return
+        end
+        local details, err = ctx.details()
+        if not details then
+          log.error(err or 'failed to load review details')
+          return
+        end
+        local base = base_ref(ctx, details)
+        if not base then
+          log.error('review base unavailable')
+          return
+        end
+        local head = review_head_ref(ctx.pr)
+        local fetch_cmd, fetch_err = fetch_head_cmd(ctx.forge, ctx.pr, head)
+        if not fetch_cmd then
+          log.error(fetch_err or 'review fetch unavailable')
+          return
+        end
+        local kind = ctx.forge.labels.pr_one
+        log.info(('opening %s #%s in diffs...'):format(kind, ctx.pr.num))
+        vim.system(fetch_cmd, { text = true }, function(result)
+          vim.schedule(function()
+            if result.code ~= 0 then
+              log.error(cmd_error(result, 'review fetch failed'))
+              return
+            end
+            local ok, open_err = open_diffs(base .. '...' .. head)
             if not ok then
               log.error(open_err)
             end

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -355,7 +355,7 @@ describe(':Forge command', function()
           return {}
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
         end,
       }
     end
@@ -1039,6 +1039,7 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=codediff'))
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=diffs'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
   end)

--- a/spec/extensibility_spec.lua
+++ b/spec/extensibility_spec.lua
@@ -46,6 +46,7 @@ describe('extensibility', function()
     })
 
     assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'codediff'))
+    assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'diffs'))
     assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'diffview'))
     assert.is_true(vim.tbl_contains(forge.review_adapter_names(), 'custom-test-review'))
   end)

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -41,7 +41,7 @@ describe('health', function()
       return 0
     end
     vim.fn.exists = function(name)
-      if name == ':DiffviewOpen' or name == ':CodeDiff' then
+      if name == ':DiffviewOpen' or name == ':CodeDiff' or name == ':Greview' then
         return 0
       end
       return old_exists(name)
@@ -77,7 +77,7 @@ describe('health', function()
           }
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
         end,
         registered_sources = function()
           return {}
@@ -146,6 +146,9 @@ describe('health', function()
       vim.tbl_contains(captured.infos, 'diffview.nvim not found (adapter=diffview unavailable)')
     )
     assert.is_true(
+      vim.tbl_contains(captured.infos, 'diffs.nvim not found (adapter=diffs unavailable)')
+    )
+    assert.is_true(
       vim.tbl_contains(captured.infos, 'codediff.nvim not found (adapter=codediff unavailable)')
     )
     assert.is_true(
@@ -182,7 +185,7 @@ describe('health', function()
           }
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
         end,
         registered_sources = function()
           return {}
@@ -202,12 +205,60 @@ describe('health', function()
     )
   end)
 
+  it('warns when the configured diffs adapter is unavailable', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            review = {
+              adapter = 'diffs',
+            },
+          }
+        end,
+        review_adapter_names = function()
+          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
+        end,
+        registered_sources = function()
+          return {}
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(
+      vim.tbl_contains(
+        captured.warns,
+        'review.adapter=diffs but diffs.nvim is not available (:Greview missing)'
+      )
+    )
+  end)
+
+  it('reports diffs as available when the command is ready', function()
+    vim.fn.exists = function(name)
+      if name == ':Greview' then
+        return 2
+      end
+      if name == ':CodeDiff' or name == ':DiffviewOpen' then
+        return 0
+      end
+      return old_exists(name)
+    end
+    package.loaded['forge.health'] = nil
+
+    require('forge.health').check()
+
+    assert.is_true(vim.tbl_contains(captured.oks, 'diffs.nvim found (adapter=diffs available)'))
+  end)
+
   it('reports codediff as available when the command and library are ready', function()
     vim.fn.exists = function(name)
       if name == ':CodeDiff' then
         return 2
       end
-      if name == ':DiffviewOpen' then
+      if name == ':DiffviewOpen' or name == ':Greview' then
         return 0
       end
       return old_exists(name)
@@ -232,7 +283,7 @@ describe('health', function()
           }
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
         end,
         registered_sources = function()
           return {}
@@ -257,7 +308,7 @@ describe('health', function()
       if name == ':CodeDiff' then
         return 2
       end
-      if name == ':DiffviewOpen' then
+      if name == ':DiffviewOpen' or name == ':Greview' then
         return 0
       end
       return old_exists(name)
@@ -272,7 +323,7 @@ describe('health', function()
           }
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffview', 'worktree' }
+          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
         end,
         registered_sources = function()
           return {}

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -34,7 +34,7 @@ describe('review adapters', function()
       },
     })
     vim.fn.exists = function(name)
-      if name == ':DiffviewOpen' or name == ':CodeDiff' then
+      if name == ':DiffviewOpen' or name == ':CodeDiff' or name == ':Greview' then
         return 2
       end
       return old_exists(name)
@@ -98,6 +98,12 @@ describe('review adapters', function()
     local review = require('forge.review')
 
     assert.is_true(vim.tbl_contains(review.names(), 'codediff'))
+  end)
+
+  it('lists diffs among built-in review adapters', function()
+    local review = require('forge.review')
+
+    assert.is_true(vim.tbl_contains(review.names(), 'diffs'))
   end)
 
   it('opens diffview review against fetched PR refs', function()
@@ -240,5 +246,76 @@ describe('review adapters', function()
     assert.same({}, captured.calls)
     assert.same({}, captured.cmds)
     assert.same({ 'codediff.nvim not found' }, captured.errors)
+  end)
+
+  it('opens diffs review against fetched PR refs', function()
+    local review = require('forge.review')
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/current',
+    }
+
+    review.open({
+      labels = { pr_one = 'PR' },
+      fetch_pr = function(_, num, ref)
+        assert.equals('42', num)
+        assert.same(scope, ref)
+        return { 'git', 'fetch', 'origin', 'pull/42/head:pr-42' }
+      end,
+      fetch_pr_details_cmd = function(_, num, ref)
+        assert.equals('42', num)
+        assert.same(scope, ref)
+        return { 'details', num }
+      end,
+      parse_pr_details = function()
+        return { base_branch = 'main' }
+      end,
+    }, { num = '42', scope = scope }, { adapter = 'diffs' })
+
+    assert.same({
+      'details 42',
+      'git fetch origin +pull/42/head:refs/forge/review/github/github.com/owner/current/pr/42',
+    }, captured.calls)
+    assert.same({
+      {
+        cmd = {
+          cmd = 'Greview',
+          args = { 'origin/main...refs/forge/review/github/github.com/owner/current/pr/42' },
+        },
+        opts = {},
+      },
+    }, captured.cmds)
+    assert.same({ 'opening PR #42 in diffs...' }, captured.infos)
+    assert.same({}, captured.errors)
+  end)
+
+  it('reports missing diffs.nvim before loading review details', function()
+    vim.fn.exists = function(name)
+      if name == ':Greview' then
+        return 0
+      end
+      return old_exists(name)
+    end
+    package.loaded['forge.review'] = nil
+
+    local review = require('forge.review')
+
+    review.open({
+      labels = { pr_one = 'PR' },
+      fetch_pr = function()
+        error('should not fetch')
+      end,
+      fetch_pr_details_cmd = function()
+        error('should not load details')
+      end,
+      parse_pr_details = function()
+        return {}
+      end,
+    }, { num = '42' }, { adapter = 'diffs' })
+
+    assert.same({}, captured.calls)
+    assert.same({}, captured.cmds)
+    assert.same({ 'diffs.nvim not found' }, captured.errors)
   end)
 end)


### PR DESCRIPTION
## Problem

Forge's built-in review adapters now cover checkout, worktree, browse, diffview, and codediff, but users still need custom glue to open pull requests directly in `diffs.nvim` without switching their checkout.

## Solution

Add a built-in `diffs` adapter that fetches the PR head into Forge-managed refs and opens `:Greview <base>...<head>` against explicit base/head refs with merge-base semantics and no checkout or worktree mutation.

Surface `diffs.nvim` availability in `:checkhealth forge.nvim`, document the adapter in the README and vimdoc, and extend the review, health, command completion, and extensibility specs to cover it.

Locally verified with changed-file `stylua`, changed-file `selene`, `prettier --check README.md`, `vimdoc-language-server check doc/`, `lua-language-server --check lua`, and `busted` (`564 successes / 0 failures / 0 errors`).

The repo's whole-tree `Lua Lint Check` currently reports pre-existing `selene` warnings from `lua/forge/completion_policy.lua` on `main`, so this PR is expected to inherit that unrelated failure until the baseline is fixed.

Closes #345