### PR TITLE
chore: final post-stack cleanup for terminology, tests, and vimdoc

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -159,7 +159,9 @@ Top-level keys: ~
     Map root picker sections to route aliases. Section names are also valid
     arguments to `require('forge').open()`.
     GitLab also accepts provider-native route values such as `mrs.open` and
-    `pipelines.current_branch`, while keeping config table keys canonical
+    `pipelines.current_branch`. Interactive route calls like
+    `require('forge').open('mrs')` and `require('forge').open('pipelines')`
+    are equivalent shortcuts there, while config table keys stay canonical
     (`routes.prs`, `routes.ci`).
 
   Defaults: >lua
@@ -610,6 +612,9 @@ Codeberg show `PRs` and `CI/CD`, while GitLab shows `Merge Requests` and
 
 Use |forge-config-sections| to hide root entries and |forge-config-routes| to
 remap them.
+On GitLab, both canonical and provider-native route arguments work here, such
+as `require('forge').open('prs')` or `require('forge').open('mrs')`; route
+config keys still remain `routes.prs` and `routes.ci`.
 
 This interactive surface requires `fzf-lua`. Direct `:Forge` commands do not.
 

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local detect = require('forge.detect')
 local ops = require('forge.ops')
 local surface = require('forge.surface')
 
@@ -903,19 +904,6 @@ function M.dispatch(command)
   return true
 end
 
----@return string?
-local function detected_forge_name()
-  local ok, forge = pcall(require, 'forge')
-  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
-    return nil
-  end
-  local detected = forge.detect()
-  if type(detected) ~= 'table' or type(detected.name) ~= 'string' or detected.name == '' then
-    return nil
-  end
-  return detected.name
-end
-
 function M.run(opts)
   opts = opts or {}
   if vim.trim(opts.args or '') == '' then
@@ -924,7 +912,7 @@ function M.run(opts)
   end
 
   local command, err = M.parse(split_words(opts.args), {
-    forge_name = detected_forge_name(),
+    forge_name = detect.forge_name(),
   })
   if not command then
     if err and err.message then
