### PR TITLE
fix: reuse branch push-context resolution

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -281,37 +281,11 @@ local function error_result(msg, opts)
 end
 
 local function target_parse_opts()
-  local ok, forge = pcall(require, 'forge')
-  if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
-    return {
-      resolve_repo = true,
-    }
-  end
-  local cfg = forge.config()
-  local targets = type(cfg) == 'table' and cfg.targets or nil
-  local aliases = type(targets) == 'table' and targets.aliases or nil
-  local default_repo = type(targets) == 'table' and targets.default_repo or nil
-  return {
-    resolve_repo = true,
-    aliases = type(aliases) == 'table' and aliases or {},
-    default_repo = type(default_repo) == 'string' and default_repo or nil,
-  }
+  return require('forge.target').parse_opts()
 end
 
 local function repo_target(value)
-  if type(value) ~= 'table' then
-    return nil
-  end
-  if value.kind == 'repo' then
-    return value
-  end
-  if value.kind == 'rev' then
-    return value.repo
-  end
-  if value.kind == 'location' and type(value.rev) == 'table' then
-    return value.rev.repo
-  end
-  return value.repo
+  return require('forge.target').repo_target(value)
 end
 
 local function default_policy(command, _)
@@ -388,7 +362,7 @@ local function resolve_scope_modifier(command, forge_name)
     or repo_target(command.default_targets.base)
     or repo_target(command.default_targets.head)
     or repo_target(command.default_targets.repo)
-  return target.repo_scope(repo, forge_name)
+  return target.resolve_scope(repo, forge_name, target_parse_opts())
 end
 
 local function dispatch_pr(command)
@@ -403,6 +377,7 @@ local function dispatch_pr(command)
   local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'create' then
     local target = require('forge.target')
+    local parse_opts = target_parse_opts()
     local head = command.parsed_modifiers.head or command.default_targets.head
     local base = command.parsed_modifiers.base or command.default_targets.base
     ops.pr_create({
@@ -411,9 +386,9 @@ local function dispatch_pr(command)
       web = command.modifiers.web == true,
       scope = scope,
       head_branch = head and head.rev or nil,
-      head_scope = target.repo_scope(repo_target(head), f.name),
+      head_scope = target.resolve_scope(head, f.name, parse_opts),
       base_branch = base and base.rev or nil,
-      base_scope = target.repo_scope(repo_target(base), f.name) or scope,
+      base_scope = target.resolve_scope(base, f.name, parse_opts) or scope,
     })
     return
   end

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -9,6 +9,7 @@ local format_mod = require('forge.format')
 local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
 local scope_mod = require('forge.scope')
+local target_mod = require('forge.target')
 local template_mod = require('forge.template')
 
 ---@type table<string, forge.Forge>
@@ -83,46 +84,12 @@ local function cmd_error(result, fallback)
   return msg
 end
 
-local function system_text(cmd)
-  local result = vim.system(cmd, { text = true }):wait()
-  if result.code ~= 0 then
-    return ''
-  end
-  return vim.trim(result.stdout or '')
-end
-
-local function push_remote_name(branch)
-  local remote = system_text({ 'git', 'config', 'branch.' .. branch .. '.pushRemote' })
-  if remote == '' then
-    remote = system_text({ 'git', 'config', 'remote.pushDefault' })
-  end
-  if remote == '' then
-    local upstream = system_text({ 'git', 'rev-parse', '--abbrev-ref', branch .. '@{upstream}' })
-    remote = upstream:match('^([^/]+)/') or ''
-  end
-  if remote == '' then
-    local remotes = system_text({ 'git', 'remote' })
-    remote = vim.split(remotes, '\n', { plain = true, trimempty = true })[1] or ''
-  end
-  return remote
-end
-
-local function remote_scope(forge_name, remote)
-  if remote == '' then
-    return nil
-  end
-  local url = system_text({ 'git', 'remote', 'get-url', remote })
-  if url == '' then
-    return nil
-  end
-  return scope_mod.from_url(forge_name, url)
-end
-
 local function push_target(branch, scope)
   if scope_mod.key(scope) ~= '' then
     return scope_mod.remote_name(scope) or scope_mod.git_url(scope) or ''
   end
-  return push_remote_name(branch)
+  local repo = target_mod.push_repo_for_branch(branch)
+  return type(repo) == 'table' and repo.remote or ''
 end
 
 local function branch_ref(branch, current_branch)
@@ -488,7 +455,7 @@ function M.create_pr(opts)
     log.warn('detached HEAD')
     return
   end
