### PR TITLE
feat: resolve current PRs from head context

### DIFF
--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -186,7 +186,7 @@ function M:pr_for_branch_cmd(branch, ref)
   return {
     'sh',
     '-c',
-    ('tea pr list --state open --output json --fields index,head --repo %s | jq -r \'[.[] | select(.head=="%s" or .head.name=="%s")][0].index // empty\''):format(
+    ('tea pr list --state open --output json --fields index,head --repo %s | jq -r \'.[] | select(.head=="%s" or .head.name=="%s") | .index // empty\''):format(
       repo_arg(ref),
       branch,
       branch

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -255,7 +255,7 @@ function M:pr_for_branch_cmd(branch, scope)
     '--json',
     'number',
     '--jq',
-    '.[0].number',
+    '.[].number',
   }
   local repo = nwo(scope)
   if repo ~= '' then
@@ -536,7 +536,7 @@ function M:fetch_pr_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,isDraft,headRefName,baseRefName,labels,assignees,reviewRequests,milestone,url',
+    'title,body,isDraft,headRefName,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,milestone,url',
   }
 end
 

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -206,7 +206,7 @@ function M:pr_for_branch_cmd(branch, ref)
   return {
     'sh',
     '-c',
-    ("glab mr list --source-branch '%s' -F json -R '%s' | jq -r '.[0].iid // empty'"):format(
+    ("glab mr list --source-branch '%s' -F json -R '%s' | jq -r '.[].iid // empty'"):format(
       branch,
       repo_arg(ref)
     ),

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -6,6 +6,7 @@ local compose_mod = require('forge.compose')
 local config_mod = require('forge.config')
 local context_mod = require('forge.context')
 local format_mod = require('forge.format')
+local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
 local scope_mod = require('forge.scope')
 local template_mod = require('forge.template')
@@ -525,86 +526,90 @@ function M.create_pr(opts)
   end
 
   log.info('checking for existing ' .. f.labels.pr_one .. '...')
+  local existing, err = resolve_mod.current_pr({
+    forge = f,
+    scope = base_scope,
+    head_branch = branch,
+    head_scope = head_scope,
+  })
+  if err then
+    log.error(err.message)
+    return
+  end
+  if existing then
+    log.info(
+      ('%s already exists for this branch; opening edit buffer for #%s'):format(
+        f.labels.pr_one,
+        existing.num
+      )
+    )
+    M.edit_pr(existing.num, existing.scope or base_scope)
+    return
+  end
 
-  vim.system(f:pr_for_branch_cmd(branch, base_scope), { text = true }, function(result)
-    local num = vim.trim(result.stdout or '')
-    vim.schedule(function()
-      if num ~= '' and num ~= 'null' then
-        log.info(
-          ('%s already exists for this branch; opening edit buffer for #%s'):format(
-            f.labels.pr_one,
-            num
-          )
-        )
-        M.edit_pr(num, base_scope)
-        return
-      end
-
-      if opts.web then
-        with_base(function(base)
-          ensure_creatable(base, function()
-            log.info('pushing...')
-            vim.system(
-              { 'git', 'push', '-u', push_to ~= '' and push_to or 'origin', branch },
-              { text = true },
-              function(push_result)
-                vim.schedule(function()
-                  if push_result.code ~= 0 then
-                    log.error('push failed')
-                    return
-                  end
-                  local web_cmd = f.create_pr_web_cmd
-                      and f:create_pr_web_cmd(base_scope, head_scope, branch, base)
-                    or nil
-                  local web_url = f.create_pr_web_url
-                      and f:create_pr_web_url(base_scope, head_scope, branch, base)
-                    or nil
-                  open_web_create(f.labels.pr_one, web_cmd, web_url)
-                end)
+  if opts.web then
+    with_base(function(base)
+      ensure_creatable(base, function()
+        log.info('pushing...')
+        vim.system(
+          { 'git', 'push', '-u', push_to ~= '' and push_to or 'origin', branch },
+          { text = true },
+          function(push_result)
+            vim.schedule(function()
+              if push_result.code ~= 0 then
+                log.error('push failed')
+                return
               end
-            )
-          end)
-        end)
-        return
-      end
-
-      with_base(function(base)
-        ensure_creatable(base, function(_, target_ref)
-          if opts.instant then
-            local title, body = template_mod.fill_from_commits(branch, target_ref, head_ref)
-            compose_mod.push_and_create(
-              f,
-              branch,
-              title,
-              body,
-              base,
-              opts.draft or false,
-              nil,
-              base_scope,
-              push_to
-            )
-          else
-            local root = git_root() or ''
-            local draft = opts.draft or false
-            local tmpl, templates, err = template_mod.discover(f:template_paths(), root)
-            if err then
-              log.error(err)
-              return
-            end
-            compose_mod.open_pr(
-              f,
-              branch,
-              base,
-              draft,
-              templates and nil or tmpl,
-              base_scope,
-              push_to,
-              target_ref,
-              head_ref
-            )
+              local web_cmd = f.create_pr_web_cmd
+                  and f:create_pr_web_cmd(base_scope, head_scope, branch, base)
+                or nil
+              local web_url = f.create_pr_web_url
+                  and f:create_pr_web_url(base_scope, head_scope, branch, base)
+                or nil
+              open_web_create(f.labels.pr_one, web_cmd, web_url)
+            end)
           end
-        end)
+        )
       end)
+    end)
+    return
+  end
+
+  with_base(function(base)
+    ensure_creatable(base, function(_, target_ref)
+      if opts.instant then
+        local title, body = template_mod.fill_from_commits(branch, target_ref, head_ref)
+        compose_mod.push_and_create(
+          f,
+          branch,
+          title,
+          body,
+          base,
+          opts.draft or false,
+          nil,
+          base_scope,
+          push_to
+        )
+      else
+        local root = git_root() or ''
+        local draft = opts.draft or false
+        local tmpl, templates, discover_err = template_mod.discover(f:template_paths(), root)
+        if discover_err then
+          log.error(discover_err)
+          return
+        end
+        compose_mod.open_pr(
+          f,
+          branch,
+          base,
+          draft,
+          templates and nil or tmpl,
+          base_scope,
+          push_to,
+          target_ref,
+          head_ref
+        )
+      end
     end)
   end)
 end
@@ -763,6 +768,7 @@ end
 M._discover_templates = template_mod.discover
 M._load_template = template_mod.load
 M._normalize_body = template_mod.normalize_body
+M.current_pr = resolve_mod.current_pr
 
 local routes_mod = require('forge.routes')
 M.current_context = routes_mod.current_context

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -1,0 +1,470 @@
+local M = {}
+
+local scope_mod = require('forge.scope')
+local target_mod = require('forge.target')
+
+local gitlab_project_ids = {}
+
+local function trim(text)
+  if type(text) ~= 'string' then
+    return nil
+  end
+  local value = vim.trim(text)
+  if value == '' then
+    return nil
+  end
+  return value
+end
+
+local function error_result(message, code)
+  return nil, {
+    code = code,
+    message = message,
+  }
+end
+
+local function cmd_error(result, fallback)
+  local msg = trim(result.stderr)
+  if not msg then
+    msg = trim(result.stdout)
+  end
+  return msg or fallback
+end
+
+local function repo_target(value)
+  if type(value) ~= 'table' then
+    return nil
+  end
+  if value.kind == 'repo' then
+    return value
+  end
+  if value.kind == 'rev' then
+    return value.repo
+  end
+  if value.kind == 'location' and type(value.rev) == 'table' then
+    return value.rev.repo
+  end
+  return value.repo
+end
+
+local function current_forge(opts)
+  if type(opts) == 'table' and type(opts.forge) == 'table' then
+    return opts.forge
+  end
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
+    return nil
+  end
+  return forge.detect()
+end
+
+local function forge_name(opts)
+  if type(opts) == 'table' then
+    if type(opts.forge_name) == 'string' and opts.forge_name ~= '' then
+      return opts.forge_name
+    end
+    if
+      type(opts.forge) == 'table'
+      and type(opts.forge.name) == 'string'
+      and opts.forge.name ~= ''
+    then
+      return opts.forge.name
+    end
+    for _, value in ipairs({
+      opts.head_scope,
+      opts.base_scope,
+      opts.scope,
+      type(opts.repo) == 'table' and opts.repo or nil,
+    }) do
+      if
+        type(value) == 'table'
+        and value.kind ~= 'repo'
+        and type(value.kind) == 'string'
+        and value.kind ~= ''
+      then
+        return value.kind
+      end
+    end
+    local head = type(opts.head) == 'table' and (opts.head.scope or opts.head.head_scope) or nil
+    if type(head) == 'table' and type(head.kind) == 'string' and head.kind ~= '' then
+      return head.kind
+    end
+  end
+  local f = current_forge(opts)
+  return f and f.name or nil
+end
+
+local function target_parse_opts(opts)
+  local explicit = type(opts) == 'table' and opts.target_opts or nil
+  if type(explicit) == 'table' then
+    local parsed = vim.deepcopy(explicit)
+    parsed.resolve_repo = true
+    return parsed
+  end
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
+    return {
+      resolve_repo = true,
+    }
+  end
+  local cfg = forge.config()
+  local targets = type(cfg) == 'table' and cfg.targets or nil
+  local aliases = type(targets) == 'table' and targets.aliases or nil
+  local default_repo = type(targets) == 'table' and targets.default_repo or nil
+  return {
+    resolve_repo = true,
+    aliases = type(aliases) == 'table' and aliases or {},
+    default_repo = type(default_repo) == 'string' and default_repo or nil,
+  }
+end
+
+local function resolve_scope(value, kind, parse_opts)
+  if
+    type(value) == 'table'
+    and value.kind ~= 'repo'
+    and type(value.host) == 'string'
+    and type(value.slug) == 'string'
+  then
+    return value
+  end
+  if type(value) == 'table' and value.kind == 'repo' then
+    return target_mod.repo_scope(value, kind)
+  end
+  if type(value) == 'string' then
+    local repo, err = target_mod.resolve_repo(value, parse_opts)
+    if not repo then
+      return nil, err
+    end
+    return target_mod.repo_scope(repo, kind)
+  end
+  return nil
+end
+
+local function add_scope(scopes, seen, value)
+  local key = scope_mod.key(value)
+  if key == '' or seen[key] then
+    return
+  end
+  seen[key] = true
+  scopes[#scopes + 1] = value
+end
+
+local function github_head(json, base_scope)
+  local branch = trim(json.headRefName)
+  local owner = type(json.headRepositoryOwner) == 'table'
+      and trim(json.headRepositoryOwner.login or json.headRepositoryOwner.name)
+    or nil
+  local repo = type(json.headRepository) == 'table' and trim(json.headRepository.name) or nil
+  local full_name = type(json.headRepository) == 'table' and trim(json.headRepository.nameWithOwner)
+    or nil
+  if not owner and full_name then
+    owner = full_name:match('^([^/]+)/')
+  end
+  if not repo and full_name then
+    repo = full_name:match('/([^/]+)$')
+  end
+  local scope = nil
+  if owner and repo then
+    local host = type(base_scope) == 'table' and base_scope.host or 'github.com'
+    scope = scope_mod.from_url('github', ('https://%s/%s/%s'):format(host, owner, repo))
+  end
+  return {
+    branch = branch,
+    scope = scope,
+  }
+end
+
+local function gitlab_head(json)
+  return {
+    branch = trim(json.source_branch),
+    project_id = json.source_project_id ~= nil and tostring(json.source_project_id) or nil,
+  }
+end
+
+local function codeberg_head(json, base_scope)
+  local head = type(json.head) == 'table' and json.head or nil
+  local branch = trim(head and (head.ref or head.name) or json.head)
+  local repo = head and type(head.repo) == 'table' and head.repo or nil
+  local full_name = trim(repo and (repo.full_name or repo.fullName))
+  local scope = nil
+  if full_name then
+    local host = type(base_scope) == 'table' and base_scope.host or 'codeberg.org'
+    scope = scope_mod.from_url('codeberg', ('https://%s/%s'):format(host, full_name))
+  end
+  return {
+    branch = branch,
+    scope = scope,
+  }
+end
+
+local function pr_head(forge, json, base_scope)
+  if forge.name == 'github' then
+    return github_head(json, base_scope)
+  end
+  if forge.name == 'gitlab' then
+    return gitlab_head(json)
+  end
+  if forge.name == 'codeberg' then
+    return codeberg_head(json, base_scope)
+  end
+  return {
+    branch = trim(json.headRefName or json.source_branch),
+    scope = nil,
+  }
+end
+
+local function gitlab_project_id(scope)
+  local key = scope_mod.key(scope)
+  if key == '' then
+    return nil
+  end
+  if gitlab_project_ids[key] ~= nil then
+    return gitlab_project_ids[key] or nil
+  end
+  local project = scope_mod.encode_project(scope)
+  if not project then
+    gitlab_project_ids[key] = false
+    return nil
+  end
+  local result = vim
+    .system(
+      { 'glab', 'api', '--hostname', scope.host or 'gitlab.com', ('projects/%s'):format(project) },
+      { text = true }
+    )
+    :wait()
+  if result.code ~= 0 then
+    return nil,
+      cmd_error(result, ('failed to resolve GitLab project for %s'):format(scope.slug or 'scope'))
+  end
+  local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+  if not ok or type(json) ~= 'table' or json.id == nil then
+    return nil, ('failed to parse GitLab project for %s'):format(scope.slug or 'scope')
+  end
+  local id = tostring(json.id)
+  gitlab_project_ids[key] = id
+  return id
+end
+
+local function head_matches(forge, expected, actual)
+  if trim(actual.branch) ~= expected.branch then
+    return false
+  end
+  if forge.name == 'gitlab' then
+    local expected_id = expected.project_id
+    local err
+    if not expected_id and expected.scope then
+      expected_id, err = gitlab_project_id(expected.scope)
+      if err then
+        return nil, err
+      end
+    end
+    local actual_id = trim(actual.project_id)
+    return expected_id ~= nil and actual_id ~= nil and expected_id == actual_id
+  end
+  return scope_mod.same(expected.scope, actual.scope)
+end
+
+local function fetch_pr_json(forge, num, scope)
+  local result = vim.system(forge:fetch_pr_details_cmd(num, scope), { text = true }):wait()
+  if result.code ~= 0 then
+    return nil,
+      cmd_error(result, ('failed to fetch %s #%s'):format(forge.labels.pr_one or 'PR', num))
+  end
+  local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+  if not ok or type(json) ~= 'table' then
+    return nil, ('failed to parse %s #%s details'):format(forge.labels.pr_one or 'PR', num)
+  end
+  return json
+end
+
+local function list_pr_numbers(forge, branch, scope)
+  local result = vim.system(forge:pr_for_branch_cmd(branch, scope), { text = true }):wait()
+  if result.code ~= 0 then
+    return nil,
+      cmd_error(result, ('failed to list %s for %s'):format(forge.labels.pr_full or 'PRs', branch))
+  end
+  local nums = {}
+  local seen = {}
+  for _, line in ipairs(vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })) do
+    local num = trim(line)
+    if num and num ~= 'null' and not seen[num] then
+      seen[num] = true
+      nums[#nums + 1] = num
+    end
+  end
+  return nums
+end
+
+local function head_label(head)
+  local slug = type(head.scope) == 'table' and head.scope.slug or nil
+  if slug and slug ~= '' then
+    return ('%s@%s'):format(slug, head.branch)
+  end
+  return head.branch
+end
+
+function M.repo(repo, opts)
+  opts = opts or {}
+  local kind = forge_name(opts)
+  if not kind then
+    return error_result('no forge detected', 'no_forge')
+  end
+  local value = repo
+  if value == nil then
+    value = opts.repo or opts.base_scope or opts.scope
+  end
+  if value == nil then
+    return nil
+  end
+  local scope, err = resolve_scope(value, kind, target_parse_opts(opts))
+  if not scope then
+    return error_result(err or 'invalid repo address', 'invalid_repo')
+  end
+  return scope
+end
+
+function M.head(head, opts)
+  opts = opts or {}
+  local kind = forge_name(opts)
+  if not kind then
+    return error_result('no forge detected', 'no_forge')
+  end
+  local parse_opts = target_parse_opts(opts)
+  local value = head
+  if value == nil then
+    value = opts.head
+  end
+  local branch = trim(opts.head_branch)
+  local scope, err = resolve_scope(opts.head_scope, kind, parse_opts)
+  if err then
+    return error_result(err, 'invalid_head')
+  end
+  local project_id = trim(opts.project_id)
+  if type(value) == 'string' then
+    local rev
+    rev, err = target_mod.parse_rev(value, parse_opts)
+    if not rev then
+      return error_result(err, 'invalid_head')
+    end
+    branch = branch or trim(rev.rev)
+    if not scope then
+      scope, err = resolve_scope(repo_target(rev), kind, parse_opts)
+      if err then
+        return error_result(err, 'invalid_head')
+      end
+    end
+  elseif type(value) == 'table' then
+    if value.kind == 'rev' then
+      branch = branch or trim(value.rev)
+      if not scope then
+        scope, err = resolve_scope(repo_target(value), kind, parse_opts)
+        if err then
+          return error_result(err, 'invalid_head')
+        end
+      end
+    else
+      branch = branch or trim(value.branch or value.head_branch or value.rev)
+      project_id = project_id or trim(value.project_id)
+      if not scope then
+        scope, err = resolve_scope(value.scope or value.head_scope or value.repo, kind, parse_opts)
+        if err then
+          return error_result(err, 'invalid_head')
+        end
+      end
+    end
+  end
+  if not branch then
+    local current = target_mod.push_rev(parse_opts)
+    branch = current and trim(current.rev) or nil
+    if not branch then
+      return error_result('detached HEAD', 'detached_head')
+    end
+    if not scope then
+      scope = target_mod.repo_scope(repo_target(current), kind)
+    end
+  end
+  if not scope then
+    scope = target_mod.repo_scope(target_mod.push_repo(parse_opts), kind)
+  end
+  return {
+    branch = branch,
+    scope = scope,
+    project_id = project_id,
+  }
+end
+
+function M.current_pr(opts)
+  opts = opts or {}
+  local forge = current_forge(opts)
+  if not forge then
+    return error_result('no forge detected', 'no_forge')
+  end
+  local kind = forge.name or forge_name(opts)
+  if not kind then
+    return error_result('no forge detected', 'no_forge')
+  end
+  local parse_opts = target_parse_opts(opts)
+  local repo = opts.repo or opts.base_scope or opts.scope
+  local repos = nil
+  if repo ~= nil then
+    local resolved, err = resolve_scope(repo, kind, parse_opts)
+    if not resolved then
+      return error_result(err or 'invalid repo address', 'invalid_repo')
+    end
+    repos = { resolved }
+  else
+    local seen = {}
+    repos = {}
+    add_scope(repos, seen, target_mod.repo_scope(target_mod.push_repo(parse_opts), kind))
+    add_scope(repos, seen, target_mod.repo_scope(target_mod.collaboration_repo(parse_opts), kind))
+  end
+  local head, err = M.head(
+    opts.head,
+    vim.tbl_extend('force', opts, {
+      forge = forge,
+      forge_name = kind,
+      target_opts = parse_opts,
+    })
+  )
+  if not head then
+    return nil, err
+  end
+  for _, scope in ipairs(repos) do
+    local nums, list_err = list_pr_numbers(forge, head.branch, scope)
+    if not nums then
+      return error_result(list_err, 'lookup_failed')
+    end
+    local matches = {}
+    for _, num in ipairs(nums) do
+      local json, fetch_err = fetch_pr_json(forge, num, scope)
+      if not json then
+        return error_result(fetch_err, 'lookup_failed')
+      end
+      local exact, match_err = head_matches(forge, head, pr_head(forge, json, scope))
+      if match_err then
+        return error_result(match_err, 'lookup_failed')
+      end
+      if exact then
+        matches[#matches + 1] = {
+          num = num,
+          scope = scope,
+        }
+      end
+    end
+    if #matches == 1 then
+      return matches[1]
+    end
+    if #matches > 1 then
+      return error_result(
+        ('multiple %s match head %s; pass repo= or head='):format(
+          forge.labels.pr_full or 'PRs',
+          head_label(head)
+        ),
+        'ambiguous_pr'
+      )
+    end
+  end
+  return nil
+end
+
+return M

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -35,6 +35,11 @@
 ---@field num string
 ---@field scope forge.Scope?
 
+---@class forge.HeadRef
+---@field branch string
+---@field scope forge.Scope?
+---@field project_id string?
+
 ---@class forge.IssueRef
 ---@field num string
 ---@field scope forge.Scope?
@@ -201,6 +206,17 @@
 ---@field head_scope forge.Scope?
 ---@field base_branch string?
 ---@field base_scope forge.Scope?
+
+---@class forge.CurrentPROpts: forge.ScopedOpts
+---@field forge forge.Forge?
+---@field forge_name string?
+---@field repo any
+---@field head any
+---@field head_branch string?
+---@field head_scope forge.Scope?
+---@field base_scope forge.Scope?
+---@field project_id string?
+---@field target_opts table?
 
 ---@class forge.CreateIssueOpts
 ---@field web boolean?

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -99,6 +99,13 @@ describe('create_pr', function()
           body = 'Body',
           isDraft = false,
           headRefName = 'feature',
+          headRepository = {
+            name = 'repo',
+            nameWithOwner = 'owner/repo',
+          },
+          headRepositoryOwner = {
+            login = 'owner',
+          },
           baseRefName = 'main',
         })
       elseif key == 'git rev-parse --abbrev-ref feature@{upstream}' then
@@ -311,12 +318,26 @@ describe('create_pr', function()
 
   it('logs an explicit notice and opens edit when the branch already has a PR', function()
     use_system_responses({
+      ['git config branch.feature.pushRemote'] = helpers.command_result('', 1),
+      ['git config remote.pushDefault'] = helpers.command_result('', 1),
+      ['git rev-parse --abbrev-ref feature@{upstream}'] = helpers.command_result(
+        'origin/feature\n'
+      ),
+      ['git remote'] = helpers.command_result('origin\n'),
+      ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/repo.git\n'),
       ['pr-for-branch feature'] = helpers.command_result('23\n'),
       ['fetch-pr 23'] = helpers.command_result(vim.json.encode({
         title = 'Existing PR',
         body = 'Body',
         isDraft = false,
         headRefName = 'feature',
+        headRepository = {
+          name = 'repo',
+          nameWithOwner = 'owner/repo',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
         baseRefName = 'main',
       })),
     })
@@ -488,6 +509,7 @@ describe('create_pr', function()
   it('reports browser open failures for URL-based web PR flows', function()
     package.preload['forge.backends.github'] = function()
       return {
+        name = 'github',
         cli = 'gh',
         labels = { pr_one = 'PR' },
         pr_for_branch_cmd = function(_, branch)

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -1,0 +1,226 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+local preload_modules = {
+  'forge',
+}
+
+local loaded_modules = {
+  'forge',
+  'forge.resolve',
+  'forge.scope',
+  'forge.target',
+}
+
+local function repo_scope(repo)
+  return {
+    kind = 'github',
+    host = 'github.com',
+    owner = 'owner',
+    repo = repo,
+    slug = 'owner/' .. repo,
+    repo_arg = 'owner/' .. repo,
+    web_url = 'https://github.com/owner/' .. repo,
+  }
+end
+
+describe('current_pr resolver', function()
+  local captured
+  local old_system
+  local old_preload
+
+  local github = {
+    name = 'github',
+    labels = {
+      pr_one = 'PR',
+      pr_full = 'PRs',
+    },
+    pr_for_branch_cmd = function(_, branch, scope)
+      return { 'pr-for-branch', branch, scope and scope.slug or '' }
+    end,
+    fetch_pr_details_cmd = function(_, num, scope)
+      return { 'fetch-pr', num, scope and scope.slug or '' }
+    end,
+  }
+
+  before_each(function()
+    captured = {
+      systems = {},
+    }
+    old_system = vim.system
+    old_preload = helpers.capture_preload(preload_modules)
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            targets = {},
+          }
+        end,
+      }
+    end
+
+    helpers.clear_loaded(loaded_modules)
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    helpers.restore_preload(old_preload)
+    helpers.clear_loaded(loaded_modules)
+  end)
+
+  local function use_system_responses(responses)
+    vim.system = helpers.system_router({
+      calls = captured.systems,
+      responses = responses,
+      default = helpers.command_result('', 1),
+    })
+  end
+
+  it('resolves explicit repo and head addresses into the matching PR', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('17\n'),
+      ['fetch-pr 17 owner/upstream'] = helpers.command_result(vim.json.encode({
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '17',
+      scope = repo_scope('upstream'),
+    }, pr)
+  end)
+
+  it('returns nil cleanly when no PR matches the requested head', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('\n'),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(pr)
+    assert.is_nil(err)
+  end)
+
+  it('reports detached HEAD when current head resolution has no branch', function()
+    use_system_responses({
+      ['git branch --show-current'] = helpers.command_result('', 1),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+    })
+
+    assert.is_nil(pr)
+    assert.same({
+      code = 'detached_head',
+      message = 'detached HEAD',
+    }, err)
+  end)
+
+  it('falls back from the push repo to the collaboration repo when needed', function()
+    use_system_responses({
+      ['git branch --show-current'] = helpers.command_result('feature\n'),
+      ['git config branch.feature.pushRemote'] = helpers.command_result('fork\n'),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['pr-for-branch feature owner/fork'] = helpers.command_result('\n'),
+      ['pr-for-branch feature owner/upstream'] = helpers.command_result('42\n'),
+      ['fetch-pr 42 owner/upstream'] = helpers.command_result(vim.json.encode({
+        headRefName = 'feature',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '42',
+      scope = repo_scope('upstream'),
+    }, pr)
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch feature owner/fork'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch feature owner/upstream'))
+    assert.is_true(
+      vim.fn.index(captured.systems, 'pr-for-branch feature owner/fork')
+        < vim.fn.index(captured.systems, 'pr-for-branch feature owner/upstream')
+    )
+  end)
+
+  it('reports ambiguity when multiple PRs match the same head', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('17\n18\n'),
+      ['fetch-pr 17 owner/upstream'] = helpers.command_result(vim.json.encode({
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+      ['fetch-pr 18 owner/upstream'] = helpers.command_result(vim.json.encode({
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(pr)
+    assert.same('ambiguous_pr', err.code)
+    assert.matches('pass repo= or head=', err.message)
+  end)
+end)

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -95,7 +95,7 @@ describe('github', function()
     assert.truthy(
       vim.tbl_contains(
         pr_details,
-        'title,body,isDraft,headRefName,baseRefName,labels,assignees,reviewRequests,milestone,url'
+        'title,body,isDraft,headRefName,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,milestone,url'
       )
     )
 


### PR DESCRIPTION
## Problem

Current PR lookup only existed as an ad hoc branch lookup in the create flow, so there was no shared resolver for finding the current PR from exact head context across higher-level entrypoints.

Closes #390.

## Solution

Add a shared `forge.resolve.current_pr()` resolver plus a public `forge.current_pr()` helper, make `create_pr()` reuse that path, teach backend branch lookups to return all candidate PRs, and disambiguate by exact head repo/branch with coverage for fallback, no-match, detached-HEAD, and ambiguity cases.
