### PR TITLE
fix: add missing luacats for target resolution

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -280,10 +280,13 @@ local function error_result(msg, opts)
   }
 end
 
+---@return forge.TargetParseOpts
 local function target_parse_opts()
   return require('forge.target').parse_opts()
 end
 
+---@param value forge.TargetValue|forge.HeadInput|forge.Scope|nil
+---@return forge.RepoLike?
 local function repo_target(value)
   return require('forge.target').repo_target(value)
 end
@@ -351,6 +354,9 @@ local function require_forge_or_warn()
   return f, forge_mod
 end
 
+---@param command forge.Command
+---@param forge_name forge.ScopeKind
+---@return forge.Scope?
 local function resolve_scope_modifier(command, forge_name)
   local target = require('forge.target')
   local repo = repo_target(command.parsed_modifiers.target)

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -3,8 +3,11 @@ local M = {}
 local scope_mod = require('forge.scope')
 local target_mod = require('forge.target')
 
+---@type table<string, string|false>
 local gitlab_project_ids = {}
 
+---@param text any
+---@return string?
 local function trim(text)
   if type(text) ~= 'string' then
     return nil
@@ -16,6 +19,9 @@ local function trim(text)
   return value
 end
 
+---@param message string
+---@param code string?
+---@return nil, forge.CmdError
 local function error_result(message, code)
   return nil, {
     code = code,
@@ -23,6 +29,9 @@ local function error_result(message, code)
   }
 end
 
+---@param result forge.SystemResult
+---@param fallback string
+---@return string
 local function cmd_error(result, fallback)
   local msg = trim(result.stderr)
   if not msg then
@@ -31,6 +40,8 @@ local function cmd_error(result, fallback)
   return msg or fallback
 end
 
+---@param opts forge.CurrentPROpts?
+---@return forge.Forge?
 local function current_forge(opts)
   if type(opts) == 'table' and type(opts.forge) == 'table' then
     return opts.forge
@@ -42,6 +53,8 @@ local function current_forge(opts)
   return forge.detect()
 end
 
+---@param value any
+---@return forge.ScopeKind?
 local function scope_kind(value)
   local scope = value
   if type(scope) == 'table' and type(scope.scope) == 'table' then
@@ -59,6 +72,9 @@ local function scope_kind(value)
   return kind
 end
 
+---@param opts forge.CurrentPROpts?
+---@param forge forge.Forge?
+---@return forge.ScopeKind?
 local function forge_name(opts, forge)
   if type(opts) == 'table' and type(opts.forge_name) == 'string' and opts.forge_name ~= '' then
     return opts.forge_name
@@ -78,6 +94,9 @@ local function forge_name(opts, forge)
   return nil
 end
 
+---@param scopes forge.Scope[]
+---@param seen table<string, boolean>
+---@param value forge.Scope?
 local function add_scope(scopes, seen, value)
   local key = scope_mod.key(value)
   if key == '' or seen[key] then
@@ -87,6 +106,9 @@ local function add_scope(scopes, seen, value)
   scopes[#scopes + 1] = value
 end
 
+---@param json table
+---@param base_scope forge.Scope?
+---@return forge.HeadRef
 local function github_head(json, base_scope)
   local branch = trim(json.headRefName)
   local owner = type(json.headRepositoryOwner) == 'table'
@@ -112,6 +134,8 @@ local function github_head(json, base_scope)
   }
 end
 
+---@param json table
+---@return forge.HeadRef
 local function gitlab_head(json)
   return {
     branch = trim(json.source_branch),
@@ -119,6 +143,9 @@ local function gitlab_head(json)
   }
 end
 
+---@param json table
+---@param base_scope forge.Scope?
+---@return forge.HeadRef
 local function codeberg_head(json, base_scope)
   local head = type(json.head) == 'table' and json.head or nil
   local branch = trim(head and (head.ref or head.name) or json.head)
@@ -135,6 +162,10 @@ local function codeberg_head(json, base_scope)
   }
 end
 
+---@param forge forge.Forge
+---@param json table
+---@param base_scope forge.Scope?
+---@return forge.HeadRef
 local function pr_head(forge, json, base_scope)
   if forge.name == 'github' then
     return github_head(json, base_scope)
@@ -151,7 +182,11 @@ local function pr_head(forge, json, base_scope)
   }
 end
 
