### PR TITLE
ci: split quality checks into separate jobs

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -8,15 +8,27 @@ on:
     branches: [main]
 
 jobs:
-  quality:
-    name: Quality
+  format:
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
       - name: Format
         run: nix develop .#ci --command just format
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
       - name: Lint
         run: nix develop .#ci --command just lint
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
       - name: Test
         run: nix develop .#ci --command just test


### PR DESCRIPTION
## Problem

The quality workflow runs format, lint, and test as sequential steps in one job. When one step fails, the remaining checks do not run, so pull requests only surface the first failing category instead of the full set of broken checks.

## Solution

Split the quality workflow into separate format, lint, and test jobs while keeping each job wired to the existing `just` recipes in the CI nix shell. This preserves `just` as the source of truth and lets GitHub report all failing categories in parallel.