@@ -1439,7 +1427,7 @@ function M.complete(arglead, cmdline, _)
   local arg_idx = arglead == '' and #words or #words - 1
   local family_name = words[2]
   local surface_opts = {
-    forge_name = detected_forge_name(),
+    forge_name = detect.forge_name(),
   }
   local family = M.family(family_name, surface_opts)
   local explicit_verb = family

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -221,13 +221,10 @@ local hl_defaults = {
 ---@type table<string, boolean>
 local valid_routes = {}
 
-for _, name in ipairs(surface.route_names()) do
-  valid_routes[name] = true
-end
 for _, name in
   ipairs(surface.route_names({
     include_aliases = true,
-    forge_name = 'gitlab',
+    include_all_aliases = true,
   }))
 do
   valid_routes[name] = true

--- a/lua/forge/detect.lua
+++ b/lua/forge/detect.lua
@@ -1,0 +1,15 @@
+local M = {}
+
+function M.forge_name()
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
+    return nil
+  end
+  local detected = forge.detect()
+  if type(detected) ~= 'table' or type(detected.name) ~= 'string' or detected.name == '' then
+    return nil
+  end
+  return detected.name
+end
+
+return M

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local ci = require('forge.ci')
+local detect = require('forge.detect')
 local surface = require('forge.surface')
 
 ---@alias forge.Segment {[1]: string, [2]: string?}
@@ -76,19 +77,6 @@ local function join_search_terms(parts)
   return table.concat(items, ' ')
 end
 
----@return string?
-local function detected_forge_name()
-  local ok, forge = pcall(require, 'forge')
-  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
-    return nil
-  end
-  local detected = forge.detect()
-  if type(detected) ~= 'table' or type(detected.name) ~= 'string' or detected.name == '' then
-    return nil
-  end
-  return detected.name
-end
-
 ---@param entry forge.PickerEntry
 ---@return string
 local function menu_search_key(entry)
@@ -102,7 +90,7 @@ local function menu_search_key(entry)
       return join_search_terms({ value.display, slug })
     end
   elseif type(value) == 'string' then
-    local forge_name = detected_forge_name()
+    local forge_name = detect.forge_name()
     local resolved = surface.resolve_section(value, forge_name)
       or surface.resolve_route(value, forge_name)
     local lookup = resolved and resolved.canonical or value

--- a/lua/forge/surface.lua
+++ b/lua/forge/surface.lua
@@ -70,7 +70,10 @@ end
 ---@return string[]
 local function aliases_for(registry, name, forge_name)
   local entry = registry[name]
-  if type(entry) ~= 'table' or forge_name == nil or forge_name == '' then
+  if type(entry) ~= 'table' then
+    return {}
+  end
+  if forge_name == nil or forge_name == '' then
     return {}
   end
   local aliases = entry[forge_name]
@@ -78,6 +81,29 @@ local function aliases_for(registry, name, forge_name)
     return {}
   end
   return vim.deepcopy(aliases)
+end
+
+local function all_aliases_for(registry, name)
+  local entry = registry[name]
+  if type(entry) ~= 'table' then
+    return {}
+  end
+  local aliases = {}
+  local seen = {}
+  local forge_names = vim.tbl_keys(entry)
+  table.sort(forge_names)
+  for _, forge_name in ipairs(forge_names) do
+    local items = entry[forge_name]
+    if type(items) == 'table' then
+      for _, alias in ipairs(items) do
+        if seen[alias] ~= true then
+          seen[alias] = true
+          aliases[#aliases + 1] = alias
+        end
+      end
+    end
+  end
+  return aliases
 end
 
 ---@param registry forge.SurfaceAliasRegistry
@@ -119,7 +145,9 @@ local function ordered_names(order, registry, opts)
   for _, name in ipairs(order) do
     names[#names + 1] = name
     if opts.include_aliases then
-      for _, alias in ipairs(aliases_for(registry, name, opts.forge_name)) do
+      local aliases = opts.include_all_aliases and all_aliases_for(registry, name)
+        or aliases_for(registry, name, opts.forge_name)
+      for _, alias in ipairs(aliases) do
         names[#names + 1] = alias
       end
     end
@@ -137,13 +165,15 @@ end
 ---@param name forge.RouteName
 ---@param forge_name string?
 ---@return string[]
-local function derived_route_aliases(name, forge_name)
+local function derived_route_aliases(name, forge_name, include_all_aliases)
   local section, suffix = route_parts(name)
   if section == nil or suffix == nil then
     return {}
   end
   local aliases = {}
-  for _, alias in ipairs(aliases_for(section_aliases, section, forge_name)) do
+  local section_names = include_all_aliases and all_aliases_for(section_aliases, section)
+    or aliases_for(section_aliases, section, forge_name)
+  for _, alias in ipairs(section_names) do
     aliases[#aliases + 1] = alias .. '.' .. suffix
   end
   return aliases
@@ -198,7 +228,7 @@ function M.route_names(opts)
   for _, name in ipairs(route_order) do
     names[#names + 1] = name
     if opts.include_aliases then
-      for _, alias in ipairs(derived_route_aliases(name, opts.forge_name)) do
+      for _, alias in ipairs(derived_route_aliases(name, opts.forge_name, opts.include_all_aliases)) do
         names[#names + 1] = alias
       end
     end

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -62,6 +62,7 @@
 
 ---@class forge.SurfaceNamesOpts: forge.SurfaceOpts
 ---@field include_aliases boolean?
+---@field include_all_aliases boolean?
 
 ---@class forge.SurfaceResolvedName
 ---@field canonical string

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -38,6 +38,16 @@ local function fake_forge(opts)
   }
 end
 
+local function fake_gitlab_forge()
+  return fake_forge({
+    name = 'gitlab',
+    labels = {
+      pr_full = 'Merge Requests',
+      ci = 'Pipelines',
+    },
+  })
+end
+
 local function use_named_current_buf(name)
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_valid(buf) and vim.api.nvim_buf_get_name(buf) == name then
@@ -212,13 +222,7 @@ describe('routes', function()
   end)
 
   it('resolves GitLab section and route aliases through canonical handlers', function()
-    detected_forge = fake_forge({
-      name = 'gitlab',
-      labels = {
-        pr_full = 'Merge Requests',
-        ci = 'Pipelines',
-      },
-    })
+    detected_forge = fake_gitlab_forge()
     current_config.routes.prs = 'mrs.closed'
     current_config.routes.ci = 'pipelines.current_branch'
 
@@ -279,13 +283,7 @@ describe('routes', function()
   end)
 
   it('uses GitLab merge request and pipeline labels in the root picker', function()
-    detected_forge = fake_forge({
-      name = 'gitlab',
-      labels = {
-        pr_full = 'Merge Requests',
-        ci = 'Pipelines',
-      },
-    })
+    detected_forge = fake_gitlab_forge()
 
     require('forge.routes').open()
 
@@ -299,13 +297,7 @@ describe('routes', function()
   end)
 
   it('accepts GitLab route aliases in root route defaults while keeping canonical keys', function()
-    detected_forge = fake_forge({
-      name = 'gitlab',
-      labels = {
-        pr_full = 'Merge Requests',
-        ci = 'Pipelines',
-      },
-    })
+    detected_forge = fake_gitlab_forge()
     current_config.routes.prs = 'mrs.closed'
     current_config.routes.ci = 'pipelines.current_branch'
 

--- a/spec/surface_spec.lua
+++ b/spec/surface_spec.lua
@@ -34,7 +34,28 @@ describe('surface', function()
         forge_name = 'gitlab',
       })
     )
+    assert.same(
+      { 'prs', 'mrs', 'issues', 'ci', 'pipelines', 'browse', 'releases' },
+      surface.section_names({
+        include_aliases = true,
+        include_all_aliases = true,
+      })
+    )
     assert.same({ 'mrs.open' }, surface.route_aliases('prs.open', 'gitlab'))
+    assert.is_true(vim.tbl_contains(
+      surface.route_names({
+        include_aliases = true,
+        include_all_aliases = true,
+      }),
+      'mrs.open'
+    ))
+    assert.is_true(vim.tbl_contains(
+      surface.route_names({
+        include_aliases = true,
+        include_all_aliases = true,
+      }),
+      'pipelines.current_branch'
+    ))
     assert.same(
       { canonical = 'prs', invoked = 'mrs', alias = 'mrs' },
       surface.resolve_section('mrs', 'gitlab')


### PR DESCRIPTION
## Problem

The GitLab terminology and alias work landed in focused slices, which kept the behavior changes reviewable but left a small amount of cleanup behind in the merged state: duplicated forge-name detection, alias validation that still special-cased GitLab, repeated GitLab route test setup, and docs that described the pieces without consolidating the final `open(...)` story in one place.

## Solution

Do the final cleanup pass from #377 on top of latest main. This consolidates forge-name detection into a shared helper, lets route validation accept provider aliases through the surface layer instead of a GitLab-specific hardcode, trims repeated GitLab route fixtures in the tests, adds coverage for alias aggregation, and tightens the vimdoc wording so GitLab-native `mrs` / `pipelines` route and `open(...)` aliases are documented together while keeping canonical config keys unchanged.