### PR TITLE
fix: align forge picker headers with fzf-lua

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -167,13 +167,15 @@ local function render_header_for(actions, bindings, entry)
       local bracketed_key = header_key:match('^<(.*)>$')
       table.insert(
         parts,
-        bracketed_key and ('<%s> %s'):format(
-          utils.ansi_from_hl(hls.bind, bracketed_key),
-          utils.ansi_from_hl(hls.text, label)
-        ) or ('%s %s'):format(
-          utils.ansi_from_hl(hls.bind, header_key),
-          utils.ansi_from_hl(hls.text, label)
-        )
+        bracketed_key
+            and ('<%s> %s'):format(
+              utils.ansi_from_hl(hls.bind, bracketed_key),
+              utils.ansi_from_hl(hls.text, label)
+            )
+          or ('%s %s'):format(
+            utils.ansi_from_hl(hls.bind, header_key),
+            utils.ansi_from_hl(hls.text, label)
+          )
       )
     end
   end

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -17,11 +17,9 @@ local function header_hls()
   local ok, config = pcall(require, 'fzf-lua.config')
   local globals = ok and type(config.globals) == 'table' and config.globals or nil
   local hls = type(globals) == 'table' and (globals.hls or globals.__HLS) or nil
-  local fzf_hls = type(hls) == 'table' and hls.fzf or nil
   return {
     bind = type(hls) == 'table' and hls.header_bind or 'FzfLuaHeaderBind',
     text = type(hls) == 'table' and hls.header_text or 'FzfLuaHeaderText',
-    separator = type(fzf_hls) == 'table' and fzf_hls.info or 'FzfLuaFzfInfo',
   }
 end
 
@@ -166,9 +164,13 @@ local function render_header_for(actions, bindings, entry)
     local label = header_key and picker_mod.resolve_label(def, entry) or nil
     if header_key and label and not seen_keys[header_key] then
       seen_keys[header_key] = true
+      local bracketed_key = header_key:match('^<(.*)>$')
       table.insert(
         parts,
-        ('%s %s'):format(
+        bracketed_key and ('<%s> %s'):format(
+          utils.ansi_from_hl(hls.bind, bracketed_key),
+          utils.ansi_from_hl(hls.text, label)
+        ) or ('%s %s'):format(
           utils.ansi_from_hl(hls.bind, header_key),
           utils.ansi_from_hl(hls.text, label)
         )
@@ -178,8 +180,7 @@ local function render_header_for(actions, bindings, entry)
   if #parts == 0 then
     return nil
   end
-  local separator = utils.ansi_from_hl(hls.separator, '|')
-  return table.concat(parts, separator)
+  return ':: ' .. table.concat(parts, '|')
 end
 
 ---@param actions forge.PickerActionDef[]

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -174,14 +174,14 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:more][FzfLuaFzfInfo:|][FzfLuaHeaderBind:^X] [FzfLuaHeaderText:browse][FzfLuaFzfInfo:|][FzfLuaHeaderBind:<tab>] [FzfLuaHeaderText:filter]',
+      ':: <[FzfLuaHeaderBind:cr]> [FzfLuaHeaderText:more]|[FzfLuaHeaderBind:^X] [FzfLuaHeaderText:browse]|<[FzfLuaHeaderBind:tab]> [FzfLuaHeaderText:filter]',
       captured.opts.fzf_opts['--header']
     )
     assert.is_nil(captured.opts.fzf_opts['--header']:match(' to '))
     assert.is_function(captured.opts.actions.tab)
   end)
 
