### PR TITLE
refactor(api): tighten public implicit-ref surface

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -940,15 +940,12 @@ The canonical order is:
    current-ref actions.
 3. `require('forge').current_pr(opts?)` when you need the resolved PR ref
    without running an action.
-4. `require('forge.ops').<action>()` only when you already have the exact
-   target and need the low-level verb layer.
-5. `require('forge.picker').pick()` for custom picker UIs.
+4. `require('forge.picker').pick()` for custom picker UIs.
 
 Routes are still the highest-level and most stable surface. The top-level
-current-ref helpers mirror the Ex command semantics. `require('forge.ops')`
-remains the low-level target-known layer used by `:Forge` and the built-in
-picker actions. `forge.picker.pick()` is the low-level UI primitive wired to
-`fzf-lua`.
+current-ref helpers mirror the Ex command semantics, including explicit
+`num=` targeting for PR actions. `forge.picker.pick()` is the low-level UI
+primitive wired to `fzf-lua`.
 On GitLab, route arguments also accept provider-native aliases such as `mrs`,
 `mrs.open`, `pipelines`, and `pipelines.current_branch`.
 
@@ -968,23 +965,17 @@ For common current-ref workflows, call `require('forge')` directly. These
 helpers mirror the Ex surface and reuse the shared resolver layer. >lua
     local forge = require('forge')
     forge.pr()
+    forge.pr({ num = '42' })
     forge.review({ adapter = 'browse' })
+    forge.review({ num = '42', adapter = 'browse' })
     forge.pr_ci({ repo = 'upstream', head = 'origin@topic' })
+    forge.pr_ci({ num = '42' })
     forge.ci({ repo = 'upstream' })
 <
 