-  local head_scope = opts.head_scope or remote_scope(f.name, push_remote_name(branch))
+  local head_scope = opts.head_scope or target_mod.push_scope_for_branch(branch, f.name)
   local push_to = push_target(branch, head_scope)
   local head_ref = branch_ref(branch, current_branch)
 

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -31,22 +31,6 @@ local function cmd_error(result, fallback)
   return msg or fallback
 end
 
-local function repo_target(value)
-  if type(value) ~= 'table' then
-    return nil
-  end
-  if value.kind == 'repo' then
-    return value
-  end
-  if value.kind == 'rev' then
-    return value.repo
-  end
-  if value.kind == 'location' and type(value.rev) == 'table' then
-    return value.rev.repo
-  end
-  return value.repo
-end
-
 local function current_forge(opts)
   if type(opts) == 'table' and type(opts.forge) == 'table' then
     return opts.forge
@@ -58,84 +42,38 @@ local function current_forge(opts)
   return forge.detect()
 end
 
-local function forge_name(opts)
-  if type(opts) == 'table' then
-    if type(opts.forge_name) == 'string' and opts.forge_name ~= '' then
-      return opts.forge_name
-    end
-    if
-      type(opts.forge) == 'table'
-      and type(opts.forge.name) == 'string'
-      and opts.forge.name ~= ''
-    then
-      return opts.forge.name
-    end
-    for _, value in ipairs({
-      opts.head_scope,
-      opts.base_scope,
-      opts.scope,
-      type(opts.repo) == 'table' and opts.repo or nil,
-    }) do
-      if
-        type(value) == 'table'
-        and value.kind ~= 'repo'
-        and type(value.kind) == 'string'
-        and value.kind ~= ''
-      then
-        return value.kind
-      end
-    end
-    local head = type(opts.head) == 'table' and (opts.head.scope or opts.head.head_scope) or nil
-    if type(head) == 'table' and type(head.kind) == 'string' and head.kind ~= '' then
-      return head.kind
-    end
+local function scope_kind(value)
+  local scope = value
+  if type(scope) == 'table' and type(scope.scope) == 'table' then
+    scope = scope.scope
+  elseif type(scope) == 'table' and type(scope.head_scope) == 'table' then
+    scope = scope.head_scope
   end
-  local f = current_forge(opts)
-  return f and f.name or nil
+  local kind = type(scope) == 'table' and scope.kind or nil
+  if kind == nil or kind == '' or kind == 'repo' then
+    return nil
+  end
+  if type(scope.host) ~= 'string' or type(scope.slug) ~= 'string' then
+    return nil
+  end
+  return kind
 end
 
-local function target_parse_opts(opts)
-  local explicit = type(opts) == 'table' and opts.target_opts or nil
-  if type(explicit) == 'table' then
-    local parsed = vim.deepcopy(explicit)
-    parsed.resolve_repo = true
-    return parsed
+local function forge_name(opts, forge)
+  if type(opts) == 'table' and type(opts.forge_name) == 'string' and opts.forge_name ~= '' then
+    return opts.forge_name
   end
-  local ok, forge = pcall(require, 'forge')
-  if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
-    return {
-      resolve_repo = true,
-    }
+  if type(forge) == 'table' and type(forge.name) == 'string' and forge.name ~= '' then
+    return forge.name
   end
-  local cfg = forge.config()
-  local targets = type(cfg) == 'table' and cfg.targets or nil
-  local aliases = type(targets) == 'table' and targets.aliases or nil
-  local default_repo = type(targets) == 'table' and targets.default_repo or nil
-  return {
-    resolve_repo = true,
-    aliases = type(aliases) == 'table' and aliases or {},
-    default_repo = type(default_repo) == 'string' and default_repo or nil,
-  }
-end
-
-local function resolve_scope(value, kind, parse_opts)
-  if
-    type(value) == 'table'
-    and value.kind ~= 'repo'
-    and type(value.host) == 'string'
-    and type(value.slug) == 'string'
-  then
-    return value
+  if type(opts) ~= 'table' then
+    return nil
   end
-  if type(value) == 'table' and value.kind == 'repo' then
-    return target_mod.repo_scope(value, kind)
-  end
-  if type(value) == 'string' then
-    local repo, err = target_mod.resolve_repo(value, parse_opts)
-    if not repo then
-      return nil, err
+  for _, value in ipairs({ opts.head_scope, opts.base_scope, opts.scope, opts.repo, opts.head }) do
+    local kind = scope_kind(value)
+    if kind then
+      return kind
     end