+---@param scope forge.Scope?
+---@return string?, string?
 local function gitlab_project_id(scope)
+  local slug = type(scope) == 'table' and scope.slug or 'scope'
+  local host = type(scope) == 'table' and scope.host or 'gitlab.com'
   local key = scope_mod.key(scope)
   if key == '' then
     return nil
@@ -165,24 +200,24 @@ local function gitlab_project_id(scope)
     return nil
   end
   local result = vim
-    .system(
-      { 'glab', 'api', '--hostname', scope.host or 'gitlab.com', ('projects/%s'):format(project) },
-      { text = true }
-    )
+    .system({ 'glab', 'api', '--hostname', host, ('projects/%s'):format(project) }, { text = true })
     :wait()
   if result.code ~= 0 then
-    return nil,
-      cmd_error(result, ('failed to resolve GitLab project for %s'):format(scope.slug or 'scope'))
+    return nil, cmd_error(result, ('failed to resolve GitLab project for %s'):format(slug))
   end
   local ok, json = pcall(vim.json.decode, result.stdout or '{}')
   if not ok or type(json) ~= 'table' or json.id == nil then
-    return nil, ('failed to parse GitLab project for %s'):format(scope.slug or 'scope')
+    return nil, ('failed to parse GitLab project for %s'):format(slug)
   end
   local id = tostring(json.id)
   gitlab_project_ids[key] = id
   return id
 end
 
+---@param forge forge.Forge
+---@param expected forge.HeadRef
+---@param actual forge.HeadRef
+---@return boolean?, string?
 local function head_matches(forge, expected, actual)
   if trim(actual.branch) ~= expected.branch then
     return false
@@ -202,6 +237,10 @@ local function head_matches(forge, expected, actual)
   return scope_mod.same(expected.scope, actual.scope)
 end
 
+---@param forge forge.Forge
+---@param num string
+---@param scope forge.Scope?
+---@return table?, string?
 local function fetch_pr_json(forge, num, scope)
   local result = vim.system(forge:fetch_pr_details_cmd(num, scope), { text = true }):wait()
   if result.code ~= 0 then
@@ -215,6 +254,10 @@ local function fetch_pr_json(forge, num, scope)
   return json
 end
 
+---@param forge forge.Forge
+---@param branch string
+---@param scope forge.Scope?
+---@return string[]?, string?
 local function list_pr_numbers(forge, branch, scope)
   local result = vim.system(forge:pr_for_branch_cmd(branch, scope), { text = true }):wait()
   if result.code ~= 0 then
@@ -233,6 +276,8 @@ local function list_pr_numbers(forge, branch, scope)
   return nums
 end
 
+---@param head forge.HeadRef
+---@return string
 local function head_label(head)
   local slug = type(head.scope) == 'table' and head.scope.slug or nil
   if slug and slug ~= '' then
@@ -241,6 +286,11 @@ local function head_label(head)
   return head.branch
 end
 
+---@param head forge.HeadLike?
+---@param opts forge.CurrentPROpts
+---@param kind forge.ScopeKind
+---@param parse_opts forge.TargetParseOpts
+---@return forge.HeadRef?, string?
 local function resolve_head(head, opts, kind, parse_opts)
   local value = head
   if value == nil then
@@ -274,6 +324,7 @@ local function resolve_head(head, opts, kind, parse_opts)
         end
       end
     else
+      ---@cast value forge.HeadInput
       branch = branch or trim(value.branch or value.head_branch or value.rev)
       project_id = project_id or trim(value.project_id)
       if not scope then
@@ -304,6 +355,11 @@ local function resolve_head(head, opts, kind, parse_opts)
   }
 end
 
+---@param opts forge.CurrentPROpts
+---@param head forge.HeadRef
+---@param kind forge.ScopeKind
+---@param parse_opts forge.TargetParseOpts
+---@return forge.Scope[]?, string?, string?
 local function candidate_scopes(opts, head, kind, parse_opts)
   local repo = opts.repo or opts.base_scope or opts.scope
   if repo ~= nil then
@@ -320,6 +376,10 @@ local function candidate_scopes(opts, head, kind, parse_opts)
   return scopes
 end
 
