### PR TITLE
feat(api): add GitLab route and open aliases for merge request and pipeline surfaces

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -158,6 +158,9 @@ Top-level keys: ~
   `table<string, string>`  (default shown below)
     Map root picker sections to route aliases. Section names are also valid
     arguments to `require('forge').open()`.
+    GitLab also accepts provider-native route values such as `mrs.open` and
+    `pipelines.current_branch`, while keeping config table keys canonical
+    (`routes.prs`, `routes.ci`).
 
   Defaults: >lua
       routes = {
@@ -872,6 +875,8 @@ MENTAL MODEL                                           *forge-extending-model*
 Routes are the highest-level and most stable surface. Verbs power `:Forge`
 and the built-in picker actions. `forge.picker.pick()` is the low-level UI
 primitive wired to `fzf-lua`.
+On GitLab, route arguments also accept provider-native aliases such as `mrs`,
+`mrs.open`, `pipelines`, and `pipelines.current_branch`.
 
 CALLING FORGE FROM YOUR OWN PICKER             *forge-extending-custom-picker*
 

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -224,6 +224,14 @@ local valid_routes = {}
 for _, name in ipairs(surface.route_names()) do
   valid_routes[name] = true
 end
+for _, name in
+  ipairs(surface.route_names({
+    include_aliases = true,
+    forge_name = 'gitlab',
+  }))
+do
+  valid_routes[name] = true
+end
 
 local function nonempty_string(v)
   return type(v) == 'string' and vim.trim(v) ~= ''

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -76,6 +76,19 @@ local function join_search_terms(parts)
   return table.concat(items, ' ')
 end
 
+---@return string?
+local function detected_forge_name()
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
+    return nil
+  end
+  local detected = forge.detect()
+  if type(detected) ~= 'table' or type(detected.name) ~= 'string' or detected.name == '' then
+    return nil
+  end
+  return detected.name
+end
+
 ---@param entry forge.PickerEntry
 ---@return string
 local function menu_search_key(entry)
@@ -89,7 +102,9 @@ local function menu_search_key(entry)
       return join_search_terms({ value.display, slug })
     end
   elseif type(value) == 'string' then
-    local resolved = surface.resolve_section(value) or surface.resolve_route(value)
+    local forge_name = detected_forge_name()
+    local resolved = surface.resolve_section(value, forge_name)
+      or surface.resolve_route(value, forge_name)
     local lookup = resolved and resolved.canonical or value
     local root_terms = root_search_terms[lookup]
     if root_terms then

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -17,6 +17,26 @@ local function prompt(ctx)
   return 'Forge> '
 end
 
+---@param ctx forge.Context?
+---@param opts? forge.RouteOpts
+---@return string?
+local function route_forge_name(ctx, opts)
+  if type(opts) == 'table' then
+    if type(opts.forge_name) == 'string' and opts.forge_name ~= '' then
+      return opts.forge_name
+    end
+    local scope = opts.scope
+    if type(scope) == 'table' and type(scope.kind) == 'string' and scope.kind ~= '' then
+      return scope.kind
+    end
+  end
+  local forge = type(ctx) == 'table' and ctx.forge or nil
+  if type(forge) == 'table' and type(forge.name) == 'string' and forge.name ~= '' then
+    return forge.name
+  end
+  return nil
+end
+
 ---@param ctx forge.Context
 ---@param opts forge.RouteOpts
 ---@return string?, string?
@@ -217,11 +237,12 @@ local function open_root(ctx, opts)
   local routes = rawget(cfg, 'routes') or {}
   local handlers = route_handlers()
   local entries = {}
+  local forge_name = route_forge_name(ctx, opts)
 
   for _, section in ipairs(section_order) do
     if sections[section] ~= false then
       local route = routes[section]
-      local resolved_route = route and M.resolve(route) or nil
+      local resolved_route = route and M.resolve(route, { forge_name = forge_name }) or nil
       if resolved_route and handlers[resolved_route] and section_available(section, ctx) then
         local label = section_label(section, ctx)
         entries[#entries + 1] = {
@@ -245,7 +266,7 @@ local function open_root(ctx, opts)
     name = 'default',
     context = ctx.id,
     back = function()
-      open_root(ctx)
+      open_root(ctx, opts)
     end,
   })
   if not default_action then
