### PR TITLE
feat(cmd): add GitLab mr and pipeline aliases

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -347,6 +347,13 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     interface:
     - legacy `--name` / `--name=value` forms for modifiers
 
+    When the detected forge is GitLab, the Ex command surface also accepts
+    provider-native family aliases:
+    - `:Forge mr ...` as an alias for `:Forge pr ...`
+    - `:Forge pipeline ...` as an alias for `:Forge ci ...`
+    Completion only offers those aliases on GitLab. Canonical config keys
+    and internal names remain `pr` and `ci`.
+
     Commands that need interactive selection are intentionally not exposed
     through `:Forge`; use the interactive picker surface instead.
     This includes list navigation, list-scoped filters/refresh, CI

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -903,6 +903,19 @@ function M.dispatch(command)
   return true
 end
 
+---@return string?
+local function detected_forge_name()
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
+    return nil
+  end
+  local detected = forge.detect()
+  if type(detected) ~= 'table' or type(detected.name) ~= 'string' or detected.name == '' then
+    return nil
+  end
+  return detected.name
+end
+
 function M.run(opts)
   opts = opts or {}
   if vim.trim(opts.args or '') == '' then
@@ -910,7 +923,9 @@ function M.run(opts)
     return false
   end
 
-  local command, err = M.parse(split_words(opts.args))
+  local command, err = M.parse(split_words(opts.args), {
+    forge_name = detected_forge_name(),
+  })
   if not command then
     if err and err.message then
       warn(err.message)
@@ -1341,8 +1356,9 @@ local function complete_release_subjects(state, prefix, policy)
   return filter(items, prefix)
 end
 
-local function completion_values(family_name, verb_name, flag_name, prefix)
-  local command = M.resolve(family_name, verb_name)
+---@param opts? forge.SurfaceOpts
+local function completion_values(family_name, verb_name, flag_name, prefix, opts)
+  local command = M.resolve(family_name, verb_name, opts)
   if not command then
     return nil
   end
@@ -1422,7 +1438,10 @@ function M.complete(arglead, cmdline, _)
   local words = split_words(cmdline)
   local arg_idx = arglead == '' and #words or #words - 1
   local family_name = words[2]
-  local family = family_index[family_name]
+  local surface_opts = {
+    forge_name = detected_forge_name(),
+  }
+  local family = M.family(family_name, surface_opts)
   local explicit_verb = family
       and words[3] ~= nil
       and (family.verbs[words[3]] ~= nil or (family.aliases and family.aliases[words[3]] ~= nil))
@@ -1431,7 +1450,8 @@ function M.complete(arglead, cmdline, _)
 
   local legacy_flag, legacy_prefix = arglead:match('^(%-%-[^=]+)=(.*)$')
   if legacy_flag then