+---@param forge forge.Forge
+---@param head forge.HeadRef
+---@param scope forge.Scope
+---@return forge.PRRef[]?, string?
 local function matching_prs(forge, head, scope)
   local nums, list_err = list_pr_numbers(forge, head.branch, scope)
   if not nums then
@@ -345,6 +405,9 @@ local function matching_prs(forge, head, scope)
   return matches
 end
 
+---@param repo forge.RepoLike?
+---@param opts forge.CurrentPROpts?
+---@return forge.Scope?, forge.CmdError?
 function M.repo(repo, opts)
   opts = opts or {}
   local forge = current_forge(opts)
@@ -366,6 +429,9 @@ function M.repo(repo, opts)
   return scope
 end
 
+---@param head forge.HeadLike?
+---@param opts forge.CurrentPROpts?
+---@return forge.HeadRef?, forge.CmdError?
 function M.head(head, opts)
   opts = opts or {}
   local forge = current_forge(opts)
@@ -377,9 +443,14 @@ function M.head(head, opts)
   if resolved then
     return resolved
   end
-  return error_result(err, err == 'detached HEAD' and 'detached_head' or 'invalid_head')
+  return error_result(
+    err or 'invalid head',
+    err == 'detached HEAD' and 'detached_head' or 'invalid_head'
+  )
 end
 
+---@param opts forge.CurrentPROpts?
+---@return forge.PRRef?, forge.CmdError?
 function M.current_pr(opts)
   opts = opts or {}
   local forge = current_forge(opts)
@@ -393,7 +464,10 @@ function M.current_pr(opts)
   local parse_opts = target_mod.parse_opts(opts)
   local head, head_err = resolve_head(opts.head, opts, kind, parse_opts)
   if not head then
-    return error_result(head_err, head_err == 'detached HEAD' and 'detached_head' or 'invalid_head')
+    return error_result(
+      head_err or 'invalid head',
+      head_err == 'detached HEAD' and 'detached_head' or 'invalid_head'
+    )
   end
   local repos, repo_err, repo_code = candidate_scopes(opts, head, kind, parse_opts)
   if not repos then
@@ -402,7 +476,7 @@ function M.current_pr(opts)
   for _, scope in ipairs(repos) do
     local matches, match_err = matching_prs(forge, head, scope)
     if not matches then
-      return error_result(match_err, 'lookup_failed')
+      return error_result(match_err or 'current PR lookup failed', 'lookup_failed')
     end
     if #matches == 1 then
       return matches[1]

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -249,7 +249,7 @@ local function fetch_pr_json(forge, num, scope)
   end
   local ok, json = pcall(vim.json.decode, result.stdout or '{}')
   if not ok or type(json) ~= 'table' then
-    return nil, ('failed to parse %s #%s details'):format(forge.labels.pr_one or 'PR', num)
+    return nil, ('failed to parse %s details'):format(forge.labels.pr_one or 'PR')
   end
   return json
 end
@@ -261,8 +261,7 @@ end
 local function list_pr_numbers(forge, branch, scope)
   local result = vim.system(forge:pr_for_branch_cmd(branch, scope), { text = true }):wait()
   if result.code ~= 0 then
-    return nil,
-      cmd_error(result, ('failed to list %s for %s'):format(forge.labels.pr_full or 'PRs', branch))
+    return nil, cmd_error(result, ('failed to fetch %s'):format(forge.labels.pr or 'PRs'))
   end
   local nums = {}
   local seen = {}

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -6,6 +6,8 @@ local default_hosts = {
   codeberg = 'codeberg.org',
 }
 
+---@param text any
+---@return string?
 local function trim(text)
   if type(text) ~= 'string' then
     return nil
@@ -17,6 +19,8 @@ local function trim(text)
   return value
 end
 
+---@param url any
+---@return string?
 local function normalize_url(url)
   local value = trim(url)
   if not value then
@@ -32,6 +36,8 @@ local function normalize_url(url)
   return normalized
 end
 
+---@param url any
+---@return string?, string?
 local function split_url(url)
   local normalized = normalize_url(url)
   if not normalized then
@@ -49,15 +55,20 @@ local function split_url(url)
   return host, path
 end
 
+---@param opts table?
+---@return table<string, string>
 local function alias_map(opts)
   return type(opts) == 'table' and type(opts.aliases) == 'table' and opts.aliases or {}
 end
 
