### PR TITLE
refactor: centralize surface alias resolution

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1,7 +1,9 @@
 local M = {}
 
 local ops = require('forge.ops')
+local surface = require('forge.surface')
 
+---@type table<string, forge.ModifierSpec>
 local modifiers = {
   state = { kind = 'value' },
   repo = { kind = 'value', target = 'repo' },
@@ -29,6 +31,7 @@ local target_modifier_parsers = {
   base = 'parse_rev',
 }
 
+---@type forge.CommandFamilyDef[]
 local families = {
   {
     name = 'pr',
@@ -190,6 +193,7 @@ local families = {
   },
 }
 
+---@type table<forge.CommandFamily, forge.CommandFamilyDef>
 local family_index = {}
 
 for _, family in ipairs(families) do
@@ -619,22 +623,46 @@ local dispatchers = {
   end,
 }
 
-function M.family_names()
+---@param opts? forge.SurfaceNamesOpts
+---@return string[]
+function M.family_names(opts)
+  opts = opts or {}
   local names = {}
   for _, family in ipairs(families) do
     names[#names + 1] = family.name
+    if opts.include_aliases then
+      for _, alias in ipairs(surface.family_aliases(family.name, opts.forge_name)) do
+        names[#names + 1] = alias
+      end
+    end
   end
   return names
 end
 
-function M.verb_names(family_name)
-  local family = family_index[family_name]
+---@param name string
+---@param opts? forge.SurfaceOpts
+---@return string
+local function resolved_family_name(name, opts)
+  local resolved = surface.resolve_family(name, opts and opts.forge_name)
+  if resolved then
+    return resolved.canonical
+  end
+  return name
+end
+
+---@param family_name string
+---@param opts? forge.SurfaceOpts
+---@return string[]
+function M.verb_names(family_name, opts)
+  local family = family_index[resolved_family_name(family_name, opts)]
   if not family then
     return {}
   end
   return copy(family.verb_order or {})
 end
 
+---@param name string
+---@return forge.ModifierSpec?
 function M.modifier(name)
   local spec = modifiers[name]
   if not spec then
@@ -643,16 +671,27 @@ function M.modifier(name)
   return copy(spec)
 end
 
-function M.family(name)
-  local family = family_index[name]
+---@param name string
+---@param opts? forge.SurfaceOpts
+---@return forge.CommandFamilyDef?
+function M.family(name, opts)
+  local family = family_index[resolved_family_name(name, opts)]
   if not family then
     return nil
   end
   return copy(family)
 end
 
-function M.resolve(family_name, verb_name)
-  local family = family_index[family_name]
+---@param family_name string
+---@param verb_name string?
+---@param opts? forge.SurfaceOpts
+---@return forge.Command?
+function M.resolve(family_name, verb_name, opts)
+  local resolved_family = surface.resolve_family(family_name, opts and opts.forge_name)
+  if not resolved_family then
+    return nil
+  end
+  local family = family_index[resolved_family.canonical]
   if not family then
     return nil
   end
@@ -682,6 +721,8 @@ function M.resolve(family_name, verb_name)
 
   local command = copy(verb)
   command.family = family.name
+  command.invoked_family = resolved_family.invoked
+  command.family_alias = resolved_family.alias
   command.name = resolved
   command.surface = family.surface
   command.implicit = implicit
@@ -689,22 +730,33 @@ function M.resolve(family_name, verb_name)
   return command
 end
 
-function M.modifier_names(family_name, verb_name)
-  local command = M.resolve(family_name, verb_name)
+---@param family_name string
+---@param verb_name string?
+---@param opts? forge.SurfaceOpts
+---@return string[]
+function M.modifier_names(family_name, verb_name, opts)
+  local command = M.resolve(family_name, verb_name, opts)
   if not command then
     return {}
   end
   return copy(command.modifiers or {})
 end
 
-function M.legacy_modifier_names(family_name, verb_name)
-  local command = M.resolve(family_name, verb_name)
+---@param family_name string
+---@param verb_name string?
+---@param opts? forge.SurfaceOpts
+---@return string[]
+function M.legacy_modifier_names(family_name, verb_name, opts)
+  local command = M.resolve(family_name, verb_name, opts)
   if not command then
     return {}
   end
   return copy(command.legacy_modifiers or {})
 end
 
+---@param args string[]
+---@param opts? forge.SurfaceOpts
+---@return forge.Command?, forge.CmdError?
 function M.parse(args, opts)
   opts = opts or {}
   if type(args) ~= 'table' or #args == 0 or args[1] == '' then
@@ -712,7 +764,7 @@ function M.parse(args, opts)
   end
 
   local family_name = args[1]
-  local family = family_index[family_name]
+  local family = M.family(family_name, opts)
   if not family then
     return error_result('unknown command: ' .. family_name)
   end
@@ -724,15 +776,15 @@ function M.parse(args, opts)
 
   if not has_explicit_verb and not family.default_verb then
     if verb_token ~= nil then
-      return error_result(unknown_verb_error(family_name, verb_token))
+      return error_result(unknown_verb_error(family.name, verb_token))
     end
     return error_result(missing_verb_error(family_name))
   end
 
-  local command = M.resolve(family_name, has_explicit_verb and verb_token or nil)
+  local command = M.resolve(family_name, has_explicit_verb and verb_token or nil, opts)
   if not command then
     if verb_token ~= nil then
-      return error_result(unknown_verb_error(family_name, verb_token))
+      return error_result(unknown_verb_error(family.name, verb_token))
     end
     return error_result(missing_verb_error(family_name))
   end

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -1,4 +1,5 @@
 local M = {}
+local surface = require('forge.surface')
 
 ---@alias forge.Split 'horizontal'|'vertical'
 
@@ -217,22 +218,12 @@ local hl_defaults = {
   ForgeLogDim = 'Comment',
 }
 
-local valid_routes = {
-  ['prs.all'] = true,
-  ['prs.open'] = true,
-  ['prs.closed'] = true,
-  ['issues.all'] = true,
-  ['issues.open'] = true,
-  ['issues.closed'] = true,
-  ['ci.all'] = true,
-  ['ci.current_branch'] = true,
-  ['browse.contextual'] = true,
-  ['browse.branch'] = true,
-  ['browse.commit'] = true,
-  ['releases.all'] = true,
-  ['releases.draft'] = true,
-  ['releases.prerelease'] = true,
-}
+---@type table<string, boolean>
+local valid_routes = {}
+
+for _, name in ipairs(surface.route_names()) do
+  valid_routes[name] = true
+end
 
 local function nonempty_string(v)
   return type(v) == 'string' and vim.trim(v) ~= ''

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -598,7 +598,7 @@ end
 
 ---@param f forge.Forge
 ---@param kind forge.WebKind
----@param opts? forge.ScopedOpts
+---@param opts? forge.RouteOpts
 function M.list_browse(f, kind, opts)
   opts = opts or {}
   local url = f.list_web_url and f:list_web_url(kind, opts.scope) or nil
@@ -630,12 +630,12 @@ function M.browse_repo(opts)
 end
 
 ---@param branch string?
----@param opts? forge.ScopedOpts
+---@param opts? forge.RouteOpts
 function M.browse_branch(branch, opts)
   require('forge').open('browse.branch', vim.tbl_extend('force', opts or {}, { branch = branch }))
 end
 
----@param opts? forge.ScopedOpts
+---@param opts? forge.RouteOpts
 function M.browse_contextual(opts)
   require('forge').open('browse.contextual', opts)
 end

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local ci = require('forge.ci')
+local surface = require('forge.surface')
 
 ---@alias forge.Segment {[1]: string, [2]: string?}
 
@@ -32,6 +33,7 @@ local ci = require('forge.ci')
 ---@field back fun()?
 ---@field stream? fun(emit: fun(entry: forge.PickerEntry?))
 
+---@type table<string, string[]>
 local root_search_terms = {
   ['prs.all'] = { 'prs', 'pull', 'requests', 'reviews' },
   ['prs.open'] = { 'prs', 'pull', 'requests', 'reviews' },
@@ -49,6 +51,8 @@ local root_search_terms = {
   ['releases.prerelease'] = { 'releases', 'tags' },
 }
 
+---@param entry forge.PickerEntry
+---@return string
 local function flatten_display(entry)
   local parts = {}
   for _, seg in ipairs(entry.display or {}) do
@@ -57,6 +61,8 @@ local function flatten_display(entry)
   return table.concat(parts)
 end
 
+---@param parts string[]
+---@return string
 local function join_search_terms(parts)
   local items = {}
   for _, part in ipairs(parts) do
@@ -70,6 +76,8 @@ local function join_search_terms(parts)
   return table.concat(items, ' ')
 end
 
+---@param entry forge.PickerEntry
+---@return string
 local function menu_search_key(entry)
   local value = entry.value
   if type(value) == 'table' then
@@ -81,7 +89,9 @@ local function menu_search_key(entry)
       return join_search_terms({ value.display, slug })
     end
   elseif type(value) == 'string' then
-    local root_terms = root_search_terms[value]
+    local resolved = surface.resolve_section(value) or surface.resolve_route(value)
+    local lookup = resolved and resolved.canonical or value
+    local root_terms = root_search_terms[lookup]
     if root_terms then
       local display = flatten_display(entry)
       return join_search_terms(vim.list_extend({ display }, vim.deepcopy(root_terms)))

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -3,15 +3,13 @@ local M = {}
 local action = require('forge.action')
 local context = require('forge.context')
 local log = require('forge.logger')
+local surface = require('forge.surface')
 
-local section_order = {
-  'prs',
-  'issues',
-  'ci',
-  'browse',
-  'releases',
-}
+---@type string[]
+local section_order = surface.section_names()
 
+---@param ctx forge.Context
+---@return string
 local function prompt(ctx)
   if ctx.branch ~= '' then
     return ('Forge (%s)> '):format(ctx.branch)
@@ -19,6 +17,9 @@ local function prompt(ctx)
   return 'Forge> '
 end
 
+---@param ctx forge.Context
+---@param opts forge.RouteOpts
+---@return string?, string?
 local function branch_for(ctx, opts)
   local branch = opts.branch
   if branch == nil or branch == '' then
@@ -30,6 +31,7 @@ local function branch_for(ctx, opts)
   return branch
 end
 
+---@return table<string, fun(ctx: forge.Context, opts: forge.RouteOpts): boolean?, string?>
 local function route_handlers()
   local pickers = require('forge.pickers')
 
@@ -148,6 +150,9 @@ local function route_handlers()
   }
 end
 
+---@param section forge.SectionName
+---@param ctx forge.Context
+---@return string
 local function section_label(section, ctx)
   if section == 'prs' then
     return ctx.forge and ctx.forge.labels.pr_full or 'PRs'
@@ -167,6 +172,9 @@ local function section_label(section, ctx)
   return section
 end
 
+---@param section forge.SectionName
+---@param ctx forge.Context
+---@return boolean
 local function section_available(section, ctx)
   if section == 'browse' then
     return ctx.forge ~= nil and ctx.branch ~= ''
@@ -177,19 +185,31 @@ local function section_available(section, ctx)
   return true
 end
 
+---@param name string?
+---@return forge.Context?, string?
 function M.current_context(name)
   return context.resolve(name)
 end
 
-function M.resolve(name)
+---@param name string?
+---@param opts? forge.SurfaceOpts
+---@return string?
+function M.resolve(name, opts)
   if not name or name == '' then
     return nil
   end
+  opts = opts or {}
   local cfg = require('forge').config()
   local routes = rawget(cfg, 'routes') or {}
-  return routes[name] or name
+  local resolved_section = surface.resolve_section(name, opts.forge_name)
+  local lookup = resolved_section and resolved_section.canonical or name
+  local route = routes[lookup] or lookup
+  local resolved_route = surface.resolve_route(route, opts.forge_name)
+  return resolved_route and resolved_route.canonical or route
 end
 
+---@param ctx forge.Context
+---@param opts? forge.RouteOpts
 local function open_root(ctx, opts)
   opts = opts or {}
   local cfg = require('forge').config()
@@ -201,7 +221,8 @@ local function open_root(ctx, opts)
   for _, section in ipairs(section_order) do
     if sections[section] ~= false then
       local route = routes[section]
-      if route and handlers[route] and section_available(section, ctx) then
+      local resolved_route = route and M.resolve(route) or nil
+      if resolved_route and handlers[resolved_route] and section_available(section, ctx) then
         local label = section_label(section, ctx)
         entries[#entries + 1] = {
           display = { { label } },
@@ -241,6 +262,8 @@ local function open_root(ctx, opts)
   })
 end
 
+---@param name string?
+---@param opts? forge.RouteOpts
 function M.open(name, opts)
   opts = opts or {}
 

--- a/lua/forge/surface.lua
+++ b/lua/forge/surface.lua
@@ -1,0 +1,242 @@
+local M = {}
+
+---@alias forge.SurfaceAliasRegistry table<string, table<string, string[]>>
+
+---@type forge.SurfaceAliasRegistry
+local family_aliases = {
+  pr = {
+    gitlab = { 'mr' },
+  },
+  review = {},
+  issue = {},
+  ci = {
+    gitlab = { 'pipeline' },
+  },
+  release = {},
+  browse = {},
+  clear = {},
+}
+
+---@type forge.SectionName[]
+local section_order = {
+  'prs',
+  'issues',
+  'ci',
+  'browse',
+  'releases',
+}
+
+---@type forge.SurfaceAliasRegistry
+local section_aliases = {
+  prs = {
+    gitlab = { 'mrs' },
+  },
+  issues = {},
+  ci = {
+    gitlab = { 'pipelines' },
+  },
+  browse = {},
+  releases = {},
+}
+
+---@type forge.RouteName[]
+local route_order = {
+  'prs.all',
+  'prs.open',
+  'prs.closed',
+  'issues.all',
+  'issues.open',
+  'issues.closed',
+  'ci.all',
+  'ci.current_branch',
+  'browse.contextual',
+  'browse.branch',
+  'browse.commit',
+  'releases.all',
+  'releases.draft',
+  'releases.prerelease',
+}
+
+---@type table<string, boolean>
+local route_set = {}
+
+for _, name in ipairs(route_order) do
+  route_set[name] = true
+end
+
+---@param registry forge.SurfaceAliasRegistry
+---@param name string
+---@param forge_name string?
+---@return string[]
+local function aliases_for(registry, name, forge_name)
+  local entry = registry[name]
+  if type(entry) ~= 'table' or forge_name == nil or forge_name == '' then
+    return {}
+  end
+  local aliases = entry[forge_name]
+  if type(aliases) ~= 'table' then
+    return {}
+  end
+  return vim.deepcopy(aliases)
+end
+
+---@param registry forge.SurfaceAliasRegistry
+---@param name string
+---@param forge_name string?
+---@return forge.SurfaceResolvedName?
+local function resolve_name(registry, name, forge_name)
+  if registry[name] ~= nil then
+    return {
+      canonical = name,
+      invoked = name,
+      alias = nil,
+    }
+  end
+  if forge_name == nil or forge_name == '' then
+    return nil
+  end
+  for canonical in pairs(registry) do
+    for _, alias in ipairs(aliases_for(registry, canonical, forge_name)) do
+      if alias == name then
+        return {
+          canonical = canonical,
+          invoked = name,
+          alias = name,
+        }
+      end
+    end
+  end
+  return nil
+end
+
+---@param order string[]
+---@param registry forge.SurfaceAliasRegistry
+---@param opts? forge.SurfaceNamesOpts
+---@return string[]
+local function ordered_names(order, registry, opts)
+  opts = opts or {}
+  local names = {}
+  for _, name in ipairs(order) do
+    names[#names + 1] = name
+    if opts.include_aliases then
+      for _, alias in ipairs(aliases_for(registry, name, opts.forge_name)) do
+        names[#names + 1] = alias
+      end
+    end
+  end
+  return names
+end
+
+---@param name string
+---@return string?, string?
+local function route_parts(name)
+  local section, suffix = name:match('^([^.]+)%.(.+)$')
+  return section, suffix
+end
+
+---@param name forge.RouteName
+---@param forge_name string?
+---@return string[]
+local function derived_route_aliases(name, forge_name)
+  local section, suffix = route_parts(name)
+  if section == nil or suffix == nil then
+    return {}
+  end
+  local aliases = {}
+  for _, alias in ipairs(aliases_for(section_aliases, section, forge_name)) do
+    aliases[#aliases + 1] = alias .. '.' .. suffix
+  end
+  return aliases
+end
+
+---@param name forge.CommandFamily
+---@param forge_name string?
+---@return string[]
+function M.family_aliases(name, forge_name)
+  return aliases_for(family_aliases, name, forge_name)
+end
+
+---@param name string
+---@param forge_name string?
+---@return forge.SurfaceResolvedName?
+function M.resolve_family(name, forge_name)
+  return resolve_name(family_aliases, name, forge_name)
+end
+
+---@param name forge.SectionName
+---@param forge_name string?
+---@return string[]
+function M.section_aliases(name, forge_name)
+  return aliases_for(section_aliases, name, forge_name)
+end
+
+---@param opts? forge.SurfaceNamesOpts
+---@return string[]
+function M.section_names(opts)
+  return ordered_names(section_order, section_aliases, opts)
+end
+
+---@param name string
+---@param forge_name string?
+---@return forge.SurfaceResolvedName?
+function M.resolve_section(name, forge_name)
+  return resolve_name(section_aliases, name, forge_name)
+end
+
+---@param name forge.RouteName
+---@param forge_name string?
+---@return string[]
+function M.route_aliases(name, forge_name)
+  return derived_route_aliases(name, forge_name)
+end
+
+---@param opts? forge.SurfaceNamesOpts
+---@return string[]
+function M.route_names(opts)
+  opts = opts or {}
+  local names = {}
+  for _, name in ipairs(route_order) do
+    names[#names + 1] = name
+    if opts.include_aliases then
+      for _, alias in ipairs(derived_route_aliases(name, opts.forge_name)) do
+        names[#names + 1] = alias
+      end
+    end
+  end
+  return names
+end
+
+---@param name string
+---@param forge_name string?
+---@return forge.SurfaceResolvedName?
+function M.resolve_route(name, forge_name)
+  if route_set[name] then
+    return {
+      canonical = name,
+      invoked = name,
+      alias = nil,
+    }
+  end
+  if forge_name == nil or forge_name == '' then
+    return nil
+  end
+  local section, suffix = route_parts(name)
+  if section == nil or suffix == nil then
+    return nil
+  end
+  local resolved_section = M.resolve_section(section, forge_name)
+  if not resolved_section then
+    return nil
+  end
+  local canonical = resolved_section.canonical .. '.' .. suffix
+  if not route_set[canonical] then
+    return nil
+  end
+  return {
+    canonical = canonical,
+    invoked = name,
+    alias = name,
+  }
+end
+
+return M

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -3,6 +3,23 @@
 ---@alias forge.ScopeKind 'github'|'gitlab'|'codeberg'
 
 ---@alias forge.WebKind 'pr'|'issue'|'ci'|'release'
+---@alias forge.CommandFamily 'pr'|'review'|'issue'|'ci'|'release'|'browse'|'clear'
+---@alias forge.SectionName 'prs'|'issues'|'ci'|'browse'|'releases'
+---@alias forge.RouteName
+---| 'prs.all'
+---| 'prs.open'
+---| 'prs.closed'
+---| 'issues.all'
+---| 'issues.open'
+---| 'issues.closed'
+---| 'ci.all'
+---| 'ci.current_branch'
+---| 'browse.contextual'
+---| 'browse.branch'
+---| 'browse.commit'
+---| 'releases.all'
+---| 'releases.draft'
+---| 'releases.prerelease'
 
 ---@class forge.Scope
 ---@field kind forge.ScopeKind
@@ -40,12 +57,89 @@
 ---@class forge.ScopedOpts
 ---@field scope forge.Scope?
 
+---@class forge.SurfaceOpts
+---@field forge_name string?
+
+---@class forge.SurfaceNamesOpts: forge.SurfaceOpts
+---@field include_aliases boolean?
+
+---@class forge.SurfaceResolvedName
+---@field canonical string
+---@field invoked string
+---@field alias string?
+
+---@class forge.CmdError
+---@field code string?
+---@field message string
+
+---@class forge.CommandSubjectSpec
+---@field kind string?
+---@field min integer?
+---@field max integer?
+
+---@class forge.ModifierSpec
+---@field kind 'value'|'flag'
+---@field target string?
+---@field values string[]?
+
+---@class forge.CommandVerbDef
+---@field subject forge.CommandSubjectSpec?
+---@field modifiers string[]?
+---@field legacy_modifiers string[]?
+---@field required_modifiers string[]?
+---@field modifier_values table<string, string[]>?
+
+---@class forge.CommandFamilyDef
+---@field name forge.CommandFamily
+---@field surface string
+---@field default_verb string?
+---@field verb_order string[]
+---@field verbs table<string, forge.CommandVerbDef>
+---@field aliases table<string, string>?
+
+---@class forge.Command
+---@field family forge.CommandFamily
+---@field invoked_family string
+---@field family_alias string?
+---@field name string
+---@field surface string
+---@field implicit boolean
+---@field alias string?
+---@field subject forge.CommandSubjectSpec?
+---@field subjects string[]
+---@field raw string[]
+---@field modifiers table<string, any>
+---@field declared_modifiers string[]
+---@field declared_legacy_modifiers string[]
+---@field legacy_modifiers string[]?
+---@field parsed_modifiers table<string, any>
+---@field modifier_values table<string, string[]>?
+---@field required_modifiers string[]?
+---@field default_policy table
+---@field default_targets table
+---@field range { start_line: integer, end_line: integer }?
+
+---@class forge.Context
+---@field id string
+---@field root string
+---@field branch string
+---@field head string
+---@field forge forge.Forge?
+---@field has_file boolean
+---@field loc string?
+
 ---@class forge.OpCallbacks
 ---@field on_success fun()?
 ---@field on_failure fun()?
 
----@class forge.PickerBackOpts: forge.ScopedOpts
+---@class forge.RouteOpts: forge.ScopedOpts
 ---@field back fun()?
+---@field forge_name string?
+---@field context string?
+---@field branch string?
+---@field commit string?
+
+---@class forge.PickerBackOpts: forge.RouteOpts
 
 ---@class forge.PickerLimitOpts: forge.PickerBackOpts
 ---@field limit integer?

--- a/spec/surface_spec.lua
+++ b/spec/surface_spec.lua
@@ -1,0 +1,72 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('surface', function()
+  before_each(function()
+    package.loaded['forge.surface'] = nil
+    package.loaded['forge.cmd'] = nil
+    package.loaded['forge.picker'] = nil
+  end)
+
+  it('exposes gitlab command aliases separately from canonical families', function()
+    local surface = require('forge.surface')
+
+    assert.same({ 'mr' }, surface.family_aliases('pr', 'gitlab'))
+    assert.same({ 'pipeline' }, surface.family_aliases('ci', 'gitlab'))
+    assert.same(
+      { canonical = 'pr', invoked = 'mr', alias = 'mr' },
+      surface.resolve_family('mr', 'gitlab')
+    )
+    assert.same(
+      { canonical = 'ci', invoked = 'pipeline', alias = 'pipeline' },
+      surface.resolve_family('pipeline', 'gitlab')
+    )
+    assert.is_nil(surface.resolve_family('mr'))
+    assert.is_nil(surface.resolve_family('pipeline'))
+  end)
+
+  it('exposes gitlab section and route aliases separately from canonical values', function()
+    local surface = require('forge.surface')
+
+    assert.same(
+      { 'prs', 'mrs', 'issues', 'ci', 'pipelines', 'browse', 'releases' },
+      surface.section_names({
+        include_aliases = true,
+        forge_name = 'gitlab',
+      })
+    )
+    assert.same({ 'mrs.open' }, surface.route_aliases('prs.open', 'gitlab'))
+    assert.same(
+      { canonical = 'prs', invoked = 'mrs', alias = 'mrs' },
+      surface.resolve_section('mrs', 'gitlab')
+    )
+    assert.same({
+      canonical = 'ci.current_branch',
+      invoked = 'pipelines.current_branch',
+      alias = 'pipelines.current_branch',
+    }, surface.resolve_route('pipelines.current_branch', 'gitlab'))
+    assert.is_nil(surface.resolve_section('mrs'))
+    assert.is_nil(surface.resolve_route('pipelines.current_branch'))
+  end)
+
+  it('lets cmd parse preserve invoked family aliases when the forge is known', function()
+    local cmd = require('forge.cmd')
+    local command, err = cmd.parse({ 'mr', 'edit', '42' }, { forge_name = 'gitlab' })
+
+    assert.is_nil(err)
+    assert.equals('pr', command.family)
+    assert.equals('mr', command.invoked_family)
+    assert.equals('mr', command.family_alias)
+    assert.equals('edit', command.name)
+    assert.same({ '42' }, command.subjects)
+  end)
+
+  it('keeps provider aliases unavailable without an explicit forge surface', function()
+    local cmd = require('forge.cmd')
+    local command, err = cmd.parse({ 'mr', 'edit', '42' })
+
+    assert.is_nil(command)
+    assert.same({ message = 'unknown command: mr' }, {
+      message = err.message,
+    })
+  end)
+end)


### PR DESCRIPTION
## Problem

Surface terminology and alias rules are hardcoded across command parsing, route validation, and root-surface helpers. That makes later GitLab-specific aliases and UI terminology changes risky to add cleanly.

Closes #373.

## Solution

Add a shared `forge.surface` registry for canonical and provider-native family, section, and route names. Refactor `forge.cmd`, `forge.routes`, config route validation, and root-surface helpers to resolve through that layer, and add strict LuaCATS coverage plus focused specs for the new alias foundation.