-    return target_mod.repo_scope(repo, kind)
   end
   return nil
 end
@@ -303,9 +241,114 @@ local function head_label(head)
   return head.branch
 end
 
+local function resolve_head(head, opts, kind, parse_opts)
+  local value = head
+  if value == nil then
+    value = opts.head
+  end
+  local branch = trim(opts.head_branch)
+  local scope, err = target_mod.resolve_scope(opts.head_scope, kind, parse_opts)
+  if err then
+    return nil, err
+  end
+  local project_id = trim(opts.project_id)
+  if type(value) == 'string' then
+    local rev, rev_err = target_mod.parse_rev(value, parse_opts)
+    if not rev then
+      return nil, rev_err
+    end
+    branch = branch or trim(rev.rev)
+    if not scope then
+      scope, err = target_mod.resolve_scope(target_mod.repo_target(rev), kind, parse_opts)
+      if err then
+        return nil, err
+      end
+    end
+  elseif type(value) == 'table' then
+    if value.kind == 'rev' then
+      branch = branch or trim(value.rev)
+      if not scope then
+        scope, err = target_mod.resolve_scope(target_mod.repo_target(value), kind, parse_opts)
+        if err then
+          return nil, err
+        end
+      end
+    else
+      branch = branch or trim(value.branch or value.head_branch or value.rev)
+      project_id = project_id or trim(value.project_id)
+      if not scope then
+        scope, err = target_mod.resolve_scope(
+          value.scope or value.head_scope or target_mod.repo_target(value),
+          kind,
+          parse_opts
+        )
+        if err then
+          return nil, err
+        end
+      end
+    end
+  end
+  if not branch then
+    branch = target_mod.current_branch()
+    if not branch then
+      return nil, 'detached HEAD'
+    end
+  end
+  if not scope then
+    scope = target_mod.push_scope_for_branch(branch, kind, parse_opts)
+  end
+  return {
+    branch = branch,
+    scope = scope,
+    project_id = project_id,
+  }
+end
+
+local function candidate_scopes(opts, head, kind, parse_opts)
+  local repo = opts.repo or opts.base_scope or opts.scope
+  if repo ~= nil then
+    local scope, err = target_mod.resolve_scope(repo, kind, parse_opts)
+    if not scope then
+      return nil, err, 'invalid_repo'
+    end
+    return { scope }
+  end
+  local scopes = {}
+  local seen = {}
+  add_scope(scopes, seen, target_mod.push_scope_for_branch(head.branch, kind, parse_opts))
+  add_scope(scopes, seen, target_mod.repo_scope(target_mod.collaboration_repo(parse_opts), kind))
+  return scopes
+end
+
+local function matching_prs(forge, head, scope)
+  local nums, list_err = list_pr_numbers(forge, head.branch, scope)
+  if not nums then
+    return nil, list_err
+  end
+  local matches = {}
+  for _, num in ipairs(nums) do
+    local json, fetch_err = fetch_pr_json(forge, num, scope)
+    if not json then
+      return nil, fetch_err
+    end
+    local exact, match_err = head_matches(forge, head, pr_head(forge, json, scope))
+    if match_err then
+      return nil, match_err
+    end
+    if exact then
+      matches[#matches + 1] = {
+        num = num,
+        scope = scope,
+      }
+    end
+  end
+  return matches
+end
+
 function M.repo(repo, opts)
   opts = opts or {}
-  local kind = forge_name(opts)
+  local forge = current_forge(opts)
+  local kind = forge_name(opts, forge)
   if not kind then
     return error_result('no forge detected', 'no_forge')
   end
@@ -316,7 +359,7 @@ function M.repo(repo, opts)
   if value == nil then
     return nil
   end
-  local scope, err = resolve_scope(value, kind, target_parse_opts(opts))
+  local scope, err = target_mod.resolve_scope(value, kind, target_mod.parse_opts(opts))
   if not scope then
     return error_result(err or 'invalid repo address', 'invalid_repo')
   end
@@ -325,72 +368,16 @@ end
 
 function M.head(head, opts)
   opts = opts or {}
-  local kind = forge_name(opts)
+  local forge = current_forge(opts)
+  local kind = forge_name(opts, forge)
   if not kind then
     return error_result('no forge detected', 'no_forge')
   end
-  local parse_opts = target_parse_opts(opts)
-  local value = head
-  if value == nil then
-    value = opts.head
+  local resolved, err = resolve_head(head, opts, kind, target_mod.parse_opts(opts))
+  if resolved then
+    return resolved
   end