-CALLING LOW-LEVEL VERBS                         *forge-extending-low-level*
-
-When you already have the exact target in hand, call `require('forge.ops')`.
-This remains the layer used by `:Forge` and the built-in picker actions, but
-it is no longer the first stop for common current-ref workflows. >lua
-    local forge = require('forge')
-    local f = assert(forge.detect(), 'no forge detected')
-    local pr = assert(forge.current_pr({ repo = 'upstream' }))
-    require('forge.ops').pr_review(f, pr, { adapter = 'browse' })
-<
-
-See |forge-ops| for the full verb inventory.
+Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua` power
+the built-in commands and pickers, but they are no longer documented as the
+public integration surface.
 
 BUILDING A CUSTOM PICKER FROM SCRATCH                 *forge-extending-picker*
 
@@ -1022,11 +1013,7 @@ contracts live in the source:
   `require('forge')`         `lua/forge/init.lua`            routes, high-level
                                                             current-ref helpers,
                                                             and extension hooks
-  `require('forge.ops')`     `lua/forge/ops.lua`             low-level verbs for
-                                                            known targets
   `require('forge.picker')`  `lua/forge/picker/init.lua`     custom picker UI
-  `require('forge.pickers')` `lua/forge/pickers.lua`         built-in picker
-                                                            entrypoints
   `forge.Forge` / shared     `lua/forge/types.lua`           backend and shared
                                                             contracts
 
@@ -1049,6 +1036,8 @@ Prefer these helpers for normal integrations:
 - `open(route?, opts?)` for built-in routes
 - `pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`, and `ci(opts?)` for current-ref
   workflows
+- `pr({ num = '42' })`, `review({ num = '42' })`, and `pr_ci({ num = '42' })`
+  for explicit PR targeting
 - `current_pr(opts?)` when you need the resolved PR ref
 - `create_pr(opts?)` and `create_issue(opts?)` for create flows
 
@@ -1062,16 +1051,9 @@ For the implicit-ref rollout:
   current-PR commands when `{num}` is omitted.
 - `:Forge ci` is current-branch CI history; PR checks live under `:Forge pr ci`.
 - `:Forge pr create` and `require('forge').create_pr()` are create-only.
+- `edit_pr()` is removed; use `pr({ num = '42' })` instead.
 - Prefer `require('forge').pr()`, `review()`, `pr_ci()`, `ci()`, and
-  `current_pr()` over `require('forge.ops')` for common workflows.
-
-LOW-LEVEL API: `require('forge.ops')` ~                            *forge-ops*
-
-The full verb inventory and signatures live in `lua/forge/ops.lua`. This is
-the low-level target-known layer used by `:Forge` and the built-in picker
-actions, not the primary entrypoint for current-ref workflows. Ref arguments
-accept either a bare id/tag or a table with `scope` plus `num`, `id`, or
-`tag`. Mutation verbs conventionally take `opts = { on_success?, on_failure? }`.
+  `current_pr()` over internal verb modules for common workflows.
 
 PUBLIC API: `require('forge.picker')` ~                     *forge-picker-api*
 

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -436,6 +436,17 @@ M.format_releases = format_mod.format_releases
 M.filter_checks = format_mod.filter_checks
 M.filter_runs = format_mod.filter_runs
 
+---@return forge.Forge?
+local function detect_or_warn()
+  local log = require('forge.logger')
+  local forge = M.detect()
+  if not forge then
+    log.warn('no forge detected')
+    return nil
+  end
+  return forge
+end
+
 ---@param opts forge.CurrentPROpts?
 ---@param forge forge.Forge
 ---@return forge.CurrentPROpts
@@ -443,13 +454,103 @@ local function implicit_ref_opts(opts, forge)
   return vim.tbl_extend('force', { forge = forge }, opts or {})
 end
 
+---@param opts forge.PRActionOpts?
+---@return string?, boolean
+local function explicit_pr_num(opts)
+  if type(opts) ~= 'table' then
+    return nil, false
+  end
+  local num = opts.num
+  if num == nil then
+    return nil, false
+  end
+  ---@type string?
+  local text = nil
+  if type(num) == 'number' then
+    text = tostring(num)
+  elseif type(num) == 'string' then
+    text = num
+  end
+  if text == nil then
+    return nil, true
+  end
+  text = vim.trim(text)
+  if text == '' then
+    return nil, true
+  end
+  return text, true
+end
+
+---@param opts forge.PRActionOpts?
+---@param forge forge.Forge?
+---@return forge.PRRef?
+local function resolve_explicit_pr(opts, forge)
+  local log = require('forge.logger')
+  local num = explicit_pr_num(opts)
+  if not num then
+    return nil
+  end
+  ---@cast opts forge.PRActionOpts
+
+  local scope = opts.scope
+  if scope == nil and opts.repo ~= nil then
+    forge = forge or detect_or_warn()
+    if not forge then
+      return nil
+    end
+    local repo_scope, scope_err = resolve_mod.repo(nil, implicit_ref_opts(opts, forge))
+    if scope_err then
+      log.warn(scope_err.message or 'invalid repo address')
+      return nil
+    end
+    scope = repo_scope
+  end
+
+  return {
+    num = num,
+    scope = scope,
+  }
+end
+
+---@param opts forge.ReviewOpts?
+---@return { adapter: string? }
+local function review_action_opts(opts)
+  return {
+    adapter = type(opts) == 'table' and opts.adapter or nil,
+  }
+end
+
+local resolve_action_pr
+
+---@param opts forge.PRActionOpts?
+---@param require_forge boolean?
+---@return forge.Forge?, forge.PRRef?
+local function resolve_pr_action_target(opts, require_forge)
+  local log = require('forge.logger')
+  local num, explicit = explicit_pr_num(opts)
+  if explicit then
+    local forge = nil
+    if require_forge or (type(opts) == 'table' and opts.repo ~= nil) then
+      forge = detect_or_warn()
+      if not forge then
+        return nil
+      end
+    end
+    if not num then
+      log.warn('missing PR number')
+      return nil
+    end
+    return forge, resolve_explicit_pr(opts, forge)
+  end
+  return resolve_action_pr(opts)
+end
+
 ---@param opts forge.CurrentPROpts?
 ---@return forge.Forge?, forge.PRRef?
-local function resolve_action_pr(opts)
+resolve_action_pr = function(opts)
   local log = require('forge.logger')
-  local forge = M.detect()
+  local forge = detect_or_warn()
   if not forge then
-    log.warn('no forge detected')
     return nil
   end
   local pr, err = M.current_pr(implicit_ref_opts(opts, forge))
@@ -468,9 +569,8 @@ end
 ---@return forge.Forge?, forge.HeadRef?
 local function resolve_ci_head(opts)
   local log = require('forge.logger')
-  local forge = M.detect()
+  local forge = detect_or_warn()
   if not forge then
-    log.warn('no forge detected')
     return nil
   end
 
@@ -503,29 +603,27 @@ local function resolve_ci_head(opts)
   return forge, head
 end
 
----@param opts forge.CurrentPROpts?
+---@param opts forge.PRActionOpts?
 function M.pr(opts)
-  local _, pr = resolve_action_pr(opts)
+  local forge, pr = resolve_pr_action_target(opts)
   if not pr then
     return
   end
-  require('forge.ops').pr_edit(pr)
+  require('forge.ops').pr_edit(pr, forge)
 end
 
 ---@param opts forge.ReviewOpts?
 function M.review(opts)
-  local forge, pr = resolve_action_pr(opts)
+  local forge, pr = resolve_pr_action_target(opts, true)
   if not forge or not pr then
     return
   end
-  require('forge.ops').pr_review(forge, pr, {
-    adapter = type(opts) == 'table' and opts.adapter or nil,
-  })
+  require('forge.ops').pr_review(forge, pr, review_action_opts(opts))
 end
 
----@param opts forge.CurrentPROpts?
+---@param opts forge.PRActionOpts?
 function M.pr_ci(opts)
-  local forge, pr = resolve_action_pr(opts)
+  local forge, pr = resolve_pr_action_target(opts, true)
   if not forge or not pr then
     return
   end
@@ -689,74 +787,11 @@ end
 
 ---@param num string
 ---@param ref? forge.Scope
-function M.edit_pr(num, ref)
-  local log = require('forge.logger')
-
-  local f = M.detect()
-  if not f then
-    log.warn('no forge detected')
-    return
-  end
-  ref = ref or M.current_scope(f.name)
-
-  local current_branch = vim.trim(vim.fn.system('git branch --show-current'))
-
-  log.info(('fetching %s #%s...'):format(f.labels.pr_one, num))
-
-  vim.system(f:fetch_pr_details_cmd(num, ref), { text = true }, function(result)
-    if result.code ~= 0 then
-      vim.schedule(function()
-        log.error('failed to fetch ' .. f.labels.pr_one .. ' #' .. num)
-      end)
-      return
-    end
-    local ok, json = pcall(vim.json.decode, result.stdout or '{}')
-    if not ok or type(json) ~= 'table' then
-      vim.schedule(function()
-        log.error('failed to parse ' .. f.labels.pr_one .. ' details')
-      end)
-      return
-    end
-    local details = f:parse_pr_details(json)
-    vim.schedule(function()
-      compose_mod.open_pr_edit(f, num, details, current_branch, ref)
-    end)
-  end)
-end
-
----@param num string
----@param ref? forge.Scope
 function M.edit_issue(num, ref)
-  local log = require('forge.logger')
-
-  local f = M.detect()
-  if not f then
-    log.warn('no forge detected')
-    return
-  end
-  ref = ref or M.current_scope(f.name)
-
-  log.info(('fetching issue #%s...'):format(num))
-
-  vim.system(f:fetch_issue_details_cmd(num, ref), { text = true }, function(result)
-    if result.code ~= 0 then
-      vim.schedule(function()
-        log.error('failed to fetch issue #' .. num)
-      end)
-      return
-    end
-    local ok, json = pcall(vim.json.decode, result.stdout or '{}')
-    if not ok or type(json) ~= 'table' then
-      vim.schedule(function()
-        log.error('failed to parse issue details')
-      end)
-      return
-    end
-    local details = f:parse_issue_details(json)
-    vim.schedule(function()
-      compose_mod.open_issue_edit(f, num, details, ref)
-    end)
-  end)
+  require('forge.ops').issue_edit({
+    num = num,
+    scope = ref,
+  })
 end
 
 ---@param opts forge.CreateIssueOpts?

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -70,6 +70,42 @@ local function normalize_run_ref(run, scope)
   return { id = run, scope = scope }
 end
 
+local function load_details(cmd, fetch_err, parse_err, parse, open)
+  vim.system(cmd, { text = true }, function(result)
+    if result.code ~= 0 then
+      vim.schedule(function()
+        log.error(cmd_error(result, fetch_err))
+      end)
+      return
+    end
+    local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+    if not ok or type(json) ~= 'table' then
+      vim.schedule(function()
+        log.error(parse_err)
+      end)
+      return
+    end
+    local details = parse(json)
+    vim.schedule(function()
+      open(details)
+    end)
+  end)
+end
+
+---@param f forge.Forge?
+---@return forge.Forge?
+local function detect_or_warn(f)
+  if f then
+    return f
+  end
+  f = require('forge').detect()
+  if not f then
+    log.warn('no forge detected')
+    return nil
+  end
+  return f
+end
+
 local function summary_job_at_cursor(buf)
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   return require('forge.log')._summary_job_at_line(lines, vim.api.nvim_win_get_cursor(0)[1])
@@ -155,9 +191,29 @@ function M.pr_create(opts)
 end
 
 ---@param pr forge.PRRefLike
-function M.pr_edit(pr)
+---@param f forge.Forge?
+function M.pr_edit(pr, f)
   pr = normalize_pr_ref(pr)
-  require('forge').edit_pr(pr.num, pr.scope)
+  f = detect_or_warn(f)
+  if not f then
+    return
+  end
+  local forge = require('forge')
+  local ref = pr.scope or forge.current_scope(f.name)
+  local current_branch = trim(vim.fn.system('git branch --show-current'))
+
+  log.info(('fetching %s #%s...'):format(f.labels.pr_one, pr.num))
+  load_details(
+    f:fetch_pr_details_cmd(pr.num, ref),
+    'failed to fetch ' .. f.labels.pr_one .. ' #' .. pr.num,
+    'failed to parse ' .. f.labels.pr_one .. ' details',
+    function(json)
+      return f:parse_pr_details(json)
+    end,
+    function(details)
+      require('forge.compose').open_pr_edit(f, pr.num, details, current_branch, ref)
+    end
+  )
 end
 
 ---@param f forge.Forge
@@ -280,9 +336,28 @@ function M.issue_create(opts)
 end
 
 ---@param issue forge.IssueRefLike
-function M.issue_edit(issue)
+---@param f forge.Forge?
+function M.issue_edit(issue, f)
   issue = normalize_issue_ref(issue)
-  require('forge').edit_issue(issue.num, issue.scope)
+  f = detect_or_warn(f)
+  if not f then
+    return
+  end
+  local forge = require('forge')
+  local ref = issue.scope or forge.current_scope(f.name)
+
+  log.info(('fetching issue #%s...'):format(issue.num))
+  load_details(
+    f:fetch_issue_details_cmd(issue.num, ref),
+    'failed to fetch issue #' .. issue.num,
+    'failed to parse issue details',
+    function(json)
+      return f:parse_issue_details(json)
+    end,
+    function(details)
+      require('forge.compose').open_issue_edit(f, issue.num, details, ref)
+    end
+  )
 end
 
 ---@param f forge.Forge

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -279,7 +279,10 @@
 ---@field project_id string?
 ---@field target_opts forge.TargetParseOpts?
 
----@class forge.ReviewOpts: forge.CurrentPROpts
+---@class forge.PRActionOpts: forge.CurrentPROpts
+---@field num string|integer?
+
+---@class forge.ReviewOpts: forge.PRActionOpts
 ---@field adapter string?
 
 ---@class forge.BranchCIOpts: forge.CurrentPROpts

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -289,6 +289,61 @@ describe('high-level implicit-ref API', function()
     assert.same({}, captured.warnings)
   end)
 
+  it(
+    'routes explicit PR targets through review() and pr_ci() without current_pr fallback',
+    function()
+      captured.repo_result = repo_scope('upstream')
+
+      local forge = require('forge')
+      forge.review({ num = '57', repo = 'upstream', adapter = 'worktree' })
+      forge.pr_ci({ num = '57', repo = 'upstream' })
+
+      assert.same({}, captured.current_pr_calls)
+      assert.equals(2, #captured.repo_calls)
+      for _, call in ipairs(captured.repo_calls) do
+        assert.is_nil(call.repo)
+        assert.equals('upstream', call.opts.repo)
+      end
+      assert.equals('pr_review', captured.ops_calls[1].name)
+      assert.equals('github', captured.ops_calls[1].f.name)
+      assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[1].pr)
+      assert.same({ adapter = 'worktree' }, captured.ops_calls[1].opts)
+      assert.equals('pr_ci', captured.ops_calls[2].name)
+      assert.equals('github', captured.ops_calls[2].f.name)
+      assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[2].pr)
+      assert.is_nil(captured.ops_calls[2].opts)
+      assert.same({}, captured.warnings)
+    end
+  )
+
+  it(
+    'does not fall back to ambient resolution when explicit PR targeting omits a usable number',
+    function()
+      require('forge').pr({ num = '   ', repo = 'upstream' })
+
+      assert.same({}, captured.current_pr_calls)
+      assert.same({}, captured.repo_calls)
+      assert.same({}, captured.ops_calls)
+      assert.same({ 'missing PR number' }, captured.warnings)
+    end
+  )
+
+  it(
+    'does not fall back to current PR resolution when explicit PR targeting has an invalid repo',
+    function()
+      captured.repo_error = {
+        code = 'invalid_repo',
+        message = 'invalid repo address',
+      }
+
+      require('forge').pr({ num = '42', repo = 'upstream' })
+
+      assert.same({}, captured.current_pr_calls)
+      assert.same({}, captured.ops_calls)
+      assert.same({ 'invalid repo address' }, captured.warnings)
+    end
+  )
+
   it('routes review() and pr_ci() through current_pr() with explicit address opts', function()
     captured.current_pr_result = {
       num = '57',
@@ -305,32 +360,14 @@ describe('high-level implicit-ref API', function()
       assert.equals('upstream', call.repo)
       assert.equals('origin@topic', call.head)
     end
-    assert.same({
-      name = 'pr_review',
-      f = {
-        name = 'github',
-        cli = 'gh',
-        labels = {
-          ci = 'CI',
-          pr_one = 'PR',
-        },
-      },
-      pr = { num = '57', scope = repo_scope('upstream') },
-      opts = { adapter = 'worktree' },
-    }, captured.ops_calls[1])
-    assert.same({
-      name = 'pr_ci',
-      f = {
-        name = 'github',
-        cli = 'gh',
-        labels = {
-          ci = 'CI',
-          pr_one = 'PR',
-        },
-      },
-      pr = { num = '57', scope = repo_scope('upstream') },
-      opts = nil,
-    }, captured.ops_calls[2])
+    assert.equals('pr_review', captured.ops_calls[1].name)
+    assert.equals('github', captured.ops_calls[1].f.name)
+    assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[1].pr)
+    assert.same({ adapter = 'worktree' }, captured.ops_calls[1].opts)
+    assert.equals('pr_ci', captured.ops_calls[2].name)
+    assert.equals('github', captured.ops_calls[2].f.name)
+    assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[2].pr)
+    assert.is_nil(captured.ops_calls[2].opts)
   end)
 
   it('opens current-branch CI through ci() and supports explicit head targeting', function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -317,12 +317,6 @@ describe(':Forge command', function()
           table.insert(captured.current_pr_calls, opts)
           return captured.current_pr_result, captured.current_pr_error
         end,
-        edit_pr = function(num)
-          captured.edit_pr = num
-        end,
-        edit_issue = function(num, scope)
-          captured.edit_issue = { num = num, scope = scope }
-        end,
         create_issue = function(opts)
           captured.create_issue = opts
         end,
@@ -395,7 +389,6 @@ describe(':Forge command', function()
         end,
         pr_edit = function(pr)
           table.insert(captured.ops_calls, { name = 'pr_edit', pr = pr })
-          require('forge').edit_pr(pr.num, pr.scope)
         end,
         pr_review = function(_, pr, opts)
           table.insert(captured.ops_calls, { name = 'pr_review', pr = pr, opts = opts or {} })
@@ -431,7 +424,6 @@ describe(':Forge command', function()
         end,
         issue_edit = function(issue)
           table.insert(captured.ops_calls, { name = 'issue_edit', issue = issue })
-          require('forge').edit_issue(issue.num, issue.scope)
         end,
         issue_browse = function(f, issue)
           table.insert(captured.ops_calls, { name = 'issue_browse', issue = issue })
@@ -1002,18 +994,6 @@ describe(':Forge command', function()
         },
       },
     }, captured.ops_calls[1])
-    assert.same({
-      num = '174',
-      scope = {
-        kind = 'github',
-        host = 'github.com',
-        owner = 'owner',
-        repo = 'upstream',
-        slug = 'owner/upstream',
-        repo_arg = 'owner/upstream',
-        web_url = 'https://github.com/owner/upstream',
-      },
-    }, captured.edit_issue)
   end)
 
   it('rejects explicit list verbs with no picker dispatch side effects', function()

--- a/spec/edit_issue_spec.lua
+++ b/spec/edit_issue_spec.lua
@@ -19,6 +19,7 @@ describe('edit_issue', function()
     old_executable = vim.fn.executable
     old_preload = {
       ['forge.action'] = package.preload['forge.action'],
+      ['forge.ci'] = package.preload['forge.ci'],
       ['forge.client'] = package.preload['forge.client'],
       ['forge.compose'] = package.preload['forge.compose'],
       ['forge.config'] = package.preload['forge.config'],
@@ -84,6 +85,10 @@ describe('edit_issue', function()
         register = function() end,
         run = function() end,
       }
+    end
+
+    package.preload['forge.ci'] = function()
+      return {}
     end
 
     package.preload['forge.client'] = function()
@@ -162,6 +167,8 @@ describe('edit_issue', function()
     end
 
     package.loaded['forge'] = nil
+    package.loaded['forge.ci'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.action'] = nil
     package.loaded['forge.client'] = nil
     package.loaded['forge.compose'] = nil
@@ -179,6 +186,7 @@ describe('edit_issue', function()
     vim.fn.executable = old_executable
 
     package.preload['forge.action'] = old_preload['forge.action']
+    package.preload['forge.ci'] = old_preload['forge.ci']
     package.preload['forge.client'] = old_preload['forge.client']
     package.preload['forge.compose'] = old_preload['forge.compose']
     package.preload['forge.config'] = old_preload['forge.config']
@@ -189,6 +197,8 @@ describe('edit_issue', function()
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
+    package.loaded['forge.ci'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.action'] = nil
     package.loaded['forge.client'] = nil
     package.loaded['forge.compose'] = nil

--- a/spec/edit_pr_spec.lua
+++ b/spec/edit_pr_spec.lua
@@ -1,6 +1,6 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
-describe('edit_pr', function()
+describe('forge.pr explicit PR targeting', function()
   local captured
   local old_fn_system
   local old_vim_system
@@ -19,6 +19,7 @@ describe('edit_pr', function()
     old_executable = vim.fn.executable
     old_preload = {
       ['forge.action'] = package.preload['forge.action'],
+      ['forge.ci'] = package.preload['forge.ci'],
       ['forge.client'] = package.preload['forge.client'],
       ['forge.compose'] = package.preload['forge.compose'],
       ['forge.config'] = package.preload['forge.config'],
@@ -93,6 +94,10 @@ describe('edit_pr', function()
         register = function() end,
         run = function() end,
       }
+    end
+
+    package.preload['forge.ci'] = function()
+      return {}
     end
 
     package.preload['forge.client'] = function()
@@ -181,6 +186,8 @@ describe('edit_pr', function()
     end
 
     package.loaded['forge'] = nil
+    package.loaded['forge.ci'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.action'] = nil
     package.loaded['forge.client'] = nil
     package.loaded['forge.compose'] = nil
@@ -198,6 +205,7 @@ describe('edit_pr', function()
     vim.fn.executable = old_executable
 
     package.preload['forge.action'] = old_preload['forge.action']
+    package.preload['forge.ci'] = old_preload['forge.ci']
     package.preload['forge.client'] = old_preload['forge.client']
     package.preload['forge.compose'] = old_preload['forge.compose']
     package.preload['forge.config'] = old_preload['forge.config']
@@ -208,6 +216,8 @@ describe('edit_pr', function()
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
+    package.loaded['forge.ci'] = nil
+    package.loaded['forge.ops'] = nil
     package.loaded['forge.action'] = nil
     package.loaded['forge.client'] = nil
     package.loaded['forge.compose'] = nil
@@ -220,7 +230,7 @@ describe('edit_pr', function()
   end)
 
   it('uses fetched PR head/base metadata instead of the current local branch', function()
-    require('forge').edit_pr('23')
+    require('forge').pr({ num = 23 })
 
     vim.wait(100, function()
       return captured.opened ~= nil
@@ -260,7 +270,7 @@ describe('edit_pr', function()
       return ''
     end
 
-    require('forge').edit_pr('23')
+    require('forge').pr({ num = '23' })
 
     vim.wait(100, function()
       return captured.opened ~= nil


### PR DESCRIPTION
## Problem
The public implicit-ref API still documented and exposed legacy PR entrypoints, duplicated explicit PR routing, and carried redundant tests that mostly restated implementation shape.

## Solution
Tighten explicit PR resolution, move PR edit plumbing into `forge.ops`, document the canonical top-level API surface, and trim the new tests down to behavior that actually protects the contract.