### PR TITLE
fix(review): honor integration labels in picker header

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -872,7 +872,7 @@ function M.pr(state, f, opts)
         if load_more_row(entry) then
           return 'load more'
         end
-        return require('forge.review').label()
+        return require('forge.review').label(f, entry and entry.value or nil)
       end,
       available = pr_load_more_or_entity,
       fn = function(entry)

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -129,6 +129,29 @@ local function adapter_name(opts)
   return 'checkout'
 end
 
+local function resolve_label(adapter, name, ctx)
+  if not adapter then
+    return name
+  end
+  local label = adapter.label
+  if type(label) == 'function' then
+    if not ctx then
+      return name
+    end
+    local ok, value = pcall(label, ctx)
+    if not ok then
+      log.debug(value)
+      return name
+    end
+    label = value
+  end
+  label = trim(label)
+  if label ~= '' then
+    return label
+  end
+  return name
+end
+
 local function builtins()
   return {
     checkout = {
@@ -340,17 +363,13 @@ function M.current_name(opts)
   return adapter_name(opts)
 end
 
-function M.label(opts)
-  local name = adapter_name(opts)
-  local adapter = M.get(name)
-  if not adapter then
-    return name
+function M.label(f, pr, opts)
+  if f ~= nil and pr ~= nil then
+    local ctx = M.context(f, pr, opts)
+    return resolve_label(M.get(ctx.adapter), ctx.adapter, ctx)
   end
-  local label = adapter.label
-  if type(label) == 'string' and label ~= '' then
-    return label
-  end
-  return name
+  local name = adapter_name(f)
+  return resolve_label(M.get(name), name, nil)
 end
 
 function M.context(f, pr, opts)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -65,12 +65,14 @@ end
 
 describe(':Forge command', function()
   local captured
+  local extra_review_adapters
   local old_preload
   local old_systemlist
   local old_system
   local old_ui_open
 
   before_each(function()
+    extra_review_adapters = {}
     captured = {
       opens = {},
       ops_calls = {},
@@ -355,7 +357,11 @@ describe(':Forge command', function()
           return {}
         end,
         review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
+          local adapters = { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
+          for _, name in ipairs(extra_review_adapters) do
+            adapters[#adapters + 1] = name
+          end
+          return adapters
         end,
       }
     end
@@ -1042,6 +1048,14 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(adapters, 'adapter=diffs'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
+  end)
+
+  it('completes registered review adapters for adapter=', function()
+    extra_review_adapters = { 'custom-test-review' }
+
+    local adapters = vim.fn.getcompletion('Forge review 42 adapter=', 'cmdline')
+
+    assert.is_true(vim.tbl_contains(adapters, 'adapter=custom-test-review'))
   end)
 
   it('does not complete picker-only command families', function()

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -26,6 +26,7 @@ local loaded_modules = {
   'forge.picker',
   'forge.picker.session',
   'forge.pickers',
+  'forge.review',
 }
 
 local function fake_forge(opts)
@@ -539,6 +540,45 @@ describe('pickers', function()
     assert.equals('draft', labels.draft)
     assert.equals('filter', labels.filter)
     assert.equals('refresh', labels.refresh)
+  end)
+
+  it('uses configured integration labels for the highlighted open PR', function()
+    vim.g.forge = {
+      review = {
+        adapter = 'diffview',
+      },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+
+    assert.is_not_nil(captured)
+    captured.stream(function() end)
+    local labels = helpers.action_labels(captured.actions, captured.entries[1])
+    assert.equals('diffview', labels.default)
+  end)
+
+  it('uses functional registered review adapter labels for the highlighted open PR', function()
+    vim.g.forge = {
+      review = {
+        adapter = 'custom-test-review',
+      },
+    }
+
+    require('forge.review').register('custom-test-review', {
+      label = function(ctx)
+        return 'review #' .. ctx.pr.num
+      end,
+      open = function() end,
+    })
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+
+    assert.is_not_nil(captured)
+    captured.stream(function() end)
+    local labels = helpers.action_labels(captured.actions, captured.entries[1])
+    assert.equals('review #42', labels.default)
   end)
 
   it('hides open-only PR actions on closed and merged rows', function()


### PR DESCRIPTION
## Problem

Forge's review adapter integrations show up through the canonical `adapter=` flow, but the PR picker's default review action still resolves its visible label without row context. That means built-in integrations were only implicitly covered, and registered/custom adapters that provide a functional `label(ctx)` could appear in adapter completion while still rendering the wrong picker header label.

## Solution

Pass the highlighted PR entry through the review-label helper so the picker can resolve adapter labels from a real review context.

Teach `forge.review.label(...)` to safely evaluate functional adapter labels when a full review context is available, while preserving the old string-label fallback when only config/options are known.

Add picker and command specs that cover configured integration labels, registered functional adapter labels, and registered adapter completion parity.

Locally verified with changed-file `stylua`, changed-file `selene`, `lua-language-server --check lua`, focused `busted` for picker/command specs, and full `busted` (`567 successes / 0 failures / 0 errors`).

Closes #350