+---@param opts table?
+---@return boolean
 local function has_parse_opts(opts)
   return type(opts) == 'table'
     and (opts.resolve_repo ~= nil or opts.aliases ~= nil or opts.default_repo ~= nil)
 end
 
+---@return forge.TargetParseOpts
 local function config_parse_opts()
   local ok, forge = pcall(require, 'forge')
   if not ok or type(forge) ~= 'table' or type(forge.config) ~= 'function' then
@@ -73,6 +84,8 @@ local function config_parse_opts()
   }
 end
 
+---@param cmd string[]
+---@return string?
 local function shell_text(cmd)
   local result = vim.system(cmd, { text = true }):wait()
   if result.code ~= 0 then
@@ -81,10 +94,13 @@ local function shell_text(cmd)
   return trim(result.stdout)
 end
 
+---@param name string
+---@return string?
 local function remote_url(name)
   return shell_text({ 'git', 'remote', 'get-url', name })
 end
 
+---@return string?
 local function preferred_remote_name()
   if remote_url('origin') then
     return 'origin'
@@ -96,6 +112,8 @@ local function preferred_remote_name()
   return vim.split(remotes, '\n', { plain = true, trimempty = true })[1]
 end
 
+---@param branch string?
+---@return string?
 local function push_remote_name(branch)
   local value = trim(branch)
   if not value then
@@ -119,6 +137,8 @@ local function push_remote_name(branch)
   return preferred_remote_name()
 end
 
+---@param fragment string?
+---@return forge.LineRange?, string?
 local function parse_range(fragment)
   if fragment == nil then
     return nil
@@ -141,6 +161,8 @@ local function parse_range(fragment)
   return nil, 'invalid range: ' .. fragment
 end
 
+---@param text string
+---@return forge.RepoTarget?, string?
 function M.parse_repo(text)
   local value = trim(text)
   if not value then
@@ -186,6 +208,9 @@ function M.parse_repo(text)
   return nil, 'invalid repo address: ' .. value
 end
 
+---@param text string
+---@param opts forge.TargetParseOpts?
+---@return forge.RepoTarget?, string?
 function M.resolve_repo(text, opts)
   local value = trim(text)
   if not value then
@@ -244,6 +269,8 @@ function M.resolve_repo(text, opts)
   return parsed
 end
 
+---@param opts table?
+---@return forge.TargetParseOpts
 function M.parse_opts(opts)
   local explicit = type(opts) == 'table' and opts.target_opts or nil
   if type(explicit) == 'table' then
@@ -261,6 +288,8 @@ function M.parse_opts(opts)
   return parsed
 end
 
+---@param value forge.TargetValue|forge.HeadInput|forge.Scope|nil
+---@return forge.RepoLike?
 function M.repo_target(value)
   if type(value) ~= 'table' then
     return nil
@@ -277,6 +306,10 @@ function M.repo_target(value)
   return value.repo
 end
 
+---@param value forge.TargetValue|forge.HeadInput|forge.RepoLike|nil
+---@param forge_name forge.ScopeKind
+---@param opts table?
+---@return forge.Scope?, string?
 function M.resolve_scope(value, forge_name, opts)
   local parse_opts = M.parse_opts(opts)
   if
@@ -285,6 +318,7 @@ function M.resolve_scope(value, forge_name, opts)
     and type(value.host) == 'string'
     and type(value.slug) == 'string'
   then
+    ---@cast value forge.Scope
     return value
   end
   if type(value) == 'table' then
@@ -306,10 +340,13 @@ function M.resolve_scope(value, forge_name, opts)
   return nil
 end
 
+---@return string?
 function M.current_branch()
   return shell_text({ 'git', 'branch', '--show-current' })
 end
 
+---@param opts table?
+---@return forge.RepoTarget?
 function M.current_repo(opts)
   local remote = preferred_remote_name()
   if not remote then
@@ -318,6 +355,9 @@ function M.current_repo(opts)
   return M.resolve_repo(remote, M.parse_opts(opts))
 end
 
+---@param branch string?
+---@param opts table?
+---@return forge.RepoTarget?
 function M.push_repo_for_branch(branch, opts)
   local remote = push_remote_name(branch)
   if not remote then