-  local branch = trim(opts.head_branch)
-  local scope, err = resolve_scope(opts.head_scope, kind, parse_opts)
-  if err then
-    return error_result(err, 'invalid_head')
-  end
-  local project_id = trim(opts.project_id)
-  if type(value) == 'string' then
-    local rev
-    rev, err = target_mod.parse_rev(value, parse_opts)
-    if not rev then
-      return error_result(err, 'invalid_head')
-    end
-    branch = branch or trim(rev.rev)
-    if not scope then
-      scope, err = resolve_scope(repo_target(rev), kind, parse_opts)
-      if err then
-        return error_result(err, 'invalid_head')
-      end
-    end
-  elseif type(value) == 'table' then
-    if value.kind == 'rev' then
-      branch = branch or trim(value.rev)
-      if not scope then
-        scope, err = resolve_scope(repo_target(value), kind, parse_opts)
-        if err then
-          return error_result(err, 'invalid_head')
-        end
-      end
-    else
-      branch = branch or trim(value.branch or value.head_branch or value.rev)
-      project_id = project_id or trim(value.project_id)
-      if not scope then
-        scope, err = resolve_scope(value.scope or value.head_scope or value.repo, kind, parse_opts)
-        if err then
-          return error_result(err, 'invalid_head')
-        end
-      end
-    end
-  end
-  if not branch then
-    local current = target_mod.push_rev(parse_opts)
-    branch = current and trim(current.rev) or nil
-    if not branch then
-      return error_result('detached HEAD', 'detached_head')
-    end
-    if not scope then
-      scope = target_mod.repo_scope(repo_target(current), kind)
-    end
-  end
-  if not scope then
-    scope = target_mod.repo_scope(target_mod.push_repo(parse_opts), kind)
-  end
-  return {
-    branch = branch,
-    scope = scope,
-    project_id = project_id,
-  }
+  return error_result(err, err == 'detached HEAD' and 'detached_head' or 'invalid_head')
 end
 
 function M.current_pr(opts)
@@ -399,57 +386,23 @@ function M.current_pr(opts)
   if not forge then
     return error_result('no forge detected', 'no_forge')
   end
-  local kind = forge.name or forge_name(opts)
+  local kind = forge_name(opts, forge)
   if not kind then
     return error_result('no forge detected', 'no_forge')
   end
-  local parse_opts = target_parse_opts(opts)
-  local repo = opts.repo or opts.base_scope or opts.scope
-  local repos = nil
-  if repo ~= nil then
-    local resolved, err = resolve_scope(repo, kind, parse_opts)
-    if not resolved then
-      return error_result(err or 'invalid repo address', 'invalid_repo')
-    end
-    repos = { resolved }
-  else
-    local seen = {}
-    repos = {}
-    add_scope(repos, seen, target_mod.repo_scope(target_mod.push_repo(parse_opts), kind))
-    add_scope(repos, seen, target_mod.repo_scope(target_mod.collaboration_repo(parse_opts), kind))
-  end
-  local head, err = M.head(
-    opts.head,
-    vim.tbl_extend('force', opts, {
-      forge = forge,
-      forge_name = kind,
-      target_opts = parse_opts,
-    })
-  )
+  local parse_opts = target_mod.parse_opts(opts)
+  local head, head_err = resolve_head(opts.head, opts, kind, parse_opts)
   if not head then
-    return nil, err
+    return error_result(head_err, head_err == 'detached HEAD' and 'detached_head' or 'invalid_head')
+  end
+  local repos, repo_err, repo_code = candidate_scopes(opts, head, kind, parse_opts)
+  if not repos then
+    return error_result(repo_err or 'invalid repo address', repo_code or 'invalid_repo')
   end
   for _, scope in ipairs(repos) do
-    local nums, list_err = list_pr_numbers(forge, head.branch, scope)
-    if not nums then
-      return error_result(list_err, 'lookup_failed')
-    end
-    local matches = {}
-    for _, num in ipairs(nums) do
-      local json, fetch_err = fetch_pr_json(forge, num, scope)
-      if not json then
-        return error_result(fetch_err, 'lookup_failed')
-      end
-      local exact, match_err = head_matches(forge, head, pr_head(forge, json, scope))
-      if match_err then
-        return error_result(match_err, 'lookup_failed')
-      end
-      if exact then
-        matches[#matches + 1] = {
-          num = num,
-          scope = scope,
-        }
-      end
+    local matches, match_err = matching_prs(forge, head, scope)
+    if not matches then
+      return error_result(match_err, 'lookup_failed')
     end
     if #matches == 1 then
       return matches[1]

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -53,6 +53,26 @@ local function alias_map(opts)
   return type(opts) == 'table' and type(opts.aliases) == 'table' and opts.aliases or {}
 end
 
