### PR TITLE
feat(api): add high-level implicit-ref Lua entrypoints

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -436,6 +436,113 @@ M.format_releases = format_mod.format_releases
 M.filter_checks = format_mod.filter_checks
 M.filter_runs = format_mod.filter_runs
 
+---@param opts forge.CurrentPROpts?
+---@param forge forge.Forge
+---@return forge.CurrentPROpts
+local function implicit_ref_opts(opts, forge)
+  return vim.tbl_extend('force', { forge = forge }, opts or {})
+end
+
+---@param opts forge.CurrentPROpts?
+---@return forge.Forge?, forge.PRRef?
+local function resolve_action_pr(opts)
+  local log = require('forge.logger')
+  local forge = M.detect()
+  if not forge then
+    log.warn('no forge detected')
+    return nil
+  end
+  local pr, err = M.current_pr(implicit_ref_opts(opts, forge))
+  if err then
+    log.warn(err.message or 'current PR lookup failed')
+    return nil
+  end
+  if pr then
+    return forge, pr
+  end
+  log.warn(('no open %s found for this branch'):format(forge.labels.pr_one or 'PR'))
+  return nil
+end
+
+---@param opts forge.BranchCIOpts?
+---@return forge.Forge?, forge.HeadRef?
+local function resolve_ci_head(opts)
+  local log = require('forge.logger')
+  local forge = M.detect()
+  if not forge then
+    log.warn('no forge detected')
+    return nil
+  end
+
+  opts = opts or {}
+  local head_input = opts.head
+  if
+    head_input == nil and (opts.branch ~= nil or opts.head_branch ~= nil or opts.head_scope ~= nil)
+  then
+    head_input = {
+      branch = opts.branch or opts.head_branch,
+      scope = opts.head_scope,
+    }
+  end
+
+  local head, head_err = resolve_mod.head(head_input, implicit_ref_opts(opts, forge))
+  if not head then
+    log.warn((head_err and head_err.message) or 'invalid head')
+    return nil
+  end
+
+  if opts.repo ~= nil or opts.scope ~= nil then
+    local scope, scope_err = resolve_mod.repo(nil, implicit_ref_opts(opts, forge))
+    if scope_err then
+      log.warn(scope_err.message or 'invalid repo address')
+      return nil
+    end
+    head.scope = scope or head.scope
+  end
+
+  return forge, head
+end
+
+---@param opts forge.CurrentPROpts?
+function M.pr(opts)
+  local _, pr = resolve_action_pr(opts)
+  if not pr then
+    return
+  end
+  require('forge.ops').pr_edit(pr)
+end
+
+---@param opts forge.ReviewOpts?
+function M.review(opts)
+  local forge, pr = resolve_action_pr(opts)
+  if not forge or not pr then
+    return
+  end
+  require('forge.ops').pr_review(forge, pr, {
+    adapter = type(opts) == 'table' and opts.adapter or nil,
+  })
+end
+
+---@param opts forge.CurrentPROpts?
+function M.pr_ci(opts)
+  local forge, pr = resolve_action_pr(opts)
+  if not forge or not pr then
+    return
+  end
+  require('forge.ops').pr_ci(forge, pr)
+end
+
+---@param opts forge.BranchCIOpts?
+function M.ci(opts)
+  local _, head = resolve_ci_head(opts)
+  if not head then
+    return
+  end
+  require('forge.ops').ci_list(head.branch, {
+    scope = head.scope,
+  })
+end
+
 ---@param opts forge.CreatePROpts?
 function M.create_pr(opts)
   opts = opts or {}

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -279,6 +279,12 @@
 ---@field project_id string?
 ---@field target_opts forge.TargetParseOpts?
 
