### PR TITLE
build(nix): use nixpkgs vimdoc-language-server

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774273680,
-        "narHash": "sha256-a++tZ1RQsDb1I0NHrFwdGuRlR5TORvCEUksM459wKUA=",
+        "lastModified": 1776329215,
+        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fdc7b8f7b30fdbedec91b71ed82f36e1637483ed",
+        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
         "type": "github"
       },
       "original": {
@@ -34,48 +16,10 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1772624091,
-        "narHash": "sha256-QKyJ0QGWBn6r0invrMAK8dmJoBYWoOWy7lN+UHzW1jc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "80bdc1e5ce51f56b19791b52b2901187931f5353",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "nixpkgs": "nixpkgs",
-        "systems": "systems",
-        "vimdoc-language-server": "vimdoc-language-server"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "vimdoc-language-server",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1772852295,
-        "narHash": "sha256-3FB/WzLZSiU2Mc50C9q9VXU1LRUZbsU6UHKmZG1C+hU=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "c10801f59c68e14c308aea8fa6b0b3d81d43c61e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "systems": "systems"
       }
     },
     "systems": {
@@ -90,41 +34,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "vimdoc-language-server": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2",
-        "rust-overlay": "rust-overlay"
-      },
-      "locked": {
-        "lastModified": 1774450573,
-        "narHash": "sha256-K2oPjDWruf+QL/81SLmY01fPM8vXDycTugh3J8wEQdo=",
-        "owner": "barrettruth",
-        "repo": "vimdoc-language-server",
-        "rev": "6a6ecc8077a50f871b7611e1b318823925171a39",
-        "type": "github"
-      },
-      "original": {
-        "owner": "barrettruth",
-        "repo": "vimdoc-language-server",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     systems.url = "github:nix-systems/default";
-    vimdoc-language-server.url = "github:barrettruth/vimdoc-language-server";
   };
 
   outputs =
     {
       nixpkgs,
       systems,
-      vimdoc-language-server,
       ...
     }:
     let
@@ -31,7 +29,7 @@
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server
-            vimdoc-language-server.packages.${pkgs.system}.default
+            pkgs.vimdoc-language-server
             (pkgs.luajit.withPackages (ps: [
               ps.busted
               ps.nlua

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -44,6 +44,8 @@ local repo_info_cache = cache_mod.new(30 * 60)
 local pr_state_cache = cache_mod.new(60)
 local list_cache = cache_mod.new(2 * 60)
 
+---@param cmd string
+---@return string?
 local function fn_system_text(cmd)
   local text = vim.trim(vim.fn.system(cmd))
   if vim.v.shell_error ~= 0 and (text == '' or text:match('^fatal:') or text:match('^error:')) then

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -170,7 +170,7 @@ end
 
 ---@param f forge.Forge
 ---@param pr forge.PRRefLike
----@param opts? forge.PickerBackOpts
+---@param opts? forge.PickerLimitOpts
 function M.pr_ci(f, pr, opts)
   pr = normalize_pr_ref(pr)
   opts = vim.tbl_extend('force', opts or {}, { scope = pr.scope })


### PR DESCRIPTION
Switch the flake from the custom vimdoc-language-server input to the nixpkgs package and refresh nixpkgs to a revision that includes it. This keeps the dev shells on the official packaged tool and drops the extra flake dependency chain.