### PR TITLE
fix: restore stylua and clarify CI help

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -251,6 +251,9 @@ Top-level keys: ~
     `all`         `none`           Jump to all filter
     `refresh`     `<c-r>`          Refresh runs/checks
 
+    `toggle` is stateful: active runs cancel, completed runs rerun, and
+    skipped runs do not expose the action.
+
   `keys.release`: ~
     Action        Default Key      Meaning ~
     `browse`      `<cr>`           Open release in browser
@@ -346,8 +349,8 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
 
     Commands that need interactive selection are intentionally not exposed
     through `:Forge`; use the interactive picker surface instead.
-    This includes list navigation, list-scoped filters/refresh, nested per-PR
-    checks, and copy helpers.
+    This includes list navigation, list-scoped filters/refresh, CI
+    cancel/rerun toggles, nested per-PR checks, and copy helpers.
 
 PR COMMANDS                                                *forge-pr-commands*
 
@@ -454,6 +457,9 @@ CI COMMANDS                                                *forge-ci-commands*
     list-consuming command fetches fresh data from the forge. Mirrors
     the CI picker's refresh action.
 
+    Cancel/rerun remains a picker action via `keys.ci.toggle`; there are
+    no direct `:Forge ci cancel`, `rerun`, or `toggle` verbs.
+
 RELEASE COMMANDS                                      *forge-release-commands*
 
 `:Forge release browse` [{tag}] [repo=...]             *:Forge-release-browse*
@@ -543,7 +549,8 @@ ISSUE PICKER ~ Lists issues.
 
                                                              *forge-picker-ci*
 CI PICKER ~ Used for repo/current-branch runs and nested PR checks. Both use
-the `ci` key group, but only repo-wide runs expose `toggle`.
+the `ci` key group, but only the run picker exposes `toggle`; nested PR
+checks do not.
 
 `<cr>` opens the primary inspect action. GitHub uses normal-mode terminals for
 run view/watch and opens per-job logs from job lines. GitLab and Codeberg
@@ -556,6 +563,9 @@ Forge-managed log and summary buffers auto-refresh at `ci.refresh`.
   `toggle`      `<c-s>`          Cancel/rerun highlighted run
   `filter`      `<tab>`          Cycle filter
   `refresh`     `<c-r>`          Re-fetch runs
+
+  `toggle` is stateful: active runs cancel, completed runs rerun, and
+  skipped runs hide the action.
 
   Optional configurable direct filter jumps:
   `failed`, `passed`, `running`, and `all` have no default bindings, but

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -1116,66 +1116,69 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(issue_create, 'head='))
   end)
 
