### PR TITLE
refactor: share CI state gating

### DIFF
--- a/lua/forge/ci.lua
+++ b/lua/forge/ci.lua
@@ -1,0 +1,29 @@
+local M = {}
+
+local function status_text(run)
+  if type(run) == 'table' then
+    run = run.status
+  end
+  if type(run) ~= 'string' then
+    return ''
+  end
+  return vim.trim(run):lower()
+end
+
+function M.in_progress(run)
+  local status = status_text(run)
+  return status == 'in_progress' or status == 'queued' or status == 'pending' or status == 'running'
+end
+
+function M.toggle_verb(run)
+  local status = status_text(run)
+  if status == 'skipped' then
+    return nil
+  end
+  if M.in_progress(status) then
+    return 'cancel'
+  end
+  return 'rerun'
+end
+
+return M

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local ci = require('forge.ci')
 local log = require('forge.logger')
 
 local function trim(text)
@@ -67,11 +68,6 @@ local function normalize_run_ref(run, scope)
     return run
   end
   return { id = run, scope = scope }
-end
-
-local function run_in_progress(status)
-  status = trim(status):lower()
-  return status == 'in_progress' or status == 'queued' or status == 'pending' or status == 'running'
 end
 
 local function summary_job_at_cursor(buf)
@@ -341,7 +337,7 @@ local function ci_log(f, run)
   run = normalize_run_ref(run)
   local run_ref = run.scope
   local status = trim(run.status):lower()
-  local in_progress = run_in_progress(status)
+  local in_progress = ci.in_progress(status)
   local url = trim(run.url)
   if url == '' and f.run_web_url then
     url = trim(f:run_web_url(run.id, run_ref) or '')
@@ -454,7 +450,7 @@ local function ci_watch(f, run)
   end
   local run_ref = run.scope
   local status = trim(run.status):lower()
-  local in_progress = run_in_progress(status)
+  local in_progress = ci.in_progress(status)
   local url = trim(run.url)
   if url == '' and f.run_web_url then
     url = trim(f:run_web_url(run.id, run_ref) or '')
@@ -477,7 +473,7 @@ end
 ---@param run forge.RunRefLike
 function M.ci_open(f, run)
   run = normalize_run_ref(run)
-  if run_in_progress(run.status) and ci_watch(f, run) then
+  if ci.in_progress(run.status) and ci_watch(f, run) then
     return
   end
   ci_log(f, run)
@@ -555,15 +551,15 @@ end
 function M.ci_toggle(f, run, opts)
   run = normalize_run_ref(run)
   opts = opts or {}
-  local status = trim(run.status):lower()
-  if status == 'skipped' then
+  local verb = ci.toggle_verb(run)
+  if verb == nil then
     log.info('nothing to toggle for skipped run')
     if opts.on_failure then
       opts.on_failure()
     end
     return
   end
-  if run_in_progress(status) then
+  if verb == 'cancel' then
     M.ci_cancel(f, run, opts)
   else
     M.ci_rerun(f, run, opts)

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local ci = require('forge.ci')
+
 ---@alias forge.Segment {[1]: string, [2]: string?}
 
 ---@class forge.PickerEntry
@@ -284,19 +286,7 @@ function M.ci_toggle_verb(entry)
   if not value then
     return nil
   end
-  local status = (value.status or ''):lower()
-  if
-    status == 'in_progress'
-    or status == 'queued'
-    or status == 'pending'
-    or status == 'running'
-  then
-    return 'cancel'
-  end
-  if status == 'skipped' then
-    return nil
-  end
-  return 'rerun'
+  return ci.toggle_verb(value)
 end
 
 ---@param opts forge.PickerOpts

--- a/spec/ci_spec.lua
+++ b/spec/ci_spec.lua
@@ -1,0 +1,35 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('forge.ci', function()
+  local ci
+
+  before_each(function()
+    package.loaded['forge.ci'] = nil
+    ci = require('forge.ci')
+  end)
+
+  it('treats active run statuses as in progress', function()
+    for _, status in ipairs({ 'in_progress', 'queued', 'pending', 'running' }) do
+      assert.is_true(ci.in_progress(status), 'status=' .. status)
+      assert.equals('cancel', ci.toggle_verb({ status = status }), 'status=' .. status)
+    end
+  end)
+
+  it('treats skipped runs as untoggleable', function()
+    assert.is_false(ci.in_progress('skipped'))
+    assert.is_nil(ci.toggle_verb({ status = 'skipped' }))
+  end)
+
+  it('treats completed and unknown statuses as rerunnable', function()
+    for _, status in ipairs({ 'success', 'failure', 'cancelled', 'timed_out', 'unknown', '' }) do
+      assert.is_false(ci.in_progress(status), 'status=' .. status)
+      assert.equals('rerun', ci.toggle_verb({ status = status }), 'status=' .. status)
+    end
+  end)
+
+  it('accepts run-like tables or raw status strings', function()
+    assert.is_true(ci.in_progress({ status = 'running' }))
+    assert.equals('cancel', ci.toggle_verb('queued'))
+    assert.equals('rerun', ci.toggle_verb({ id = '1' }))
+  end)
+end)

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -410,6 +410,31 @@ describe('shared operations', function()
     assert.equals(1, done)
   end)
 
+  it('dispatches CI toggle to rerun when the run status is missing', function()
+    local done = 0
+    local ops = require('forge.ops')
+    ops.ci_toggle({
+      name = 'github',
+      cancel_run_cmd = function(_, id)
+        return { 'cancel', id }
+      end,
+      rerun_run_cmd = function(_, id)
+        return { 'rerun', id }
+      end,
+    }, { id = '77' }, {
+      on_success = function()
+        done = done + 1
+      end,
+    })
+
+    vim.wait(100, function()
+      return done == 1
+    end)
+
+    assert.same({ 'rerun 77' }, captured.commands)
+    assert.equals(1, done)
+  end)
+
   it('no-ops CI toggle for skipped runs', function()
     local failed = 0
     local ops = require('forge.ops')

--- a/spec/picker_init_spec.lua
+++ b/spec/picker_init_spec.lua
@@ -94,6 +94,10 @@ describe('forge.picker.ci_toggle_verb', function()
     end
   end)
 
+  it('returns rerun when a run status is missing', function()
+    assert.equals('rerun', picker.ci_toggle_verb({ value = { id = '1' } }))
+  end)
+
   it('returns nil for skipped runs', function()
     assert.is_nil(picker.ci_toggle_verb({ value = { id = '1', status = 'skipped' } }))
   end)


### PR DESCRIPTION
## Problem

Closes #362.

CI status interpretation was split between picker labels and ops dispatch, so the plugin encoded the same cancel/rerun decision in multiple places.

## Solution

Add a shared `forge.ci` helper for CI status classification, route picker and ops consumers through it, and cover the shared seam with dedicated specs plus regression coverage for picker and ops behavior.