### PR TITLE
docs(readme): remove permalink feature bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ without leaving your editor.
   integrations), edit, merge, approve, draft/ready
 - Issue workflows: list, create, edit, browse, close/reopen
 - CI/CD workflows: list runs, filter by status, inspect summaries, stream logs
-- Forge web browsing and file/line permalinks
 - Automatic forge detection from git remote via `gh`, `glab`, or `tea`
 
 ## Requirements


### PR DESCRIPTION
## Problem

The README feature list says forge.nvim provides \"Forge web browsing and file/line permalinks\", which reads broader than the plugin's actual browse/open behavior and can imply gitlinker-style permalink copying.

## Solution

Remove the misleading feature bullet from the README so the top-level feature list does not advertise permalink support more broadly than the plugin provides.