+local function has_parse_opts(opts)
+  return type(opts) == 'table'
+    and (opts.resolve_repo ~= nil or opts.aliases ~= nil or opts.default_repo ~= nil)
+end
+
+local function config_parse_opts()
+  local ok, forge = pcall(require, 'forge')
+  if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
+    return {}
+  end
+  local cfg = forge.config()
+  local targets = type(cfg) == 'table' and cfg.targets or nil
+  local aliases = type(targets) == 'table' and targets.aliases or nil
+  local default_repo = type(targets) == 'table' and targets.default_repo or nil
+  return {
+    aliases = type(aliases) == 'table' and aliases or {},
+    default_repo = type(default_repo) == 'string' and default_repo or nil,
+  }
+end
+
 local function shell_text(cmd)
   local result = vim.system(cmd, { text = true }):wait()
   if result.code ~= 0 then
@@ -224,6 +244,68 @@ function M.resolve_repo(text, opts)
   return parsed
 end
 
+function M.parse_opts(opts)
+  local explicit = type(opts) == 'table' and opts.target_opts or nil
+  if type(explicit) == 'table' then
+    local parsed = vim.deepcopy(explicit)
+    parsed.resolve_repo = true
+    return parsed
+  end
+  if has_parse_opts(opts) then
+    local parsed = vim.deepcopy(opts)
+    parsed.resolve_repo = true
+    return parsed
+  end
+  local parsed = config_parse_opts()
+  parsed.resolve_repo = true
+  return parsed
+end
+
+function M.repo_target(value)
+  if type(value) ~= 'table' then
+    return nil
+  end
+  if value.kind == 'repo' then
+    return value
+  end
+  if value.kind == 'rev' then
+    return value.repo
+  end
+  if value.kind == 'location' and type(value.rev) == 'table' then
+    return value.rev.repo
+  end
+  return value.repo
+end
+
+function M.resolve_scope(value, forge_name, opts)
+  local parse_opts = M.parse_opts(opts)
+  if
+    type(value) == 'table'
+    and value.kind ~= 'repo'
+    and type(value.host) == 'string'
+    and type(value.slug) == 'string'
+  then
+    return value
+  end
+  if type(value) == 'table' then
+    if value.kind == 'repo' then
+      return M.repo_scope(value, forge_name)
+    end
+    local repo = M.repo_target(value)
+    if type(repo) == 'table' then
+      return M.resolve_scope(repo, forge_name, parse_opts)
+    end
+  end
+  if type(value) == 'string' then
+    local repo, err = M.resolve_repo(value, parse_opts)
+    if not repo then
+      return nil, err
+    end
+    return M.repo_scope(repo, forge_name)
+  end
+  return nil
+end
+
 function M.current_branch()
   return shell_text({ 'git', 'branch', '--show-current' })
 end
@@ -233,28 +315,32 @@ function M.current_repo(opts)
   if not remote then
     return nil
   end
-  return M.resolve_repo(remote, opts)
+  return M.resolve_repo(remote, M.parse_opts(opts))
 end
 
-function M.push_repo(opts)
-  local branch = M.current_branch()
+function M.push_repo_for_branch(branch, opts)
   local remote = push_remote_name(branch)
   if not remote then
     return nil
   end
-  return M.resolve_repo(remote, opts)
+  return M.resolve_repo(remote, M.parse_opts(opts))
+end
+
+function M.push_repo(opts)
+  return M.push_repo_for_branch(M.current_branch(), opts)
 end
 
 function M.collaboration_repo(opts)
-  local configured = type(opts) == 'table' and trim(opts.default_repo) or nil
+  local parse_opts = M.parse_opts(opts)
+  local configured = type(parse_opts) == 'table' and trim(parse_opts.default_repo) or nil
   if configured then
-    local resolved = M.resolve_repo(configured, opts)
+    local resolved = M.resolve_repo(configured, parse_opts)
     if resolved then
       return resolved
     end
   end
   for _, remote in ipairs({ 'upstream', 'origin' }) do
-    local resolved = M.resolve_repo(remote, opts)
+    local resolved = M.resolve_repo(remote, parse_opts)
     if resolved then
       return resolved
     end