@@ -326,10 +366,14 @@ function M.push_repo_for_branch(branch, opts)
   return M.resolve_repo(remote, M.parse_opts(opts))
 end
 
+---@param opts table?
+---@return forge.RepoTarget?
 function M.push_repo(opts)
   return M.push_repo_for_branch(M.current_branch(), opts)
 end
 
+---@param opts table?
+---@return forge.RepoTarget?
 function M.collaboration_repo(opts)
   local parse_opts = M.parse_opts(opts)
   local configured = type(parse_opts) == 'table' and trim(parse_opts.default_repo) or nil
@@ -348,6 +392,9 @@ function M.collaboration_repo(opts)
   return nil
 end
 
+---@param branch string?
+---@param repo forge.RepoTarget?
+---@return forge.RevTarget?
 function M.branch_rev(branch, repo)
   local value = trim(branch)
   if not value then
@@ -364,6 +411,8 @@ function M.branch_rev(branch, repo)
   return rev
 end
 
+---@param repo forge.RepoTarget?
+---@return forge.RevTarget?
 function M.default_branch_rev(repo)
   if not repo then
     return nil
@@ -376,26 +425,42 @@ function M.default_branch_rev(repo)
   }
 end
 
+---@param opts table?
+---@return forge.RevTarget?
 function M.current_rev(opts)
   return M.branch_rev(M.current_branch(), M.current_repo(opts))
 end
 
+---@param branch string?
+---@param forge_name forge.ScopeKind
+---@param opts table?
+---@return forge.Scope?
 function M.push_scope_for_branch(branch, forge_name, opts)
   return M.repo_scope(M.push_repo_for_branch(branch, opts), forge_name)
 end
 
+---@param branch string?
+---@param opts table?
+---@return forge.RevTarget?
 function M.push_rev_for_branch(branch, opts)
   return M.branch_rev(branch, M.push_repo_for_branch(branch, opts))
 end
 
+---@param opts table?
+---@return forge.RevTarget?
 function M.push_rev(opts)
   return M.push_rev_for_branch(M.current_branch(), opts)
 end
 
+---@param opts table?
+---@return forge.RevTarget?
 function M.collaboration_default_branch(opts)
   return M.default_branch_rev(M.collaboration_repo(opts))
 end
 
+---@param text string
+---@param opts forge.TargetParseOpts?
+---@return forge.RevTarget?, string?
 function M.parse_rev(text, opts)
   local value = trim(text)
   if not value then
@@ -440,6 +505,9 @@ function M.parse_rev(text, opts)
   return parsed
 end
 
+---@param text any
+---@param label string
+---@return string?, string?
 local function parse_bare_ref(text, label)
   local value = trim(text)
   if not value then
@@ -457,6 +525,8 @@ local function parse_bare_ref(text, label)
   return value
 end
 
+---@param text string
+---@return forge.BranchTarget?, string?
 function M.parse_branch(text)
   local value, err = parse_bare_ref(text, 'branch')
   if not value then
@@ -469,6 +539,8 @@ function M.parse_branch(text)
   }
 end
 
+---@param text string
+---@return forge.CommitTarget?, string?
 function M.parse_commit(text)
   local value, err = parse_bare_ref(text, 'commit')
   if not value then
@@ -481,6 +553,9 @@ function M.parse_commit(text)
   }
 end
 
+---@param text string
+---@param opts forge.TargetParseOpts?
+---@return forge.LocationTarget?, string?
 function M.parse_location(text, opts)
   local value = trim(text)
   if not value then
@@ -522,6 +597,9 @@ function M.parse_location(text, opts)
   }
 end
 
+---@param repo forge.RepoTarget?
+---@param forge_name forge.ScopeKind
+---@return forge.Scope?
 function M.repo_scope(repo, forge_name)
   if type(repo) ~= 'table' then
     return nil

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -31,6 +31,54 @@
 ---@field namespace string?
 ---@field repo string?
 
