### PR TITLE
fix(cmd): keep pr create create-only

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -504,13 +504,12 @@ function M.create_pr(opts)
     return
   end
   if existing then
-    log.info(
-      ('%s already exists for this branch; opening edit buffer for #%s'):format(
+    log.warn(
+      ('%s already exists for this branch (#%s); use :Forge pr or :Forge review'):format(
         f.labels.pr_one,
         existing.num
       )
     )
-    M.edit_pr(existing.num, existing.scope or base_scope)
     return
   end
 

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -316,7 +316,45 @@ describe('create_pr', function()
     assert.is_nil(captured.picker)
   end)
 
-  it('logs an explicit notice and opens edit when the branch already has a PR', function()
+  it(
+    'stops create when the branch already has a PR and directs the user to current-PR commands',
+    function()
+      use_system_responses({
+        ['git config branch.feature.pushRemote'] = helpers.command_result('', 1),
+        ['git config remote.pushDefault'] = helpers.command_result('', 1),
+        ['git rev-parse --abbrev-ref feature@{upstream}'] = helpers.command_result(
+          'origin/feature\n'
+        ),
+        ['git remote'] = helpers.command_result('origin\n'),
+        ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/repo.git\n'),
+        ['pr-for-branch feature'] = helpers.command_result('23\n'),
+        ['fetch-pr 23'] = helpers.command_result(vim.json.encode({
+          title = 'Existing PR',
+          body = 'Body',
+          isDraft = false,
+          headRefName = 'feature',
+          headRepository = {
+            name = 'repo',
+            nameWithOwner = 'owner/repo',
+          },
+          headRepositoryOwner = {
+            login = 'owner',
+          },
+          baseRefName = 'main',
+        })),
+      })
+
+      require('forge').create_pr()
+
+      assert.is_nil(captured.edited)
+      assert.same({
+        'PR already exists for this branch (#23); use :Forge pr or :Forge review',
+      }, captured.warnings)
+      assert.is_false(vim.tbl_contains(captured.systems, 'default-branch'))
+    end
+  )
+
+  it('stops web create when the branch already has a PR and does not push', function()
     use_system_responses({
       ['git config branch.feature.pushRemote'] = helpers.command_result('', 1),
       ['git config remote.pushDefault'] = helpers.command_result('', 1),
@@ -342,35 +380,14 @@ describe('create_pr', function()
       })),
     })
 
-    require('forge').create_pr()
-
-    vim.wait(100, function()
-      return captured.edited ~= nil
-    end)
+    require('forge').create_pr({ web = true })
 
     assert.same({
-      num = '23',
-      details = {
-        title = 'Existing PR',
-        body = 'Body',
-        draft = false,
-        head_branch = 'feature',
-        base_branch = 'main',
-        labels = {},
-        assignees = {},
-        reviewers = {},
-        milestone = '',
-      },
-      current_branch = 'feature',
-      scope = repo_scope('repo'),
-    }, captured.edited)
-    assert.is_true(
-      vim.tbl_contains(
-        captured.infos,
-        'PR already exists for this branch; opening edit buffer for #23'
-      )
-    )
+      'PR already exists for this branch (#23); use :Forge pr or :Forge review',
+    }, captured.warnings)
     assert.is_false(vim.tbl_contains(captured.systems, 'default-branch'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'create-pr-web'))
   end)
 
   it('blocks web PR creation when the current branch already matches the base', function()


### PR DESCRIPTION
## Problem

Part of #389. Closes #392.

`:Forge pr create` still redirected into the existing-PR edit path when the branch already had an open PR, which blurred the new distinction between create flows and current-PR flows.

## Solution

Keep `:Forge pr create` strictly creation-oriented by stopping when a matching open PR already exists, warning with an actionable message that points users to `:Forge pr` or `:Forge review`, and covering both normal and web create flows in specs.