@@ -294,8 +380,16 @@ function M.current_rev(opts)
   return M.branch_rev(M.current_branch(), M.current_repo(opts))
 end
 
+function M.push_scope_for_branch(branch, forge_name, opts)
+  return M.repo_scope(M.push_repo_for_branch(branch, opts), forge_name)
+end
+
+function M.push_rev_for_branch(branch, opts)
+  return M.branch_rev(branch, M.push_repo_for_branch(branch, opts))
+end
+
 function M.push_rev(opts)
-  return M.branch_rev(M.current_branch(), M.push_repo(opts))
+  return M.push_rev_for_branch(M.current_branch(), opts)
 end
 
 function M.collaboration_default_branch(opts)

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -488,6 +488,35 @@ describe('create_pr', function()
     assert.equals('owner/fork', captured.web_create.head_scope.slug)
   end)
 
+  it('uses explicit head-branch push context when head scope is implicit', function()
+    use_branch_context('feature')
+    use_system_responses({
+      ['git config branch.topic.pushRemote'] = helpers.command_result('fork\n'),
+      ['git diff --quiet origin/stable..topic'] = helpers.command_result('', 1),
+      ['pr-for-branch topic'] = helpers.command_result('\n'),
+      ['git remote'] = helpers.command_result('origin\nfork\n'),
+      ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/repo.git\n'),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+    })
+
+    require('forge').create_pr({
+      web = true,
+      head_branch = 'topic',
+      base_branch = 'stable',
+      base_scope = repo_scope('repo'),
+    })
+
+    vim.wait(100, function()
+      return vim.tbl_contains(captured.infos, 'opened PR creation in browser')
+    end)
+
+    assert.is_true(vim.tbl_contains(captured.systems, 'git config branch.topic.pushRemote'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'git diff --quiet origin/stable..topic'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'git push -u fork topic'))
+    assert.equals('topic', captured.web_create.head_branch)
+    assert.equals('owner/fork', captured.web_create.head_scope.slug)
+  end)
+
   it('reports an error when the web PR command fails', function()
     use_system_responses({
       ['pr-for-branch feature'] = helpers.command_result('\n'),

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -184,6 +184,41 @@ describe('current_pr resolver', function()
     )
   end)
 
+  it('uses explicit head-branch push context before collaboration fallback', function()
+    use_system_responses({
+      ['git config branch.topic.pushRemote'] = helpers.command_result('fork\n'),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['pr-for-branch topic owner/fork'] = helpers.command_result('\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('57\n'),
+      ['fetch-pr 57 owner/upstream'] = helpers.command_result(vim.json.encode({
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      head_branch = 'topic',
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '57',
+      scope = repo_scope('upstream'),
+    }, pr)
+    assert.is_true(vim.tbl_contains(captured.systems, 'git config branch.topic.pushRemote'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'git branch --show-current'))
+  end)
+
   it('reports ambiguity when multiple PRs match the same head', function()
     use_system_responses({
       ['git remote get-url upstream'] = helpers.command_result(

--- a/spec/target_spec.lua
+++ b/spec/target_spec.lua
@@ -198,6 +198,37 @@ describe('target parsing', function()
     assert.equals('owner/fork', rev.repo.slug)
   end)
 
+  it('resolves explicit branch push context without consulting the current branch', function()
+    vim.system = function(cmd)
+      local key = table.concat(cmd, ' ')
+      if key == 'git config branch.topic.pushRemote' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'fork\n' }
+          end,
+        }
+      end
+      if key == 'git remote get-url fork' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'git@github.com:owner/fork.git\n' }
+          end,
+        }
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '' }
+        end,
+      }
+    end
+
+    local target = require('forge.target')
+    local rev = assert(target.push_rev_for_branch('topic', {}))
+
+    assert.equals('topic', rev.rev)
+    assert.equals('owner/fork', rev.repo.slug)
+  end)
+
   it('converts resolved repo targets into forge scopes', function()
     local target = require('forge.target')
     local scope = assert(target.repo_scope({


### PR DESCRIPTION
## Problem

The first current-PR resolver pass left target parsing and branch push-context lookup split across `forge.target`, `forge.resolve`, `forge.init`, and `cmd.lua`. That made the flow harder to audit and allowed explicit head-branch resolution to fall back to the current branch context in places that should have used the requested branch.

## Solution

Move the reusable target helpers into `forge.target`, make the resolver, command dispatch, and PR creation flow all call those shared helpers, and add regression coverage for explicit branch push-context resolution in the target, resolver, and create paths.