+---@class forge.LineRange
+---@field start_line integer
+---@field end_line integer
+
+---@class forge.RepoTarget
+---@field kind 'repo'
+---@field form 'hosted'|'path'|'symbolic'
+---@field text string
+---@field host string?
+---@field slug string?
+---@field name string?
+---@field via 'alias'|'remote'|'explicit'?
+---@field alias string?
+---@field remote string?
+
+---@class forge.RevTarget
+---@field kind 'rev'
+---@field text string
+---@field rev string?
+---@field repo forge.RepoTarget?
+---@field default_branch boolean?
+
+---@class forge.BranchTarget
+---@field kind 'branch'
+---@field text string
+---@field branch string
+
+---@class forge.CommitTarget
+---@field kind 'commit'
+---@field text string
+---@field commit string
+
+---@class forge.LocationTarget
+---@field kind 'location'
+---@field text string
+---@field rev forge.RevTarget
+---@field path string
+---@field range forge.LineRange?
+
+---@class forge.HeadInput
+---@field branch string?
+---@field head_branch string?
+---@field rev string?
+---@field scope forge.Scope?
+---@field head_scope forge.Scope?
+---@field repo forge.RepoLike?
+---@field project_id string?
+
 ---@class forge.PRRef
 ---@field num string
 ---@field scope forge.Scope?
@@ -58,9 +106,17 @@
 ---@alias forge.IssueRefLike forge.IssueRef|string
 ---@alias forge.ReleaseRefLike forge.ReleaseRef|string
 ---@alias forge.RunRefLike forge.RunRef|string
+---@alias forge.TargetValue forge.RepoTarget|forge.RevTarget|forge.BranchTarget|forge.CommitTarget|forge.LocationTarget
+---@alias forge.RepoLike forge.Scope|forge.RepoTarget|string
+---@alias forge.HeadLike forge.HeadInput|forge.HeadRef|forge.RevTarget|string
 
 ---@class forge.ScopedOpts
 ---@field scope forge.Scope?
+
+---@class forge.TargetParseOpts
+---@field resolve_repo boolean?
+---@field aliases table<string, string>?
+---@field default_repo string?
 
 ---@class forge.SurfaceOpts
 ---@field forge_name string?
@@ -77,6 +133,11 @@
 ---@class forge.CmdError
 ---@field code string?
 ---@field message string
+
+---@class forge.SystemResult
+---@field code integer
+---@field stdout string?
+---@field stderr string?
 
 ---@class forge.CommandSubjectSpec
 ---@field kind string?
@@ -210,13 +271,13 @@
 ---@class forge.CurrentPROpts: forge.ScopedOpts
 ---@field forge forge.Forge?
 ---@field forge_name string?
----@field repo any
----@field head any
+---@field repo forge.RepoLike?
+---@field head forge.HeadLike?
 ---@field head_branch string?
 ---@field head_scope forge.Scope?
 ---@field base_scope forge.Scope?
 ---@field project_id string?
----@field target_opts table?
+---@field target_opts forge.TargetParseOpts?
 
 ---@class forge.CreateIssueOpts
 ---@field web boolean?

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -13,16 +13,16 @@ local loaded_modules = {
   'forge.target',
 }
 