+---@class forge.ReviewOpts: forge.CurrentPROpts
+---@field adapter string?
+
+---@class forge.BranchCIOpts: forge.CurrentPROpts
+---@field branch string?
+
 ---@class forge.CreateIssueOpts
 ---@field web boolean?
 ---@field blank boolean?

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -1,0 +1,421 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+local preload_modules = {
+  'forge.action',
+  'forge.backends.github',
+  'forge.cache',
+  'forge.compose',
+  'forge.config',
+  'forge.context',
+  'forge.format',
+  'forge.logger',
+  'forge.ops',
+  'forge.resolve',
+  'forge.review',
+  'forge.routes',
+  'forge.scope',
+  'forge.target',
+  'forge.template',
+}
+
+local loaded_modules = vim.list_extend({ 'forge' }, preload_modules)
+
+local function repo_scope(repo)
+  return {
+    kind = 'github',
+    host = 'github.com',
+    owner = 'owner',
+    repo = repo,
+    slug = 'owner/' .. repo,
+    repo_arg = 'owner/' .. repo,
+    web_url = 'https://github.com/owner/' .. repo,
+  }
+end
+
+describe('high-level implicit-ref API', function()
+  local captured
+  local old_fn_system
+  local old_executable
+  local old_preload
+
+  before_each(function()
+    captured = {
+      current_pr_calls = {},
+      current_pr_error = nil,
+      current_pr_result = nil,
+      errors = {},
+      head_calls = {},
+      head_error = nil,
+      head_result = nil,
+      infos = {},
+      ops_calls = {},
+      repo_calls = {},
+      repo_error = nil,
+      repo_result = nil,
+      warnings = {},
+    }
+
+    old_fn_system = vim.fn.system
+    old_executable = vim.fn.executable
+    old_preload = helpers.capture_preload(preload_modules)
+
+    vim.fn.executable = function(bin)
+      if bin == 'gh' then
+        return 1
+      end
+      return 0
+    end
+
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/current.git\n'
+      end
+      if cmd == 'git branch --show-current' then
+        return 'feature\n'
+      end
+      return ''
+    end
+
+    package.preload['forge.action'] = function()
+      return {
+        register = function() end,
+        run = function() end,
+      }
+    end
+
+    package.preload['forge.backends.github'] = function()
+      return {
+        name = 'github',
+        cli = 'gh',
+        labels = {
+          ci = 'CI',
+          pr_one = 'PR',
+        },
+      }
+    end
+
+    package.preload['forge.cache'] = function()
+      return {
+        new = function()
+          return {
+            clear = function() end,
+            clear_prefix = function() end,
+            get = function()
+              return nil
+            end,
+            set = function() end,
+          }
+        end,
+      }
+    end
+
+    package.preload['forge.compose'] = function()
+      return {}
+    end
+
+    package.preload['forge.config'] = function()
+      return {
+        config = function()
+          return {
+            sources = {
+              github = { hosts = { 'github.com' } },
+              gitlab = { hosts = { 'gitlab.com' } },
+              codeberg = { hosts = { 'codeberg.org', 'gitea.com', 'forgejo.org' } },
+            },
+          }
+        end,
+      }
+    end
+
+    package.preload['forge.context'] = function()
+      return {
+        register = function() end,
+      }
+    end
+
+    package.preload['forge.format'] = function()
+      return {}
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        error = function(msg)
+          table.insert(captured.errors, msg)
+        end,
+        info = function(msg)
+          table.insert(captured.infos, msg)
+        end,
+        warn = function(msg)
+          table.insert(captured.warnings, msg)
+        end,
+      }
+    end
+
+    package.preload['forge.ops'] = function()
+      return {
+        ci_list = function(branch, opts)
+          table.insert(captured.ops_calls, { name = 'ci_list', branch = branch, opts = opts or {} })
+        end,
+        pr_ci = function(f, pr, opts)
+          table.insert(captured.ops_calls, { name = 'pr_ci', f = f, pr = pr, opts = opts })
+        end,
+        pr_edit = function(pr)
+          table.insert(captured.ops_calls, { name = 'pr_edit', pr = pr })
+        end,
+        pr_review = function(f, pr, opts)
+          table.insert(
+            captured.ops_calls,
+            { name = 'pr_review', f = f, pr = pr, opts = opts or {} }
+          )
+        end,
+      }
+    end
+
+    package.preload['forge.resolve'] = function()
+      return {
+        current_pr = function(opts)
+          table.insert(captured.current_pr_calls, opts)
+          return captured.current_pr_result, captured.current_pr_error
+        end,
+        head = function(head, opts)
+          table.insert(captured.head_calls, { head = head, opts = opts })
+          return captured.head_result, captured.head_error
+        end,
+        repo = function(repo, opts)
+          table.insert(captured.repo_calls, { repo = repo, opts = opts })
+          return captured.repo_result, captured.repo_error
+        end,
+      }
+    end
+
+    package.preload['forge.review'] = function()
+      return {
+        names = function()
+          return {}
+        end,
+        register = function() end,
+      }
+    end
+
+    package.preload['forge.routes'] = function()
+      return {
+        current_context = function()
+          return nil
+        end,
+        open = function() end,
+      }
+    end
+
+    package.preload['forge.scope'] = function()
+      return {
+        from_url = function(kind, url)
+          local host, owner, repo = url:match('^https://([^/]+)/([^/]+)/([^/]+)$')
+          return {
+            kind = kind,
+            host = host,
+            owner = owner,
+            repo = repo,
+            slug = owner .. '/' .. repo,
+            repo_arg = owner .. '/' .. repo,
+            web_url = url,
+          }
+        end,
+        key = function(scope)
+          if type(scope) ~= 'table' then
+            return ''
+          end
+          return table.concat({
+            scope.kind or '',
+            scope.host or '',
+            scope.slug or '',
+          }, '|')
+        end,
+        remote_name = function(scope)
+          return type(scope) == 'table' and scope.repo or nil
+        end,
+        remote_ref = function(scope, branch)
+          return ((type(scope) == 'table' and scope.repo) or 'origin') .. '/' .. branch
+        end,
+        same = function(a, b)
+          return (a and a.kind or '') == (b and b.kind or '')
+            and (a and a.host or '') == (b and b.host or '')
+            and (a and a.slug or '') == (b and b.slug or '')
+        end,
+        web_url = function(scope)
+          return type(scope) == 'table' and scope.web_url or ''
+        end,
+      }
+    end
+
+    package.preload['forge.target'] = function()
+      return {}
+    end
+
+    package.preload['forge.template'] = function()
+      return {}
+    end
+
+    helpers.clear_loaded(loaded_modules)
+  end)
+
+  after_each(function()
+    vim.fn.system = old_fn_system
+    vim.fn.executable = old_executable
+
+    helpers.restore_preload(old_preload)
+    helpers.clear_loaded(loaded_modules)
+  end)
+
+  it('opens the current PR through the high-level pr() entrypoint', function()
+    captured.current_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+
+    require('forge').pr()
+
+    assert.equals(1, #captured.current_pr_calls)
+    assert.equals('github', captured.current_pr_calls[1].forge.name)
+    assert.same({
+      name = 'pr_edit',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({}, captured.warnings)
+  end)
+
+  it('routes review() and pr_ci() through current_pr() with explicit address opts', function()
+    captured.current_pr_result = {
+      num = '57',
+      scope = repo_scope('upstream'),
+    }
+
+    local forge = require('forge')
+    forge.review({ repo = 'upstream', head = 'origin@topic', adapter = 'worktree' })
+    forge.pr_ci({ repo = 'upstream', head = 'origin@topic' })
+
+    assert.equals(2, #captured.current_pr_calls)
+    for _, call in ipairs(captured.current_pr_calls) do
+      assert.equals('github', call.forge.name)
+      assert.equals('upstream', call.repo)
+      assert.equals('origin@topic', call.head)
+    end
+    assert.same({
+      name = 'pr_review',
+      f = {
+        name = 'github',
+        cli = 'gh',
+        labels = {
+          ci = 'CI',
+          pr_one = 'PR',
+        },
+      },
+      pr = { num = '57', scope = repo_scope('upstream') },
+      opts = { adapter = 'worktree' },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_ci',
+      f = {
+        name = 'github',
+        cli = 'gh',
+        labels = {
+          ci = 'CI',
+          pr_one = 'PR',
+        },
+      },
+      pr = { num = '57', scope = repo_scope('upstream') },
+      opts = nil,
+    }, captured.ops_calls[2])
+  end)
+
+  it('opens current-branch CI through ci() and supports explicit head targeting', function()
+    local forge = require('forge')
+
+    captured.head_result = {
+      branch = 'feature',
+      scope = repo_scope('current'),
+    }
+    forge.ci()
+
+    captured.head_result = {
+      branch = 'release',
+      scope = repo_scope('upstream'),
+    }
+    forge.ci({ head = 'upstream@release' })
+
+    assert.equals(2, #captured.head_calls)
+    assert.is_nil(captured.head_calls[1].head)
+    assert.equals('upstream@release', captured.head_calls[2].head)
+    assert.same({
+      name = 'ci_list',
+      branch = 'feature',
+      opts = { scope = repo_scope('current') },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'ci_list',
+      branch = 'release',
+      opts = { scope = repo_scope('upstream') },
+    }, captured.ops_calls[2])
+    assert.same({}, captured.repo_calls)
+  end)
+
+  it('uses explicit repo targeting for ci() when only the repo is overridden', function()
+    captured.head_result = {
+      branch = 'feature',
+      scope = repo_scope('current'),
+    }
+    captured.repo_result = repo_scope('upstream')
+
+    require('forge').ci({ repo = 'upstream' })
+
+    assert.equals(1, #captured.repo_calls)
+    assert.is_nil(captured.repo_calls[1].repo)
+    assert.equals('upstream', captured.repo_calls[1].opts.repo)
+    assert.same({
+      name = 'ci_list',
+      branch = 'feature',
+      opts = { scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+  end)
+
+  it('warns cleanly when no current PR matches the high-level current-ref entrypoints', function()
+    local forge = require('forge')
+
+    forge.pr()
+    forge.review()
+    forge.pr_ci()
+
+    assert.same({
+      'no open PR found for this branch',
+      'no open PR found for this branch',
+      'no open PR found for this branch',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('surfaces resolver warnings from the high-level current-ref entrypoints', function()
+    captured.current_pr_error = {
+      code = 'ambiguous_pr',
+      message = 'multiple PRs match head owner/current@main; pass repo= or head=',
+    }
+    captured.head_error = {
+      code = 'detached_head',
+      message = 'detached HEAD',
+    }
+
+    local forge = require('forge')
+    forge.pr()
+    forge.ci()
+
+    assert.same({
+      'multiple PRs match head owner/current@main; pass repo= or head=',
+      'detached HEAD',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+end)


### PR DESCRIPTION
## Problem

Lua callers still have to rebuild implicit current-ref resolution themselves even though the Ex command surface already supports current-PR and current-branch actions.

## Solution

Add `forge.pr()`, `forge.review()`, `forge.pr_ci()`, and `forge.ci()` so the high-level Lua API mirrors the new Ex semantics, reuse the existing resolver flow for PR and branch targeting, add LuaCATS for the new option shapes, and cover the entrypoints with dedicated API specs.

Closes #393.