@@ -272,13 +293,14 @@ function M.open(name, opts)
     log.warn(err)
     return
   end
+  local forge_name = route_forge_name(ctx, opts)
 
   if not name or name == '' then
-    open_root(ctx, opts)
+    open_root(ctx, vim.tbl_extend('force', opts, { forge_name = forge_name }))
     return
   end
 
-  local route = M.resolve(name)
+  local route = M.resolve(name, { forge_name = forge_name })
   local handler = route_handlers()[route]
   if not handler then
     log.warn('unknown route: ' .. name)

--- a/spec/config_validation_spec.lua
+++ b/spec/config_validation_spec.lua
@@ -58,6 +58,20 @@ describe('config validation', function()
     )
   end)
 
+  it('accepts GitLab route aliases as route values', function()
+    vim.g.forge = {
+      routes = {
+        prs = 'mrs.closed',
+        ci = 'pipelines.current_branch',
+      },
+    }
+
+    local cfg = config.config()
+
+    assert.equals('mrs.closed', cfg.routes.prs)
+    assert.equals('pipelines.current_branch', cfg.routes.ci)
+  end)
+
   it('rejects malformed key notation strings', function()
     assert.matches(
       'forge%.keys%.pr%.edit',

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -211,6 +211,27 @@ describe('routes', function()
     assert.equals('closed', captured.pr)
   end)
 
+  it('resolves GitLab section and route aliases through canonical handlers', function()
+    detected_forge = fake_forge({
+      name = 'gitlab',
+      labels = {
+        pr_full = 'Merge Requests',
+        ci = 'Pipelines',
+      },
+    })
+    current_config.routes.prs = 'mrs.closed'
+    current_config.routes.ci = 'pipelines.current_branch'
+
+    require('forge.routes').open('mrs')
+    assert.equals('closed', captured.pr)
+
+    require('forge.routes').open('pipelines')
+    assert.equals('main', captured.ci)
+
+    require('forge.routes').open('pipelines.current_branch')
+    assert.equals('main', captured.ci)
+  end)
+
   it('passes scoped route options through picker handlers', function()
     local scope = {
       kind = 'github',
@@ -275,6 +296,38 @@ describe('routes', function()
         return entry.display[1][1]
       end, captured.root.entries)
     )
+  end)
+
+  it('accepts GitLab route aliases in root route defaults while keeping canonical keys', function()
+    detected_forge = fake_forge({
+      name = 'gitlab',
+      labels = {
+        pr_full = 'Merge Requests',
+        ci = 'Pipelines',
+      },
+    })
+    current_config.routes.prs = 'mrs.closed'
+    current_config.routes.ci = 'pipelines.current_branch'
+
+    require('forge.routes').open()
+
+    assert.is_not_nil(captured.root)
+    assert.equals('mrs.closed', captured.root.entries[1].value)
+    assert.equals('pipelines.current_branch', captured.root.entries[3].value)
+    assert.equals(
+      'Merge Requests prs pull requests reviews',
+      require('forge.picker').search_key('_menu', captured.root.entries[1])
+    )
+    assert.equals(
+      'Pipelines ci checks runs actions',
+      require('forge.picker').search_key('_menu', captured.root.entries[3])
+    )
+
+    captured.root.actions[1].fn(captured.root.entries[1])
+    assert.equals('closed', captured.pr)
+
+    captured.root.actions[1].fn(captured.root.entries[3])
+    assert.equals('main', captured.ci)
   end)
 
   it('uses repo browsing for contextual browse without a file buffer', function()


### PR DESCRIPTION
## Problem

The route and programmatic open surfaces only exposed canonical names like `prs.open`, `ci.current_branch`, and `require('forge').open('prs')`, which left the GitLab-native terminology work incomplete.

## Solution

Teach route resolution, root route defaults, and picker menu search keys to resolve GitLab-only aliases such as `mrs`, `mrs.closed`, `pipelines`, and `pipelines.current_branch` through the canonical handlers while keeping config keys canonical. Update config validation, route specs, and vimdoc so GitLab users can use provider-native route values and `require('forge').open(...)` arguments without changing the underlying schema.