-local function repo_scope(repo)
-  return {
-    kind = 'github',
-    host = 'github.com',
-    owner = 'owner',
-    repo = repo,
-    slug = 'owner/' .. repo,
-    repo_arg = 'owner/' .. repo,
-    web_url = 'https://github.com/owner/' .. repo,
-  }
+local function github_scope(repo)
+  return assert(require('forge.scope').from_url('github', 'https://github.com/owner/' .. repo))
+end
+
+local function gitlab_scope(slug)
+  return assert(require('forge.scope').from_url('gitlab', 'https://gitlab.com/' .. slug))
+end
+
+local function codeberg_scope(repo)
+  return assert(require('forge.scope').from_url('codeberg', 'https://codeberg.org/owner/' .. repo))
 end
 
 describe('current_pr resolver', function()
@@ -33,8 +33,39 @@ describe('current_pr resolver', function()
   local github = {
     name = 'github',
     labels = {
+      pr = 'PRs',
       pr_one = 'PR',
       pr_full = 'PRs',
+    },
+    pr_for_branch_cmd = function(_, branch, scope)
+      return { 'pr-for-branch', branch, scope and scope.slug or '' }
+    end,
+    fetch_pr_details_cmd = function(_, num, scope)
+      return { 'fetch-pr', num, scope and scope.slug or '' }
+    end,
+  }
+
+  local gitlab = {
+    name = 'gitlab',
+    labels = {
+      pr = 'Merge Requests',
+      pr_one = 'MR',
+      pr_full = 'Merge Requests',
+    },
+    pr_for_branch_cmd = function(_, branch, scope)
+      return { 'pr-for-branch', branch, scope and scope.slug or '' }
+    end,
+    fetch_pr_details_cmd = function(_, num, scope)
+      return { 'fetch-pr', num, scope and scope.slug or '' }
+    end,
+  }
+
+  local codeberg = {
+    name = 'codeberg',
+    labels = {
+      pr = 'PRs',
+      pr_one = 'PR',
+      pr_full = 'Pull Requests',
     },
     pr_for_branch_cmd = function(_, branch, scope)
       return { 'pr-for-branch', branch, scope and scope.slug or '' }
@@ -106,7 +137,7 @@ describe('current_pr resolver', function()
     assert.is_nil(err)
     assert.same({
       num = '17',
-      scope = repo_scope('upstream'),
+      scope = github_scope('upstream'),
     }, pr)
   end)
 
@@ -174,7 +205,7 @@ describe('current_pr resolver', function()
     assert.is_nil(err)
     assert.same({
       num = '42',
-      scope = repo_scope('upstream'),
+      scope = github_scope('upstream'),
     }, pr)
     assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch feature owner/fork'))
     assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch feature owner/upstream'))
@@ -213,10 +244,91 @@ describe('current_pr resolver', function()
     assert.is_nil(err)
     assert.same({
       num = '57',
-      scope = repo_scope('upstream'),
+      scope = github_scope('upstream'),
     }, pr)
     assert.is_true(vim.tbl_contains(captured.systems, 'git config branch.topic.pushRemote'))
     assert.is_false(vim.tbl_contains(captured.systems, 'git branch --show-current'))
+  end)
+
+  it('matches GitLab merge requests by source project and branch', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@gitlab.com:group/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@gitlab.com:group/fork.git\n'),
+      ['pr-for-branch topic group/upstream'] = helpers.command_result('8\n'),
+      ['fetch-pr 8 group/upstream'] = helpers.command_result(vim.json.encode({
+        source_branch = 'topic',
+        source_project_id = 101,
+      })),
+      ['glab api --hostname gitlab.com projects/group%2Ffork'] = helpers.command_result(
+        vim.json.encode({ id = 101 })
+      ),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = gitlab,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '8',
+      scope = gitlab_scope('group/upstream'),
+    }, pr)
+  end)
+
+  it('matches Codeberg pull requests by head repo and branch', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@codeberg.org:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@codeberg.org:owner/fork.git\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('13\n'),
+      ['fetch-pr 13 owner/upstream'] = helpers.command_result(vim.json.encode({
+        head = {
+          ref = 'topic',
+          repo = {
+            full_name = 'owner/fork',
+          },
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = codeberg,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '13',
+      scope = codeberg_scope('upstream'),
+    }, pr)
+  end)
+
+  it('uses existing fetch-style error phrasing for resolver failures', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('', 1),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(pr)
+    assert.same({
+      code = 'lookup_failed',
+      message = 'failed to fetch PRs',
+    }, err)
   end)
 
   it('reports ambiguity when multiple PRs match the same head', function()
@@ -257,5 +369,28 @@ describe('current_pr resolver', function()
     assert.is_nil(pr)
     assert.same('ambiguous_pr', err.code)
     assert.matches('pass repo= or head=', err.message)
+  end)
+
+  it('uses existing parse-detail phrasing when PR details are malformed', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch topic owner/upstream'] = helpers.command_result('17\n'),
+      ['fetch-pr 17 owner/upstream'] = helpers.command_result('{'),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(pr)
+    assert.same({
+      code = 'lookup_failed',
+      message = 'failed to parse PR details',
+    }, err)
   end)
 end)


### PR DESCRIPTION
## Problem

The target-resolution follow-up still introduced a large LuaCATS gap around the new target and current-PR resolver shapes, and the resolver coverage remained too GitHub-specific to prove the backend-specific matching logic. A couple of fallback resolver errors also drifted from forge’s usual fetch/parse phrasing.

## Solution

Add LuaCATS for the new target and resolver types and helpers, cover GitHub, GitLab, and Codeberg current-PR matching explicitly in resolver specs, and align fallback lookup errors with the existing `failed to fetch …` and `failed to parse … details` wording used elsewhere.