-    local values = completion_values(family_name, explicit_verb, legacy_flag:sub(3), legacy_prefix)
+    local values =
+      completion_values(family_name, explicit_verb, legacy_flag:sub(3), legacy_prefix, surface_opts)
     if values then
       return vim.tbl_map(function(v)
         return legacy_flag .. '=' .. v
@@ -1440,7 +1460,7 @@ function M.complete(arglead, cmdline, _)
   end
   local flag, value_prefix = arglead:match('^([%w%-_]+)=(.*)$')
   if flag then
-    local values = completion_values(family_name, explicit_verb, flag, value_prefix)
+    local values = completion_values(family_name, explicit_verb, flag, value_prefix, surface_opts)
     if values then
       return vim.tbl_map(function(v)
         return flag .. '=' .. v
@@ -1448,18 +1468,24 @@ function M.complete(arglead, cmdline, _)
     end
   end
   if arg_idx == 1 then
-    return filter(M.family_names(), arglead)
+    return filter(
+      M.family_names({
+        include_aliases = true,
+        forge_name = surface_opts.forge_name,
+      }),
+      arglead
+    )
   end
   if not family then
     return {}
   end
   if arg_idx == 2 then
-    local command = M.resolve(family_name)
+    local command = M.resolve(family_name, nil, surface_opts)
     local state = command and completion_state(command, {}) or { modifiers = {}, subjects = {} }
     local slot_policy = require('forge.completion_policy').family_slot(command)
     local candidates = {}
     if slot_policy.include_verbs then
-      for _, verb in ipairs(M.verb_names(family_name)) do
+      for _, verb in ipairs(M.verb_names(family_name, surface_opts)) do
         candidates[#candidates + 1] = verb
       end
     end
@@ -1479,7 +1505,7 @@ function M.complete(arglead, cmdline, _)
     end
     return filter(candidates, arglead)
   end
-  local command = M.resolve(family_name, explicit_verb)
+  local command = M.resolve(family_name, explicit_verb, surface_opts)
   if not command then
     return {}
   end

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -69,6 +69,7 @@ end
 
 describe(':Forge command', function()
   local captured
+  local detected_forge_name
   local extra_review_adapters
   local old_preload
   local old_systemlist
@@ -77,6 +78,7 @@ describe(':Forge command', function()
 
   before_each(function()
     extra_review_adapters = {}
+    detected_forge_name = 'github'
     captured = {
       opens = {},
       ops_calls = {},
@@ -137,7 +139,7 @@ describe(':Forge command', function()
       return {
         detect = function()
           return {
-            name = 'github',
+            name = detected_forge_name,
             capabilities = {
               per_pr_checks = true,
               draft = true,
@@ -975,6 +977,42 @@ describe(':Forge command', function()
     }, captured.ops_calls[1])
   end)
 
+  it('keeps GitLab family aliases unavailable outside GitLab surfaces', function()
+    vim.cmd('Forge mr edit 42')
+    vim.cmd('Forge pipeline browse 123')
+
+    assert.same({
+      'unknown command: mr',
+      'unknown command: pipeline',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('dispatches GitLab family aliases through the canonical command families', function()
+    detected_forge_name = 'gitlab'
+
+    vim.cmd('Forge mr edit 42')
+    vim.cmd('Forge pipeline browse 123')
+
+    assert.same({
+      {
+        name = 'pr_edit',
+        pr = {
+          num = '42',
+          scope = nil,
+        },
+      },
+      {
+        name = 'ci_browse',
+        run = {
+          id = '123',
+          scope = nil,
+        },
+      },
+    }, captured.ops_calls)
+    assert.same({}, captured.warnings)
+  end)
+
   it('dispatches refresh verbs to forge.clear_list_kind per family', function()
     vim.cmd('Forge pr refresh')
     vim.cmd('Forge issue refresh')
@@ -1071,6 +1109,8 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(families, 'review'))
     assert.is_true(vim.tbl_contains(families, 'ci'))
     assert.is_true(vim.tbl_contains(families, 'browse'))
+    assert.is_false(vim.tbl_contains(families, 'mr'))
+    assert.is_false(vim.tbl_contains(families, 'pipeline'))
     assert.is_false(vim.tbl_contains(families, 'branches'))
     assert.is_false(vim.tbl_contains(families, 'commits'))
     assert.is_false(vim.tbl_contains(families, 'worktrees'))
@@ -1114,6 +1154,31 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(issue_create, 'blank'))
     assert.is_true(vim.tbl_contains(issue_create, 'web'))
     assert.is_false(vim.tbl_contains(issue_create, 'head='))
+  end)
+
+  it('completes GitLab family aliases contextually', function()
+    detected_forge_name = 'gitlab'
+
+    local families = completion('Forge ')
+    local mr = completion('Forge mr ')
+    local pipeline = completion('Forge pipeline ')
+
+    assert.is_true(vim.tbl_contains(families, 'pr'))
+    assert.is_true(vim.tbl_contains(families, 'ci'))
+    assert.is_true(vim.tbl_contains(families, 'mr'))
+    assert.is_true(vim.tbl_contains(families, 'pipeline'))
+    assert.same({
+      'close',
+      'reopen',
+      'create',
+      'edit',
+      'approve',
+      'merge',
+      'draft',
+      'ready',
+      'refresh',
+    }, mr)
+    assert.same({ 'open', 'browse', 'refresh' }, pipeline)
   end)
 
   it(


### PR DESCRIPTION
Closes #375.

This PR teaches the `:Forge` command surface to expose GitLab-only `mr` and `pipeline` family aliases while keeping canonical internals and config keys unchanged. The aliases are additive rather than replacing `pr` and `ci`, and command-line completion only suggests them when the detected forge is GitLab.

It wires the detected forge through command parsing and completion, adds focused command-spec coverage for both alias dispatch and contextual completion, and updates vimdoc to document the GitLab-specific Ex aliases.

Verified with `cd /tmp/forge.nvim/375 && nix develop --command just ci`.