### PR TITLE
chore(format): replace Prettier with Biome

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,9 +1,0 @@
-{
-  "proseWrap": "always",
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
-  "trailingComma": "none",
-  "semi": false,
-  "singleQuote": true
-}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": true
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80
+  },
+  "linter": {
+    "enabled": false
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded",
+      "trailingCommas": "none"
+    }
+  },
+  "assist": {
+    "enabled": false
+  }
+}

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
           yamlParser = pkgs.vimPlugins.nvim-treesitter-parsers.yaml;
           commonPackages = [
             pkgs.just
-            pkgs.prettier
+            pkgs.biome
             pkgs.stylua
             pkgs.selene
             pkgs.lua-language-server

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ default:
 format:
     nix fmt -- --ci
     stylua --check .
-    prettier --check .
+    biome check .
 
 lint:
     git ls-files '*.lua' | xargs selene --display-style quiet


### PR DESCRIPTION
## Problem

forge.nvim still uses Prettier for its repo format check and dev shell.

## Solution

Replace the Prettier package and `prettier --check .` format step with Biome, add a Biome config for the repo, and remove the obsolete Prettier config files.