### PR TITLE
feat(cmd): ground modifier-value completion locally (#341)

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -172,7 +172,7 @@ local families = {
     verbs = {
       open = {
         subject = { min = 0, max = 0 },
-        modifiers = { 'branch', 'commit' },
+        modifiers = { 'branch', 'commit', 'target' },
       },
     },
   },
@@ -579,6 +579,11 @@ local function dispatch_browse(command)
     return
   end
   local scope = resolve_scope_modifier(command, f.name)
+  local location = command.parsed_modifiers.target
+  if location then
+    ops.browse_location(f, location, scope)
+    return
+  end
   local commit = command.parsed_modifiers.commit
   if commit and commit.commit then
     ops.browse_commit({ commit = commit.commit, scope = scope })
@@ -1297,7 +1302,7 @@ local function completion_values(family_name, verb_name, flag_name, prefix)
   if policy.source == 'repo' then
     return repo_completion_values(prefix or '')
   end
-  if policy.source == 'rev' then
+  if policy.source == 'ref' then
     return ref_completion_values(prefix or '')
   end
   if policy.source == 'rev_address' then

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -35,6 +35,23 @@ local function issue_completion_available(verb, _, entry)
   return true
 end
 
+local function list_contains(items, value)
+  for _, item in ipairs(items or {}) do
+    if item == value then
+      return true
+    end
+  end
+  return false
+end
+
+local function declares_modifier(command, flag_name)
+  if type(command) ~= 'table' then
+    return false
+  end
+  return list_contains(command.declared_modifiers or command.modifiers, flag_name)
+    or list_contains(command.declared_legacy_modifiers or command.legacy_modifiers, flag_name)
+end
+
 function M.family_slot(command)
   return {
     slot_class = 'family',
@@ -125,6 +142,9 @@ function M.subject(command)
 end
 
 function M.modifier_value(command, flag_name, spec)
+  if not declares_modifier(command, flag_name) then
+    return nil
+  end
   if flag_name == 'repo' then
     return {
       slot_class = 'modifier_value',
@@ -133,12 +153,12 @@ function M.modifier_value(command, flag_name, spec)
       source = 'repo',
     }
   end
-  if flag_name == 'rev' then
+  if flag_name == 'branch' or flag_name == 'commit' then
     return {
       slot_class = 'modifier_value',
       cmdline_usefulness = 'local_only',
       allow_empty_prefix = true,
-      source = 'rev',
+      source = 'ref',
     }
   end
   if flag_name == 'head' or flag_name == 'base' then

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -165,12 +165,20 @@ describe('command schema', function()
     }))
     local browse_branch = assert(cmd.parse({ 'browse', 'branch=main' }))
     local browse_commit = assert(cmd.parse({ 'browse', 'commit=abc1234' }))
+    local browse_target = assert(cmd.parse({
+      'browse',
+      'target=upstream@main:lua/forge/init.lua#L10-L20',
+    }))
 
     assert.equals('main', create.parsed_modifiers.base.rev)
     assert.equals('topic', create.parsed_modifiers.head.rev)
     assert.equals('barrettruth/forge.nvim', create.parsed_modifiers.head.repo.slug)
     assert.equals('main', browse_branch.parsed_modifiers.branch.branch)
     assert.equals('abc1234', browse_commit.parsed_modifiers.commit.commit)