-  it('uses resolved fzf-lua header highlight config for binds, labels, and separators', function()
+  it('uses resolved fzf-lua header highlight config for binds and labels', function()
     set_header_hls('ForgeTestHeaderBind', 'ForgeTestHeaderText', 'ForgeTestHeaderSep')
 
     local picker = require('forge.picker.fzf')
@@ -206,7 +206,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[ForgeTestHeaderBind:<cr>] [ForgeTestHeaderText:more][ForgeTestHeaderSep:|][ForgeTestHeaderBind:^X] [ForgeTestHeaderText:browse][ForgeTestHeaderSep:|][ForgeTestHeaderBind:<tab>] [ForgeTestHeaderText:filter]',
+      ':: <[ForgeTestHeaderBind:cr]> [ForgeTestHeaderText:more]|[ForgeTestHeaderBind:^X] [ForgeTestHeaderText:browse]|<[ForgeTestHeaderBind:tab]> [ForgeTestHeaderText:filter]',
       captured.opts.fzf_opts['--header']
     )
   end)
@@ -236,7 +236,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[ForgeTestHeaderBind:<cr>] [ForgeTestHeaderText:more][ForgeTestHeaderSep:|][ForgeTestHeaderBind:^X] [ForgeTestHeaderText:browse][ForgeTestHeaderSep:|][ForgeTestHeaderBind:<tab>] [ForgeTestHeaderText:filter]',
+      ':: <[ForgeTestHeaderBind:cr]> [ForgeTestHeaderText:more]|[ForgeTestHeaderBind:^X] [ForgeTestHeaderText:browse]|<[ForgeTestHeaderBind:tab]> [ForgeTestHeaderText:filter]',
       captured.opts.fzf_opts['--header']
     )
   end)
@@ -259,7 +259,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:use]',
+      ':: <[FzfLuaHeaderBind:cr]> [FzfLuaHeaderText:use]',
       captured.opts.fzf_opts['--header']
     )
   end)
@@ -314,7 +314,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:^A] [FzfLuaHeaderText:create][FzfLuaFzfInfo:|][FzfLuaHeaderBind:^R] [FzfLuaHeaderText:refresh]',
+      ':: [FzfLuaHeaderBind:^A] [FzfLuaHeaderText:create]|[FzfLuaHeaderBind:^R] [FzfLuaHeaderText:refresh]',
       captured.opts.fzf_opts['--header']
     )
   end)
@@ -341,7 +341,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:run]',
+      ':: <[FzfLuaHeaderBind:cr]> [FzfLuaHeaderText:run]',
       captured.opts.fzf_opts['--header']
     )
     assert.is_function(captured.opts.actions['ctrl-o'])
@@ -386,7 +386,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:open]',
+      ':: <[FzfLuaHeaderBind:cr]> [FzfLuaHeaderText:open]',
       captured.opts.fzf_opts['--header']
     )
     assert.is_function(captured.opts.actions['ctrl-x'])
@@ -421,7 +421,7 @@ describe('fzf picker', function()
 
     assert.is_not_nil(captured)
     assert.equals(
-      '[FzfLuaHeaderBind:<cr>] [FzfLuaHeaderText:open][FzfLuaFzfInfo:|][FzfLuaHeaderBind:^S] [FzfLuaHeaderText:close][FzfLuaFzfInfo:|][FzfLuaHeaderBind:<tab>] [FzfLuaHeaderText:filter]',
+      ':: <[FzfLuaHeaderBind:cr]> [FzfLuaHeaderText:open]|[FzfLuaHeaderBind:^S] [FzfLuaHeaderText:close]|<[FzfLuaHeaderBind:tab]> [FzfLuaHeaderText:filter]',
       captured.opts.fzf_opts['--header']
     )
   end)


### PR DESCRIPTION
## Problem

Forge's compact picker header styling diverged from native fzf-lua scaffolding, so the plain prefix, separators, and compact ctrl bindings did not use the same visual structure users compare against in fzf-lua. Closes #335.

## Solution

Render Forge headers with native-style `:: ` and `|` scaffolding, keep naturally bracketed keys like `<cr>` and `<tab>` bracketed, leave compact ctrl keys like `^X` unbracketed, and update the picker specs to match the new formatting.