-  it('completes local-only and static modifier values without consulting forge entity lists', function()
-    local repos = completion('Forge pr create repo=')
-    local branches = completion('Forge browse branch=')
-    local commits = completion('Forge browse commit=')
-    local targets = completion('Forge browse target=')
-    local heads = completion('Forge pr create head=')
-    local bases = completion('Forge pr create base=')
-    local templates = completion('Forge issue create template=')
-    local adapters = completion('Forge review 42 adapter=')
-    local methods = completion('Forge pr merge method=')
+  it(
+    'completes local-only and static modifier values without consulting forge entity lists',
+    function()
+      local repos = completion('Forge pr create repo=')
+      local branches = completion('Forge browse branch=')
+      local commits = completion('Forge browse commit=')
+      local targets = completion('Forge browse target=')
+      local heads = completion('Forge pr create head=')
+      local bases = completion('Forge pr create base=')
+      local templates = completion('Forge issue create template=')
+      local adapters = completion('Forge review 42 adapter=')
+      local methods = completion('Forge pr merge method=')
 
-    assert.is_true(vim.tbl_contains(repos, 'repo=work'))
-    assert.is_true(vim.tbl_contains(repos, 'repo=mirror'))
-    assert.is_true(vim.tbl_contains(repos, 'repo=origin'))
-    assert.is_true(vim.tbl_contains(repos, 'repo=upstream'))
+      assert.is_true(vim.tbl_contains(repos, 'repo=work'))
+      assert.is_true(vim.tbl_contains(repos, 'repo=mirror'))
+      assert.is_true(vim.tbl_contains(repos, 'repo=origin'))
+      assert.is_true(vim.tbl_contains(repos, 'repo=upstream'))
 
-    assert.is_true(vim.tbl_contains(branches, 'branch=main'))
-    assert.is_true(vim.tbl_contains(branches, 'branch=feature'))
-    assert.is_true(vim.tbl_contains(branches, 'branch=v1.0.0'))
-    assert.is_true(vim.tbl_contains(branches, 'branch=deadbee'))
+      assert.is_true(vim.tbl_contains(branches, 'branch=main'))
+      assert.is_true(vim.tbl_contains(branches, 'branch=feature'))
+      assert.is_true(vim.tbl_contains(branches, 'branch=v1.0.0'))
+      assert.is_true(vim.tbl_contains(branches, 'branch=deadbee'))
 
-    assert.is_true(vim.tbl_contains(commits, 'commit=main'))
-    assert.is_true(vim.tbl_contains(commits, 'commit=feature'))
-    assert.is_true(vim.tbl_contains(commits, 'commit=v1.0.0'))
-    assert.is_true(vim.tbl_contains(commits, 'commit=deadbee'))
+      assert.is_true(vim.tbl_contains(commits, 'commit=main'))
+      assert.is_true(vim.tbl_contains(commits, 'commit=feature'))
+      assert.is_true(vim.tbl_contains(commits, 'commit=v1.0.0'))
+      assert.is_true(vim.tbl_contains(commits, 'commit=deadbee'))
 
-    assert.is_true(vim.tbl_contains(targets, 'target=work@'))
-    assert.is_true(vim.tbl_contains(targets, 'target=origin@'))
-    assert.is_true(vim.tbl_contains(targets, 'target=@main:'))
-    assert.is_true(vim.tbl_contains(targets, 'target=@deadbee:'))
+      assert.is_true(vim.tbl_contains(targets, 'target=work@'))
+      assert.is_true(vim.tbl_contains(targets, 'target=origin@'))
+      assert.is_true(vim.tbl_contains(targets, 'target=@main:'))
+      assert.is_true(vim.tbl_contains(targets, 'target=@deadbee:'))
 
-    for _, values in ipairs({ heads, bases }) do
-      local prefix = values == heads and 'head=' or 'base='
-      assert.is_true(vim.tbl_contains(values, prefix .. 'work@'))
-      assert.is_true(vim.tbl_contains(values, prefix .. 'origin@'))
-      assert.is_true(vim.tbl_contains(values, prefix .. '@main'))
-      assert.is_true(vim.tbl_contains(values, prefix .. '@deadbee'))
+      for _, values in ipairs({ heads, bases }) do
+        local prefix = values == heads and 'head=' or 'base='
+        assert.is_true(vim.tbl_contains(values, prefix .. 'work@'))
+        assert.is_true(vim.tbl_contains(values, prefix .. 'origin@'))
+        assert.is_true(vim.tbl_contains(values, prefix .. '@main'))
+        assert.is_true(vim.tbl_contains(values, prefix .. '@deadbee'))
+      end
+
+      assert.is_true(vim.tbl_contains(templates, 'template=bug'))
+      assert.is_true(vim.tbl_contains(templates, 'template=feature'))
+
+      assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
+      assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
+      assert.is_true(vim.tbl_contains(adapters, 'adapter=codediff'))
+      assert.is_true(vim.tbl_contains(adapters, 'adapter=diffs'))
+      assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
+      assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
+
+      assert.same({ 'method=merge', 'method=squash', 'method=rebase' }, methods)
+
+      assert.same({}, completion('Forge browse rev='))
+      assert.same({}, captured.get_list_calls)
+      assert.equals(
+        0,
+        vim.iter(captured.system_calls):fold(0, function(acc, item)
+          return acc + (item:match('^gh ') and 1 or 0)
+        end)
+      )
     end
-
-    assert.is_true(vim.tbl_contains(templates, 'template=bug'))
-    assert.is_true(vim.tbl_contains(templates, 'template=feature'))
-
-    assert.is_true(vim.tbl_contains(adapters, 'adapter=browse'))
-    assert.is_true(vim.tbl_contains(adapters, 'adapter=checkout'))
-    assert.is_true(vim.tbl_contains(adapters, 'adapter=codediff'))
-    assert.is_true(vim.tbl_contains(adapters, 'adapter=diffs'))
-    assert.is_true(vim.tbl_contains(adapters, 'adapter=diffview'))
-    assert.is_true(vim.tbl_contains(adapters, 'adapter=worktree'))
-
-    assert.same({ 'method=merge', 'method=squash', 'method=rebase' }, methods)
-
-    assert.same({}, completion('Forge browse rev='))
-    assert.same({}, captured.get_list_calls)
-    assert.equals(
-      0,
-      vim.iter(captured.system_calls):fold(0, function(acc, item)
-        return acc + (item:match('^gh ') and 1 or 0)
-      end)
-    )
-  end)
+  )
 
   it('completes registered review adapters for adapter=', function()
     extra_review_adapters = { 'custom-test-review' }


### PR DESCRIPTION
## Problem

Main still fails the repo's stylua check because `spec/command_spec.lua` has pending formatting drift, and the help does not clearly describe the current CI cancel/rerun surface.

## Solution

Apply the pending stylua normalization, document `keys.ci.toggle` as a stateful picker action, clarify that nested PR checks do not expose the toggle, and state explicitly that CI cancel/rerun remains picker-only rather than a direct `:Forge ci` command surface.