### PR TITLE
feat(cmd): add implicit current-PR commands

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -37,7 +37,10 @@ local families = {
   {
     name = 'pr',
     surface = 'forge',
+    default_verb = 'open',
     verb_order = {
+      'open',
+      'ci',
       'close',
       'reopen',
       'create',
@@ -49,6 +52,14 @@ local families = {
       'refresh',
     },
     verbs = {
+      open = {
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head' },
+      },
+      ci = {
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head' },
+      },
       close = {
         subject = { kind = 'pr', min = 1, max = 1 },
         modifiers = { 'repo' },
@@ -94,8 +105,8 @@ local families = {
     verb_order = { 'open' },
     verbs = {
       open = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo', 'adapter' },
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head', 'adapter' },
       },
     },
   },
@@ -211,6 +222,13 @@ local function split_words(text)
     words[#words + 1] = word
   end
   return words
+end
+
+local function token_is_modifier_like(token)
+  if type(token) ~= 'string' then
+    return false
+  end
+  return token:match('^%-%-') ~= nil or token:find('=', 1, true) ~= nil
 end
 
 local function list_contains(items, value)
@@ -371,6 +389,39 @@ local function resolve_scope_modifier(command, forge_name)
   return target.resolve_scope(repo, forge_name, target_parse_opts())
 end
 
+local function resolve_repo_modifier(command, forge_name)
+  local target = require('forge.target')
+  local repo = repo_target(command.parsed_modifiers.repo)
+    or repo_target(command.default_targets.repo)
+  return target.resolve_scope(repo, forge_name, target_parse_opts())
+end
+
+local function current_pr_resolution_opts(command, f)
+  local opts = {
+    forge = f,
+  }
+  if command.parsed_modifiers.repo ~= nil then
+    opts.repo = command.parsed_modifiers.repo
+  end
+  if command.parsed_modifiers.head ~= nil then
+    opts.head = command.parsed_modifiers.head
+  end
+  return opts
+end
+
+local function resolve_current_pr_or_warn(command, f)
+  local pr, err = require('forge').current_pr(current_pr_resolution_opts(command, f))
+  if err then
+    warn(err.message)
+    return nil
+  end
+  if pr then
+    return pr
+  end
+  warn(('no open %s found for this branch'):format((f.labels and f.labels.pr_one) or 'PR'))
+  return nil
+end
+
 local function dispatch_pr(command)
   if not require_git_or_warn() then
     return
@@ -380,12 +431,12 @@ local function dispatch_pr(command)
     return
   end
   local num = command.subjects[1]
-  local scope = resolve_scope_modifier(command, f.name)
   if command.name == 'create' then
     local target = require('forge.target')
     local parse_opts = target_parse_opts()
     local head = command.parsed_modifiers.head or command.default_targets.head
     local base = command.parsed_modifiers.base or command.default_targets.base
+    local scope = resolve_repo_modifier(command, f.name)
     ops.pr_create({
       draft = command.modifiers.draft == true,
       instant = command.modifiers.fill == true,
@@ -398,6 +449,33 @@ local function dispatch_pr(command)
     })
     return
   end
+  if command.name == 'open' then
+    if num then
+      ops.pr_edit({ num = num, scope = resolve_repo_modifier(command, f.name) })
+      return
+    end
+    local pr = resolve_current_pr_or_warn(command, f)
+    if not pr then
+      return
+    end
+    ops.pr_edit(pr)
+    return
+  end
+  if command.name == 'ci' then
+    local pr = num and { num = num, scope = resolve_repo_modifier(command, f.name) }
+      or resolve_current_pr_or_warn(command, f)
+    if not pr then
+      return
+    end
+    ops.pr_ci(f, pr)
+    return
+  end
+  if command.name == 'refresh' then
+    require('forge').clear_list_kind('pr')
+    require('forge.logger').info('refreshed ' .. ((f.labels and f.labels.pr) or 'pr') .. ' list')
+    return
+  end
+  local scope = resolve_repo_modifier(command, f.name)
   if command.name == 'edit' then
     ops.pr_edit({ num = num, scope = scope })
     return
@@ -426,11 +504,6 @@ local function dispatch_pr(command)
     ops.pr_reopen(f, { num = num, scope = scope })
     return
   end
-  if command.name == 'refresh' then
-    require('forge').clear_list_kind('pr')
-    require('forge.logger').info('refreshed ' .. ((f.labels and f.labels.pr) or 'pr') .. ' list')
-    return
-  end
   warn(('unsupported pr action: %s'):format(command.name))
 end
 
@@ -443,10 +516,18 @@ local function dispatch_review(command)
     return
   end
   local num = command.subjects[1]
-  local scope = resolve_scope_modifier(command, f.name)
-  ops.pr_review(f, { num = num, scope = scope }, {
+  local opts = {
     adapter = command.modifiers.adapter ~= true and command.modifiers.adapter or nil,
-  })
+  }
+  if num then
+    ops.pr_review(f, { num = num, scope = resolve_repo_modifier(command, f.name) }, opts)
+    return
+  end
+  local pr = resolve_current_pr_or_warn(command, f)
+  if not pr then
+    return
+  end
+  ops.pr_review(f, pr, opts)
 end
 
 local function dispatch_issue(command)
@@ -458,7 +539,7 @@ local function dispatch_issue(command)
     return
   end
   local num = command.subjects[1]
-  local scope = resolve_scope_modifier(command, f.name)
+  local scope = resolve_repo_modifier(command, f.name)
   if command.name == 'create' then
     local template = command.modifiers.template
     ops.issue_create({
@@ -505,7 +586,7 @@ local function dispatch_ci(command)
   if not f then
     return
   end
-  local scope = resolve_scope_modifier(command, f.name)
+  local scope = resolve_repo_modifier(command, f.name)
   if command.name == 'open' then
     ops.ci_open(f, { id = command.subjects[1], scope = scope })
     return
@@ -536,7 +617,7 @@ local function dispatch_release(command)
     return
   end
   local tag = command.subjects[1]
-  local scope = resolve_scope_modifier(command, f.name)
+  local scope = resolve_repo_modifier(command, f.name)
   if command.name == 'browse' then
     if tag then
       ops.release_browse(f, { tag = tag, scope = scope })
@@ -755,6 +836,20 @@ function M.parse(args, opts)
   local has_explicit_verb = verb_token ~= nil
     and (family.verbs[verb_token] ~= nil or (family.aliases and family.aliases[verb_token] ~= nil))
   local rest_index = has_explicit_verb and 3 or 2
+  local implicit_command = not has_explicit_verb
+      and family.default_verb
+      and M.resolve(family_name, nil, opts)
+    or nil
+
+  if implicit_command and verb_token ~= nil and not token_is_modifier_like(verb_token) then
+    local subject = implicit_command.subject or {}
+    local kind = subject.kind
+    local looks_like_subject = kind ~= 'pr' and kind ~= 'issue' and kind ~= 'run'
+      or verb_token:match('^%d+$') ~= nil
+    if not looks_like_subject then
+      return error_result(unknown_verb_error(family.name, verb_token))
+    end
+  end
 
   if not has_explicit_verb and not family.default_verb then
     if verb_token ~= nil then

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -87,7 +87,8 @@ describe('command schema', function()
     local browse = cmd.resolve('browse')
     local clear = cmd.resolve('clear')
 
-    assert.is_nil(pr)
+    assert.equals('open', pr.name)
+    assert.is_true(pr.implicit)
     assert.is_nil(issue)
     assert.is_nil(ci)
     assert.is_nil(release)
@@ -99,20 +100,38 @@ describe('command schema', function()
     assert.is_true(clear.implicit)
   end)
 
-  it('rejects implicit picker forms and parses explicit direct actions', function()
+  it('parses implicit current-PR forms and explicit direct actions', function()
+    local pr = assert(cmd.parse({ 'pr' }))
+    local pr_num = assert(cmd.parse({ 'pr', '42' }))
+    local pr_ci = assert(cmd.parse({ 'pr', 'ci' }))
+    local pr_ci_num = assert(cmd.parse({ 'pr', 'ci', '42' }))
     local create = assert(cmd.parse({ 'pr', 'create', 'draft' }))
     local open = assert(cmd.parse({ 'ci', 'open', '123' }))
-    local review = assert(cmd.parse({ 'review', '42' }))
-    local _, pr_missing = cmd.parse({ 'pr' })
+    local review = assert(cmd.parse({ 'review' }))
+    local review_num = assert(cmd.parse({ 'review', '42' }))
     local _, ci_missing = cmd.parse({ 'ci' })
-    local _, review_missing = cmd.parse({ 'review' })
     local _, pr_checkout = cmd.parse({ 'pr', 'checkout', '42' })
     local _, pr_worktree = cmd.parse({ 'pr', 'worktree', '42' })
     local _, pr_browse = cmd.parse({ 'pr', 'browse' })
     local _, pr_list = cmd.parse({ 'pr', 'list' })
-    local _, pr_ci = cmd.parse({ 'pr', 'ci', '42' })
     local _, ci_log = cmd.parse({ 'ci', 'log', '123' })
     local _, ci_watch = cmd.parse({ 'ci', 'watch', '123' })
+
+    assert.equals('pr', pr.family)
+    assert.equals('open', pr.name)
+    assert.same({}, pr.subjects)
+
+    assert.equals('pr', pr_num.family)
+    assert.equals('open', pr_num.name)
+    assert.same({ '42' }, pr_num.subjects)
+
+    assert.equals('pr', pr_ci.family)
+    assert.equals('ci', pr_ci.name)
+    assert.same({}, pr_ci.subjects)
+
+    assert.equals('pr', pr_ci_num.family)
+    assert.equals('ci', pr_ci_num.name)
+    assert.same({ '42' }, pr_ci_num.subjects)
 
     assert.equals('pr', create.family)
     assert.equals('create', create.name)
@@ -124,16 +143,17 @@ describe('command schema', function()
 
     assert.equals('review', review.family)
     assert.equals('open', review.name)
-    assert.same({ '42' }, review.subjects)
+    assert.same({}, review.subjects)
 
-    assert.equals('missing action', pr_missing.message)
+    assert.equals('review', review_num.family)
+    assert.equals('open', review_num.name)
+    assert.same({ '42' }, review_num.subjects)
+
     assert.equals('missing action', ci_missing.message)
-    assert.equals('missing PR number', review_missing.message)
     assert.equals('unknown pr action: checkout', pr_checkout.message)
     assert.equals('unknown pr action: worktree', pr_worktree.message)
     assert.equals('unknown pr action: browse', pr_browse.message)
     assert.equals('unknown pr action: list', pr_list.message)
-    assert.equals('unknown pr action: ci', pr_ci.message)
     assert.equals('unknown action: log', ci_log.message)
     assert.equals('unknown action: watch', ci_watch.message)
   end)
@@ -181,6 +201,34 @@ describe('command schema', function()
     assert.same({ start_line = 10, end_line = 20 }, browse_target.parsed_modifiers.target.range)
   end)
 
+  it('attaches implicit current-PR disambiguation modifiers to normalized commands', function()
+    local pr = assert(cmd.parse({ 'pr', 'repo=upstream', 'head=origin@topic' }))
+    local review = assert(cmd.parse({
+      'review',
+      'repo=upstream',
+      'head=origin@topic',
+      'adapter=worktree',
+    }))
+    local pr_ci = assert(cmd.parse({ 'pr', 'ci', 'repo=upstream', 'head=origin@topic' }))
+
+    assert.equals('open', pr.name)
+    assert.same({}, pr.subjects)
+    assert.equals('owner/upstream', pr.parsed_modifiers.repo.slug)
+    assert.equals('topic', pr.parsed_modifiers.head.rev)
+    assert.equals('owner/current', pr.parsed_modifiers.head.repo.slug)
+
+    assert.equals('open', review.name)
+    assert.same({}, review.subjects)
+    assert.equals('worktree', review.modifiers.adapter)
+    assert.equals('owner/upstream', review.parsed_modifiers.repo.slug)
+    assert.equals('topic', review.parsed_modifiers.head.rev)
+
+    assert.equals('ci', pr_ci.name)
+    assert.same({}, pr_ci.subjects)
+    assert.equals('owner/upstream', pr_ci.parsed_modifiers.repo.slug)
+    assert.equals('topic', pr_ci.parsed_modifiers.head.rev)
+  end)
+
   it('attaches default target policy for omitted direct-action addresses', function()
     local create = assert(cmd.parse({ 'pr', 'create' }))
 
@@ -196,19 +244,23 @@ describe('command schema', function()
   end)
 
   it('exposes per-verb modifiers for canonical operations', function()
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('pr'))
     assert.same(
       { 'repo', 'head', 'base', 'draft', 'fill', 'web' },
       cmd.modifier_names('pr', 'create')
     )
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'ci'))
     assert.same({ 'repo' }, cmd.modifier_names('ci', 'open'))
     assert.same({ 'repo' }, cmd.modifier_names('ci', 'browse'))
     assert.same({ 'repo', 'web', 'blank', 'template' }, cmd.modifier_names('issue', 'create'))
     assert.same({ 'repo', 'method' }, cmd.modifier_names('pr', 'merge'))
-    assert.same({ 'repo', 'adapter' }, cmd.modifier_names('review'))
+    assert.same({ 'repo', 'head', 'adapter' }, cmd.modifier_names('review'))
   end)
 
   it('keeps direct forge verbs aligned with canonical non-list operations', function()
     assert.same({
+      'open',
+      'ci',
       'close',
       'reopen',
       'create',

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -82,6 +82,9 @@ describe(':Forge command', function()
     captured = {
       opens = {},
       ops_calls = {},
+      current_pr_calls = {},
+      current_pr_result = nil,
+      current_pr_error = nil,
       pr_action_num = nil,
       pr_action_scope = nil,
       warnings = {},
@@ -305,6 +308,10 @@ describe(':Forge command', function()
         end,
         create_pr = function(opts)
           captured.create_pr = opts
+        end,
+        current_pr = function(opts)
+          table.insert(captured.current_pr_calls, opts)
+          return captured.current_pr_result, captured.current_pr_error
         end,
         edit_pr = function(num)
           captured.edit_pr = num
@@ -563,10 +570,8 @@ describe(':Forge command', function()
     end
   end)
 
-  it('warns instead of opening interactive surfaces for missing or UI-only commands', function()
+  it('warns instead of opening interactive surfaces for missing or unsupported commands', function()
     vim.cmd('Forge')
-    vim.cmd('Forge pr')
-    vim.cmd('Forge review')
     vim.cmd('Forge pr checkout 42')
     vim.cmd('Forge pr worktree 42')
     vim.cmd('Forge pr browse 42')
@@ -578,8 +583,6 @@ describe(':Forge command', function()
 
     assert.same({
       'missing command',
-      'missing action',
-      'missing PR number',
       'unknown pr action: checkout',
       'unknown pr action: worktree',
       'unknown pr action: browse',
@@ -591,6 +594,99 @@ describe(':Forge command', function()
     }, captured.warnings)
     assert.is_nil(captured.opens[1])
     assert.is_nil(captured.ops_calls[1])
+  end)
+
+  it('dispatches implicit current-PR commands through forge.current_pr', function()
+    captured.current_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+
+    vim.cmd('Forge pr')
+    vim.cmd('Forge review adapter=worktree')
+    vim.cmd('Forge pr ci')
+
+    assert.equals(3, #captured.current_pr_calls)
+    assert.equals('github', captured.current_pr_calls[1].forge.name)
+    assert.is_nil(captured.current_pr_calls[1].repo)
+    assert.is_nil(captured.current_pr_calls[1].head)
+    assert.equals('github', captured.current_pr_calls[2].forge.name)
+    assert.equals('github', captured.current_pr_calls[3].forge.name)
+    assert.same({
+      name = 'pr_edit',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '42', scope = repo_scope('upstream') },
+      opts = { adapter = 'worktree' },
+    }, captured.ops_calls[2])
+    assert.same({
+      name = 'pr_ci',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[3])
+    assert.same({}, captured.warnings)
+  end)
+
+  it('passes repo= and head= disambiguation through implicit current-PR commands', function()
+    captured.current_pr_result = {
+      num = '57',
+      scope = repo_scope('upstream'),
+    }
+
+    vim.cmd('Forge pr repo=upstream head=origin@topic')
+    vim.cmd('Forge review repo=upstream head=origin@topic adapter=worktree')
+    vim.cmd('Forge pr ci repo=upstream head=origin@topic')
+
+    for _, call in ipairs(captured.current_pr_calls) do
+      assert.equals('github', call.forge.name)
+      assert.equals('repo', call.repo.kind)
+      assert.equals('owner/upstream', call.repo.slug)
+      assert.equals('rev', call.head.kind)
+      assert.equals('topic', call.head.rev)
+      assert.equals('owner/current', call.head.repo.slug)
+    end
+
+    assert.same({
+      name = 'pr_edit',
+      pr = { num = '57', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_review',
+      pr = { num = '57', scope = repo_scope('upstream') },
+      opts = { adapter = 'worktree' },
+    }, captured.ops_calls[2])
+    assert.same({
+      name = 'pr_ci',
+      pr = { num = '57', scope = repo_scope('upstream') },
+    }, captured.ops_calls[3])
+  end)
+
+  it('warns cleanly when implicit current-PR commands find no matching PR', function()
+    vim.cmd('Forge pr')
+    vim.cmd('Forge review')
+    vim.cmd('Forge pr ci')
+
+    assert.same({
+      'no open PR found for this branch',
+      'no open PR found for this branch',
+      'no open PR found for this branch',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('surfaces resolver errors from implicit current-PR commands', function()
+    captured.current_pr_error = {
+      code = 'ambiguous_pr',
+      message = 'multiple PRs match head owner/current@main; pass repo= or head=',
+    }
+
+    vim.cmd('Forge pr')
+
+    assert.same({
+      'multiple PRs match head owner/current@main; pass repo= or head=',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
   end)
 
   it('allows :Forge to be followed by a bar command', function()
@@ -742,6 +838,20 @@ describe(':Forge command', function()
     }, captured.ops_calls[2])
   end)
 
+  it('dispatches explicit PR open and PR checks through forge.ops', function()
+    vim.cmd('Forge pr open 42')
+    vim.cmd('Forge pr ci 42 repo=upstream')
+
+    assert.same({
+      name = 'pr_edit',
+      pr = { num = '42', scope = nil },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_ci',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[2])
+  end)
+
   it('passes ex ranges through browse file resolution', function()
     assert.equals('.', vim.api.nvim_get_commands({ builtin = false }).Forge.range)
     vim.api.nvim_buf_set_name(0, '/repo/lua/forge/init.lua')
@@ -884,14 +994,12 @@ describe(':Forge command', function()
 
   it('rejects explicit list verbs with no picker dispatch side effects', function()
     vim.cmd('Forge pr list')
-    vim.cmd('Forge pr ci 42')
     vim.cmd('Forge issue list')
     vim.cmd('Forge ci list')
     vim.cmd('Forge release list')
 
     assert.same({
       'unknown pr action: list',
-      'unknown pr action: ci',
       'unknown issue action: list',
       'unknown action: list',
       'unknown release action: list',
@@ -1038,6 +1146,8 @@ describe(':Forge command', function()
       {
         cmdline = 'Forge pr ',
         expected = {
+          'open',
+          'ci',
           'close',
           'reopen',
           'create',
@@ -1047,6 +1157,8 @@ describe(':Forge command', function()
           'draft',
           'ready',
           'refresh',
+          'repo=',
+          'head=',
         },
       },
       {
@@ -1071,7 +1183,11 @@ describe(':Forge command', function()
       },
       {
         cmdline = 'Forge review ',
-        expected = { 'open', 'repo=', 'adapter=' },
+        expected = { 'open', 'repo=', 'head=', 'adapter=' },
+      },
+      {
+        cmdline = 'Forge pr ci ',
+        expected = { 'repo=', 'head=' },
       },
       {
         cmdline = 'Forge issue browse ',
@@ -1101,6 +1217,7 @@ describe(':Forge command', function()
     local issue = completion('Forge issue ')
     local ci = completion('Forge ci ')
     local release = completion('Forge release ')
+    local pr_ci = completion('Forge pr ci ')
     local browse = completion('Forge browse ')
     local pr_create = completion('Forge pr create ')
     local issue_create = completion('Forge issue create ')
@@ -1115,25 +1232,29 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(families, 'commits'))
     assert.is_false(vim.tbl_contains(families, 'worktrees'))
 
+    assert.is_true(vim.tbl_contains(pr, 'open'))
+    assert.is_true(vim.tbl_contains(pr, 'ci'))
     assert.is_true(vim.tbl_contains(pr, 'create'))
     assert.is_true(vim.tbl_contains(pr, 'approve'))
     assert.is_true(vim.tbl_contains(pr, 'merge'))
     assert.is_true(vim.tbl_contains(pr, 'draft'))
     assert.is_true(vim.tbl_contains(pr, 'ready'))
     assert.is_true(vim.tbl_contains(pr, 'refresh'))
+    assert.is_true(vim.tbl_contains(pr, 'repo='))
+    assert.is_true(vim.tbl_contains(pr, 'head='))
     assert.is_false(vim.tbl_contains(pr, 'checkout'))
     assert.is_false(vim.tbl_contains(pr, 'worktree'))
     assert.is_false(vim.tbl_contains(pr, 'browse'))
-    assert.is_false(vim.tbl_contains(pr, 'ci'))
+    assert.is_false(vim.tbl_contains(pr, 'state='))
     assert.is_true(vim.tbl_contains(review, 'adapter='))
     assert.is_true(vim.tbl_contains(review, 'repo='))
+    assert.is_true(vim.tbl_contains(review, 'head='))
     assert.is_true(vim.tbl_contains(ci, 'open'))
     assert.is_true(vim.tbl_contains(ci, 'browse'))
     assert.is_true(vim.tbl_contains(ci, 'refresh'))
     assert.is_false(vim.tbl_contains(ci, 'log'))
     assert.is_false(vim.tbl_contains(ci, 'watch'))
-    assert.is_false(vim.tbl_contains(pr, 'state='))
-    assert.is_false(vim.tbl_contains(pr, 'repo='))
+    assert.same({ 'repo=', 'head=' }, pr_ci)
     assert.is_true(vim.tbl_contains(issue, 'edit'))
     assert.is_true(vim.tbl_contains(issue, 'refresh'))
     assert.is_true(vim.tbl_contains(release, 'browse'))
@@ -1168,6 +1289,8 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(families, 'mr'))
     assert.is_true(vim.tbl_contains(families, 'pipeline'))
     assert.same({
+      'open',
+      'ci',
       'close',
       'reopen',
       'create',
@@ -1177,6 +1300,8 @@ describe(':Forge command', function()
       'draft',
       'ready',
       'refresh',
+      'repo=',
+      'head=',
     }, mr)
     assert.same({ 'open', 'browse', 'refresh' }, pipeline)
   end)
@@ -1185,19 +1310,25 @@ describe(':Forge command', function()
     'completes local-only and static modifier values without consulting forge entity lists',
     function()
       local repos = completion('Forge pr create repo=')
+      local current_pr_repos = completion('Forge pr repo=')
       local branches = completion('Forge browse branch=')
       local commits = completion('Forge browse commit=')
       local targets = completion('Forge browse target=')
       local heads = completion('Forge pr create head=')
       local bases = completion('Forge pr create base=')
+      local current_pr_heads = completion('Forge pr head=')
+      local review_heads = completion('Forge review head=')
+      local pr_ci_heads = completion('Forge pr ci head=')
       local templates = completion('Forge issue create template=')
       local adapters = completion('Forge review 42 adapter=')
       local methods = completion('Forge pr merge method=')
 
-      assert.is_true(vim.tbl_contains(repos, 'repo=work'))
-      assert.is_true(vim.tbl_contains(repos, 'repo=mirror'))
-      assert.is_true(vim.tbl_contains(repos, 'repo=origin'))
-      assert.is_true(vim.tbl_contains(repos, 'repo=upstream'))
+      for _, values in ipairs({ repos, current_pr_repos }) do
+        assert.is_true(vim.tbl_contains(values, 'repo=work'))
+        assert.is_true(vim.tbl_contains(values, 'repo=mirror'))
+        assert.is_true(vim.tbl_contains(values, 'repo=origin'))
+        assert.is_true(vim.tbl_contains(values, 'repo=upstream'))
+      end
 
       assert.is_true(vim.tbl_contains(branches, 'branch=main'))
       assert.is_true(vim.tbl_contains(branches, 'branch=feature'))
@@ -1214,8 +1345,15 @@ describe(':Forge command', function()
       assert.is_true(vim.tbl_contains(targets, 'target=@main:'))
       assert.is_true(vim.tbl_contains(targets, 'target=@deadbee:'))
 
-      for _, values in ipairs({ heads, bases }) do
-        local prefix = values == heads and 'head=' or 'base='
+      for _, case in ipairs({
+        { values = heads, prefix = 'head=' },
+        { values = bases, prefix = 'base=' },
+        { values = current_pr_heads, prefix = 'head=' },
+        { values = review_heads, prefix = 'head=' },
+        { values = pr_ci_heads, prefix = 'head=' },
+      }) do
+        local values = case.values
+        local prefix = case.prefix
         assert.is_true(vim.tbl_contains(values, prefix .. 'work@'))
         assert.is_true(vim.tbl_contains(values, prefix .. 'origin@'))
         assert.is_true(vim.tbl_contains(values, prefix .. '@main'))
@@ -1294,26 +1432,34 @@ describe(':Forge command', function()
     captured.pr_states['owner/current#102'] = { review_decision = '', is_draft = true }
     captured.pr_states['owner/current#103'] = { review_decision = 'APPROVED', is_draft = false }
 
+    local pr = vim.fn.getcompletion('Forge pr ', 'cmdline')
     local close = vim.fn.getcompletion('Forge pr close ', 'cmdline')
     local edit = vim.fn.getcompletion('Forge pr edit ', 'cmdline')
     local approve = vim.fn.getcompletion('Forge pr approve ', 'cmdline')
     local merge = vim.fn.getcompletion('Forge pr merge ', 'cmdline')
+    local pr_ci = vim.fn.getcompletion('Forge pr ci ', 'cmdline')
     local draft = vim.fn.getcompletion('Forge pr draft ', 'cmdline')
     local ready = vim.fn.getcompletion('Forge pr ready ', 'cmdline')
     local review = vim.fn.getcompletion('Forge review ', 'cmdline')
 
+    assert.is_true(vim.tbl_contains(pr, 'open'))
+    assert.is_true(vim.tbl_contains(pr, 'repo='))
+    assert.is_true(vim.tbl_contains(pr, 'head='))
     assert.is_true(vim.tbl_contains(close, 'repo='))
     assert.is_true(vim.tbl_contains(edit, 'repo='))
     assert.is_true(vim.tbl_contains(approve, 'repo='))
     assert.is_true(vim.tbl_contains(merge, 'repo='))
     assert.is_true(vim.tbl_contains(merge, 'method='))
+    assert.is_true(vim.tbl_contains(pr_ci, 'repo='))
+    assert.is_true(vim.tbl_contains(pr_ci, 'head='))
     assert.is_true(vim.tbl_contains(draft, 'repo='))
     assert.is_true(vim.tbl_contains(ready, 'repo='))
     assert.is_true(vim.tbl_contains(review, 'open'))
     assert.is_true(vim.tbl_contains(review, 'repo='))
+    assert.is_true(vim.tbl_contains(review, 'head='))
     assert.is_true(vim.tbl_contains(review, 'adapter='))
 
-    for _, results in ipairs({ close, edit, approve, merge, draft, ready, review }) do
+    for _, results in ipairs({ pr, close, edit, approve, merge, pr_ci, draft, ready, review }) do
       assert.is_false(vim.tbl_contains(results, '101'))
       assert.is_false(vim.tbl_contains(results, '102'))
       assert.is_false(vim.tbl_contains(results, '103'))


### PR DESCRIPTION
## Problem

Part of #389. Closes #391.

The current-PR resolver exists, but the Ex command surface still makes branch-relative PR flows indirect and inconsistent.

## Solution

Add implicit current-PR command forms for `:Forge pr`, `:Forge review`, and `:Forge pr ci`, route them through the shared current-PR resolver with explicit `repo=` and `head=` disambiguation, keep `:Forge ci` as branch CI, and cover the new command and completion flows in specs.