+    assert.equals('main', browse_target.parsed_modifiers.target.rev.rev)
+    assert.equals('owner/upstream', browse_target.parsed_modifiers.target.rev.repo.slug)
+    assert.equals('lua/forge/init.lua', browse_target.parsed_modifiers.target.path)
+    assert.same({ start_line = 10, end_line = 20 }, browse_target.parsed_modifiers.target.range)
   end)
 
   it('attaches default target policy for omitted direct-action addresses', function()
@@ -250,7 +258,7 @@ describe('command schema', function()
   end)
 
   it('keeps legacy browse modifiers separate from canonical ones', function()
-    assert.same({ 'branch', 'commit' }, cmd.modifier_names('browse'))
+    assert.same({ 'branch', 'commit', 'target' }, cmd.modifier_names('browse'))
     assert.same({}, cmd.legacy_modifier_names('browse'))
   end)
 
@@ -268,14 +276,14 @@ describe('command schema', function()
     assert.equals('duplicate modifier: repo', duplicate.message)
   end)
 
-  it('rejects removed browse modifiers and malformed branch/commit syntax', function()
+  it('rejects obsolete browse modifiers and malformed browse target syntax', function()
     local _, target_err = cmd.parse({ 'browse', 'target=README.md#L10' })
     local _, repo_err = cmd.parse({ 'browse', 'repo=upstream' })
     local _, rev_err = cmd.parse({ 'browse', 'rev=main' })
     local _, branch_err = cmd.parse({ 'browse', 'branch=@main' })
     local _, commit_err = cmd.parse({ 'browse', 'commit=abc:def' })
 
-    assert.equals('unknown modifier: target', target_err.message)
+    assert.equals('invalid location address: README.md#L10', target_err.message)
     assert.equals('unknown modifier: repo', repo_err.message)
     assert.equals('unknown modifier: rev', rev_err.message)
     assert.equals('invalid branch: @main', branch_err.message)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -352,7 +352,7 @@ describe(':Forge command', function()
           table.insert(captured.opens, { route = route, opts = opts })
         end,
         template_slugs = function()
-          return {}
+          return { 'bug', 'feature' }
         end,
         review_adapter_names = function()
           return { 'browse', 'checkout', 'diffview', 'worktree' }
@@ -676,6 +676,21 @@ describe(':Forge command', function()
     assert.equals('abc1234', captured.opens[1].opts.commit)
   end)
 
+  it('dispatches explicit location browsing through ops.browse_location', function()
+    vim.cmd('Forge browse target=upstream@main:lua/forge/init.lua#L10-L20')
+
+    assert.equals('browse_location', captured.ops_calls[1].name)
+    assert.equals('lua/forge/init.lua', captured.ops_calls[1].location.path)
+    assert.same({ start_line = 10, end_line = 20 }, captured.ops_calls[1].location.range)
+    assert.equals('main', captured.ops_calls[1].location.rev.rev)
+    assert.same(repo_scope('upstream'), captured.ops_calls[1].scope)
+    assert.same({
+      loc = 'lua/forge/init.lua:10-20',
+      branch = 'main',
+      scope = repo_scope('upstream'),
+    }, captured.browse_calls[1])
+  end)
+
   it('dispatches argless kind browse through ops.list_browse', function()
     vim.cmd('Forge issue browse')
     vim.cmd('Forge ci browse')
@@ -967,6 +982,7 @@ describe(':Forge command', function()
     local issue = vim.fn.getcompletion('Forge issue ', 'cmdline')
     local ci = vim.fn.getcompletion('Forge ci ', 'cmdline')
     local release = vim.fn.getcompletion('Forge release ', 'cmdline')
+    local browse = vim.fn.getcompletion('Forge browse ', 'cmdline')
     local pr_create = vim.fn.getcompletion('Forge pr create ', 'cmdline')
     local issue_create = vim.fn.getcompletion('Forge issue create ', 'cmdline')
 
@@ -1002,6 +1018,9 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(release, 'browse'))
     assert.is_true(vim.tbl_contains(release, 'delete'))
     assert.is_true(vim.tbl_contains(release, 'refresh'))
+    assert.is_true(vim.tbl_contains(browse, 'branch='))
+    assert.is_true(vim.tbl_contains(browse, 'commit='))
+    assert.is_true(vim.tbl_contains(browse, 'target='))
 
     assert.is_true(vim.tbl_contains(pr_create, 'head='))
     assert.is_true(vim.tbl_contains(pr_create, 'base='))
@@ -1016,10 +1035,13 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(issue_create, 'head='))
   end)
 
-  it('completes modifier values for repo, revision, and target addresses', function()
+  it('completes local-only modifier values without consulting forge entity lists', function()
     local repos = vim.fn.getcompletion('Forge pr create repo=', 'cmdline')
-    local revs = vim.fn.getcompletion('Forge browse rev=', 'cmdline')
+    local branches = vim.fn.getcompletion('Forge browse branch=', 'cmdline')
+    local commits = vim.fn.getcompletion('Forge browse commit=', 'cmdline')
+    local targets = vim.fn.getcompletion('Forge browse target=', 'cmdline')
     local heads = vim.fn.getcompletion('Forge pr create head=', 'cmdline')
+    local templates = vim.fn.getcompletion('Forge issue create template=', 'cmdline')
     local adapters = vim.fn.getcompletion('Forge review 42 adapter=', 'cmdline')
 
     assert.is_true(vim.tbl_contains(repos, 'repo=work'))
@@ -1027,19 +1049,42 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(repos, 'repo=origin'))
     assert.is_true(vim.tbl_contains(repos, 'repo=upstream'))
 
-    assert.is_true(vim.tbl_contains(revs, 'rev=main'))
-    assert.is_true(vim.tbl_contains(revs, 'rev=feature'))
-    assert.is_true(vim.tbl_contains(revs, 'rev=v1.0.0'))
-    assert.is_true(vim.tbl_contains(revs, 'rev=deadbee'))
+    assert.is_true(vim.tbl_contains(branches, 'branch=main'))
+    assert.is_true(vim.tbl_contains(branches, 'branch=feature'))
+    assert.is_true(vim.tbl_contains(branches, 'branch=v1.0.0'))
+    assert.is_true(vim.tbl_contains(branches, 'branch=deadbee'))
+
+    assert.is_true(vim.tbl_contains(commits, 'commit=main'))
+    assert.is_true(vim.tbl_contains(commits, 'commit=feature'))
+    assert.is_true(vim.tbl_contains(commits, 'commit=v1.0.0'))
+    assert.is_true(vim.tbl_contains(commits, 'commit=deadbee'))
+
+    assert.is_true(vim.tbl_contains(targets, 'target=work@'))
+    assert.is_true(vim.tbl_contains(targets, 'target=origin@'))
+    assert.is_true(vim.tbl_contains(targets, 'target=@main:'))
+    assert.is_true(vim.tbl_contains(targets, 'target=@deadbee:'))
 
     assert.is_true(vim.tbl_contains(heads, 'head=work@'))
     assert.is_true(vim.tbl_contains(heads, 'head=origin@'))
     assert.is_true(vim.tbl_contains(heads, 'head=@main'))
     assert.is_true(vim.tbl_contains(heads, 'head=@deadbee'))
+
+    assert.is_true(vim.tbl_contains(templates, 'template=bug'))
+    assert.is_true(vim.tbl_contains(templates, 'template=feature'))
+
     assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
     assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
+
+    assert.same({}, vim.fn.getcompletion('Forge browse rev=', 'cmdline'))
+    assert.same({}, captured.get_list_calls)
+    assert.equals(
+      0,
+      vim.iter(captured.system_calls):fold(0, function(acc, item)
+        return acc + (item:match('^gh ') and 1 or 0)
+      end)
+    )
   end)
 
   it('does not complete picker-only command families', function()

--- a/spec/completion_policy_spec.lua
+++ b/spec/completion_policy_spec.lua
@@ -162,8 +162,8 @@ describe('forge.completion_policy', function()
 
   it('classifies local and static modifier-value policies', function()
     local command = {
+      modifiers = { 'repo', 'branch', 'commit', 'head', 'target', 'adapter', 'state', 'method' },
       modifier_values = {
-        adapter = { 'browse' },
         state = { 'open', 'closed' },
       },
     }
@@ -179,8 +179,29 @@ describe('forge.completion_policy', function()
       slot_class = 'modifier_value',
       cmdline_usefulness = 'local_only',
       allow_empty_prefix = true,
+      source = 'ref',
+    }, policy.modifier_value(command, 'branch'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'ref',
+    }, policy.modifier_value(command, 'commit'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
       source = 'rev_address',
     }, policy.modifier_value(command, 'head'))
+
+    assert.same({
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'local_only',
+      allow_empty_prefix = true,
+      source = 'target',
+    }, policy.modifier_value(command, 'target'))
 
     assert.same({
       slot_class = 'modifier_value',
@@ -203,6 +224,7 @@ describe('forge.completion_policy', function()
       source = 'modifier_values',
     }, policy.modifier_value(command, 'method', { values = { 'merge', 'squash', 'rebase' } }))
 
+    assert.is_nil(policy.modifier_value(command, 'rev'))
     assert.is_nil(policy.modifier_value(command, 'missing'))
   end)
 end)


### PR DESCRIPTION
## Problem
Modifier-value completion still exposed completion-only paths like `rev=`, did not complete `branch=` / `commit=` from local refs, and left `target=` as latent browse plumbing instead of a real stock-cmdline subtree.

## Solution
Closes #341 by gating modifier-value completion to declared modifiers, wiring `branch=` / `commit=` through the local ref source, exposing `target=` on `:Forge browse` and routing it through `browse_location`, and extending the focused cmdline specs to cover the local-only subtree boundary.