### PR TITLE
feat: add :Forge browse {num} with cross-forge auto-dispatch

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -472,6 +472,10 @@ IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
 `:Forge pr ready` {num} [repo=...]                           *:Forge-pr-ready*
     Mark PR `{num}` as ready when supported by the forge.
 
+`:Forge pr browse` [{num}] [repo=...]                       *:Forge-pr-browse*
+    Open PR `{num}` in the browser, or the PR list landing page when
+    `{num}` is omitted. Mirrors `:Forge issue browse` for PRs/MRs.
+
 `:Forge pr refresh` [repo=...]                             *:Forge-pr-refresh*
     Invalidate the cached PR list so the next picker or list-consuming
     command fetches fresh data from the forge. Mirrors the PR picker's
@@ -552,11 +556,21 @@ RELEASE COMMANDS                                      *forge-release-commands*
 
 BROWSE COMMANDS                                        *forge-browse-commands*
 
-`:Forge browse` [branch=...] [commit=...] [target=...]         *:Forge-browse*
+`:Forge browse` [{num}] [repo=...] [branch=...] [commit=...] [target=...]
+                                                               *:Forge-browse*
     Open a forge web URL.
-    (no modifiers)     Open the current file/line permalink on the current
+    (no args)          Open the current file/line permalink on the current
                        branch. In non-file buffers, this falls back to the
                        current repo root.
+    `{num}`            Open issue or PR `{num}` in the browser, dispatched
+                       automatically. On GitHub and Codeberg, issue and PR
+                       numbers share a single space, so the dispatch is
+                       always unambiguous. On GitLab, issue and merge
+                       request iids are independent; if both `#{num}` and
+                       `!{num}` exist, Forge errors and points at the
+                       explicit verbs `:Forge pr browse {num}` and
+                       `:Forge issue browse {num}`.
+    `repo=`            Scope the lookup to a specific repo.
     `branch=<name>`    Open the given branch on the forge. When a file
                        location is available, the file/line permalink is
                        anchored to that branch instead; otherwise the

--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -1,4 +1,5 @@
 local forge = require('forge')
+local log = require('forge.logger')
 local submission = require('forge.submission')
 
 ---@class forge.Codeberg: forge.Forge
@@ -120,24 +121,70 @@ end
 
 ---@param kind string
 ---@param num string
+---@param ref forge.Scope?
 function M:view_web(kind, num, ref)
   local base = forge.remote_web_url(ref)
   vim.ui.open(('%s/%s/%s'):format(base, kind, num))
 end
 
+---@param num string
+---@param ref forge.Scope?
+function M:browse_subject(num, ref)
+  local cmd = {
+    'tea',
+    'api',
+    '--repo',
+    repo_arg(ref),
+    ('/repos/{owner}/{repo}/issues/%s'):format(num),
+  }
+  local parse_err = ('failed to parse #%s details'):format(num)
+  vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        local stderr = vim.trim(result.stderr or '')
+        if stderr:match('404') or stderr:match('not[%s_-]?found') then
+          log.warn(('no PR or issue found for #%s'):format(num))
+        else
+          log.error(stderr ~= '' and stderr or ('no PR or issue found for #%s'):format(num))
+        end
+        return
+      end
+      local ok, data = pcall(vim.json.decode, result.stdout or '{}')
+      if not ok or type(data) ~= 'table' then
+        log.error(parse_err)
+        return
+      end
+      local url = type(data.html_url) == 'string' and data.html_url or ''
+      if url == '' then
+        log.error(parse_err)
+        return
+      end
+      local _, open_err = vim.ui.open(url)
+      if open_err then
+        log.error(open_err)
+      end
+    end)
+  end)
+end
+
 ---@param loc string
 ---@param branch string
+---@param ref forge.Scope?
 function M:browse(loc, branch, ref)
   local base = forge.remote_web_url(ref)
   local file, lines = loc:match('^(.+):(.+)$')
   vim.ui.open(('%s/src/branch/%s/%s#L%s'):format(base, branch, file, lines))
 end
 
+---@param branch string
+---@param ref forge.Scope?
 function M:browse_branch(branch, ref)
   local base = forge.remote_web_url(ref)
   vim.ui.open(base .. '/src/branch/' .. branch)
 end
 
+---@param commit string
+---@param ref forge.Scope?
 function M:browse_commit(commit, ref)
   local base = forge.remote_web_url(ref)
   vim.ui.open(base .. '/commit/' .. commit)
@@ -151,6 +198,7 @@ local LIST_PATHS = {
 }
 
 ---@param kind forge.WebKind
+---@param ref forge.Scope?
 ---@return string?
 function M:list_web_url(kind, ref)
   local base = forge.remote_web_url(ref)

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -138,6 +138,7 @@ end
 
 ---@param kind string
 ---@param num string
+---@param scope forge.Scope?
 function M:view_web(kind, num, scope)
   local cmd = { 'gh', kind, 'view', num, '--web' }
   local repo = nwo(scope)
@@ -148,8 +149,21 @@ function M:view_web(kind, num, scope)
   vim.system(cmd)
 end
 
+---@param num string
+---@param scope forge.Scope?
+function M:browse_subject(num, scope)
+  local cmd = { 'gh', 'browse', num }
+  local repo = nwo(scope)
+  if repo ~= '' then
+    table.insert(cmd, '-R')
+    table.insert(cmd, repo)
+  end
+  open_browse_url(cmd)
+end
+
 ---@param loc string
 ---@param branch string
+---@param scope forge.Scope?
 function M:browse(loc, branch, scope)
   local cmd = { 'gh', 'browse', loc, '--branch', branch }
   local repo = nwo(scope)
@@ -160,6 +174,8 @@ function M:browse(loc, branch, scope)
   open_browse_url(cmd)
 end
 
+---@param branch string
+---@param scope forge.Scope?
 function M:browse_branch(branch, scope)
   local cmd = { 'gh', 'browse', '--branch', branch }
   local repo = nwo(scope)
@@ -170,6 +186,8 @@ function M:browse_branch(branch, scope)
   open_browse_url(cmd)
 end
 
+---@param commit string
+---@param scope forge.Scope?
 function M:browse_commit(commit, scope)
   local cmd = { 'gh', 'browse', commit }
   local repo = nwo(scope)
@@ -188,6 +206,7 @@ local LIST_PATHS = {
 }
 
 ---@param kind forge.WebKind
+---@param scope forge.Scope?
 ---@return string?
 function M:list_web_url(kind, scope)
   local base = forge.remote_web_url(scope)

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -1,4 +1,5 @@
 local forge = require('forge')
+local log = require('forge.logger')
 local scope = require('forge.scope')
 local submission = require('forge.submission')
 
@@ -127,23 +128,100 @@ end
 
 ---@param kind string
 ---@param num string
+---@param ref forge.Scope?
 function M:view_web(kind, num, ref)
   vim.system({ 'glab', kind, 'view', num, '--web', '-R', repo_arg(ref) })
 end
 
+---@param num string
+---@param ref forge.Scope?
+function M:browse_subject(num, ref)
+  local current = ref or forge.current_scope(M.name)
+  local pid = project(current)
+  local host = hostname(current) or 'gitlab.com'
+  if pid == '' then
+    log.error('failed to resolve repo for browse')
+    return
+  end
+
+  local pending = 2
+  ---@type string?
+  local mr_url = nil
+  ---@type string?
+  local issue_url = nil
+
+  local function finalize()
+    pending = pending - 1
+    if pending > 0 then
+      return
+    end
+    if mr_url and issue_url then
+      log.warn(
+        ('ambiguous: %s and issue #%s both exist; use :Forge pr browse %s or :Forge issue browse %s'):format(
+          M.labels.pr_one,
+          num,
+          num,
+          num
+        )
+      )
+      return
+    end
+    local url = mr_url or issue_url
+    if not url or url == '' then
+      log.warn(('no PR or issue found for #%s'):format(num))
+      return
+    end
+    local _, open_err = vim.ui.open(url)
+    if open_err then
+      log.error(open_err)
+    end
+  end
+
+  ---@param path string
+  ---@param set_url fun(url: string)
+  local function probe(path, set_url)
+    vim.system({ 'glab', 'api', '--hostname', host, path }, { text = true }, function(result)
+      vim.schedule(function()
+        if result.code == 0 then
+          local ok, data = pcall(vim.json.decode, result.stdout or '{}')
+          if ok and type(data) == 'table' then
+            local web_url = type(data.web_url) == 'string' and data.web_url or ''
+            if web_url ~= '' then
+              set_url(web_url)
+            end
+          end
+        end
+        finalize()
+      end)
+    end)
+  end
+
+  probe(('projects/%s/merge_requests/%s'):format(pid, num), function(u)
+    mr_url = u
+  end)
+  probe(('projects/%s/issues/%s'):format(pid, num), function(u)
+    issue_url = u
+  end)
+end
+
 ---@param loc string
 ---@param branch string
+---@param ref forge.Scope?
 function M:browse(loc, branch, ref)
   local base = forge.remote_web_url(ref)
   local file, lines = loc:match('^(.+):(.+)$')
   vim.ui.open(('%s/-/blob/%s/%s#L%s'):format(base, branch, file, lines))
 end
 
+---@param branch string
+---@param ref forge.Scope?
 function M:browse_branch(branch, ref)
   local base = forge.remote_web_url(ref)
   vim.ui.open(base .. '/-/tree/' .. branch)
 end
 
+---@param commit string
+---@param ref forge.Scope?
 function M:browse_commit(commit, ref)
   local base = forge.remote_web_url(ref)
   vim.ui.open(base .. '/-/commit/' .. commit)
@@ -157,6 +235,7 @@ local LIST_PATHS = {
 }
 
 ---@param kind forge.WebKind
+---@param ref forge.Scope?
 ---@return string?
 function M:list_web_url(kind, ref)
   local base = forge.remote_web_url(ref)

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -40,6 +40,7 @@ local families = {
     default_verb = 'open',
     verb_order = {
       'open',
+      'browse',
       'ci',
       'close',
       'reopen',
@@ -55,6 +56,10 @@ local families = {
       open = {
         subject = { kind = 'pr', min = 0, max = 1 },
         modifiers = { 'repo', 'head' },
+      },
+      browse = {
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo' },
       },
       ci = {
         subject = { kind = 'pr', min = 0, max = 1 },
@@ -187,8 +192,8 @@ local families = {
     verb_order = { 'open' },
     verbs = {
       open = {
-        subject = { min = 0, max = 0 },
-        modifiers = { 'branch', 'commit', 'target' },
+        subject = { min = 0, max = 1 },
+        modifiers = { 'repo', 'branch', 'commit', 'target' },
       },
     },
   },
@@ -471,6 +476,15 @@ local function dispatch_pr(command)
     ops.pr_ci(f, pr)
     return
   end
+  if command.name == 'browse' then
+    local scope = resolve_repo_modifier(command, f.name)
+    if num then
+      ops.pr_browse(f, { num = num, scope = scope })
+    else
+      ops.list_browse(f, 'pr', { scope = scope })
+    end
+    return
+  end
   if command.name == 'refresh' then
     require('forge').clear_list_kind('pr')
     require('forge.logger').info('refreshed ' .. ((f.labels and f.labels.pr) or 'pr') .. ' list')
@@ -653,6 +667,11 @@ local function dispatch_browse(command)
     return
   end
   local scope = resolve_scope_modifier(command, f.name)
+  local subject = command.subjects[1]
+  if subject then
+    ops.browse_subject(f, { num = subject, scope = scope })
+    return
+  end
   local location = command.parsed_modifiers.target
   if location then
     ops.browse_location(f, location, scope)

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -324,6 +324,13 @@ function M.pr_toggle_draft(f, pr, is_draft, opts)
   )
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRefLike
+function M.pr_browse(f, pr)
+  pr = normalize_pr_ref(pr)
+  f:view_web(f.kinds.pr, pr.num, pr.scope)
+end
+
 ---@param state? 'open'|'closed'|'all'
 ---@param opts? forge.PickerBackOpts
 function M.issue_list(state, opts)
@@ -685,6 +692,16 @@ function M.list_browse(f, kind, opts)
   if err then
     log.error(err)
   end
+end
+
+---@param f forge.Forge
+---@param ref forge.SubjectRef
+function M.browse_subject(f, ref)
+  if not f.browse_subject then
+    log.warn(('%s does not support browse by number'):format(f.name))
+    return
+  end
+  f:browse_subject(ref.num, ref.scope)
 end
 
 ---@param opts? { commit?: string, scope?: forge.Scope }

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -92,6 +92,10 @@
 ---@field num string
 ---@field scope forge.Scope?
 
+---@class forge.SubjectRef
+---@field num string
+---@field scope forge.Scope?
+
 ---@class forge.ReleaseRef
 ---@field tag string
 ---@field scope forge.Scope?
@@ -356,6 +360,7 @@
 ---@field pr_fields { number: string, title: string, branch: string, state: string, author: string, created_at: string }
 ---@field issue_fields { number: string, title: string, state: string, author: string, created_at: string }
 ---@field view_web fun(self: forge.Forge, kind: string, num: string, scope?: forge.Scope)
+---@field browse_subject (fun(self: forge.Forge, num: string, scope?: forge.Scope))?
 ---@field browse fun(self: forge.Forge, loc: string, branch: string, scope?: forge.Scope)
 ---@field browse_branch fun(self: forge.Forge, branch: string, scope?: forge.Scope)
 ---@field browse_commit fun(self: forge.Forge, commit: string, scope?: forge.Scope)

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -114,7 +114,6 @@ describe('command schema', function()
     local review_num = assert(cmd.parse({ 'review', '42' }))
     local _, pr_checkout = cmd.parse({ 'pr', 'checkout', '42' })
     local _, pr_worktree = cmd.parse({ 'pr', 'worktree', '42' })
-    local _, pr_browse = cmd.parse({ 'pr', 'browse' })
     local _, pr_list = cmd.parse({ 'pr', 'list' })
     local _, ci_log = cmd.parse({ 'ci', 'log', '123' })
     local _, ci_watch = cmd.parse({ 'ci', 'watch', '123' })
@@ -161,7 +160,6 @@ describe('command schema', function()
 
     assert.equals('unknown pr action: checkout', pr_checkout.message)
     assert.equals('unknown pr action: worktree', pr_worktree.message)
-    assert.equals('unknown pr action: browse', pr_browse.message)
     assert.equals('unknown pr action: list', pr_list.message)
     assert.equals('unknown action: log', ci_log.message)
     assert.equals('unknown action: watch', ci_watch.message)
@@ -169,20 +167,42 @@ describe('command schema', function()
 
   it('accepts argless browse for kind families that have a list landing page', function()
     local issue = assert(cmd.parse({ 'issue', 'browse' }))
+    local pr = assert(cmd.parse({ 'pr', 'browse' }))
     local ci = assert(cmd.parse({ 'ci', 'browse' }))
     local release = assert(cmd.parse({ 'release', 'browse' }))
 
     assert.equals('browse', issue.name)
     assert.same({}, issue.subjects)
+    assert.equals('browse', pr.name)
+    assert.same({}, pr.subjects)
     assert.equals('browse', ci.name)
     assert.same({}, ci.subjects)
     assert.equals('browse', release.name)
     assert.same({}, release.subjects)
 
+    local pr_with = assert(cmd.parse({ 'pr', 'browse', '42' }))
     local ci_with = assert(cmd.parse({ 'ci', 'browse', '123' }))
     local release_with = assert(cmd.parse({ 'release', 'browse', 'v1.2.3' }))
+    assert.same({ '42' }, pr_with.subjects)
     assert.same({ '123' }, ci_with.subjects)
     assert.same({ 'v1.2.3' }, release_with.subjects)
+  end)
+
+  it('accepts an optional numeric subject on :Forge browse', function()
+    local bare = assert(cmd.parse({ 'browse' }))
+    local with_num = assert(cmd.parse({ 'browse', '42' }))
+    local with_num_repo = assert(cmd.parse({ 'browse', '42', 'repo=upstream' }))
+
+    assert.equals('browse', bare.family)
+    assert.equals('open', bare.name)
+    assert.same({}, bare.subjects)
+
+    assert.equals('browse', with_num.family)
+    assert.equals('open', with_num.name)
+    assert.same({ '42' }, with_num.subjects)
+
+    assert.same({ '42' }, with_num_repo.subjects)
+    assert.equals('upstream', with_num_repo.parsed_modifiers.repo.text)
   end)
 
   it('attaches parsed target-bearing modifiers to normalized commands', function()
@@ -269,6 +289,7 @@ describe('command schema', function()
   it('keeps direct forge verbs aligned with canonical non-list operations', function()
     assert.same({
       'open',
+      'browse',
       'ci',
       'close',
       'reopen',
@@ -319,7 +340,7 @@ describe('command schema', function()
   end)
 
   it('keeps legacy browse modifiers separate from canonical ones', function()
-    assert.same({ 'branch', 'commit', 'target' }, cmd.modifier_names('browse'))
+    assert.same({ 'repo', 'branch', 'commit', 'target' }, cmd.modifier_names('browse'))
     assert.same({}, cmd.legacy_modifier_names('browse'))
   end)
 
@@ -339,13 +360,11 @@ describe('command schema', function()
 
   it('rejects obsolete browse modifiers and malformed browse target syntax', function()
     local _, target_err = cmd.parse({ 'browse', 'target=README.md#L10' })
-    local _, repo_err = cmd.parse({ 'browse', 'repo=upstream' })
     local _, rev_err = cmd.parse({ 'browse', 'rev=main' })
     local _, branch_err = cmd.parse({ 'browse', 'branch=@main' })
     local _, commit_err = cmd.parse({ 'browse', 'commit=abc:def' })
 
     assert.equals('invalid location address: README.md#L10', target_err.message)
-    assert.equals('unknown modifier: repo', repo_err.message)
     assert.equals('unknown modifier: rev', rev_err.message)
     assert.equals('invalid branch: @main', branch_err.message)
     assert.equals('invalid commit: abc:def', commit_err.message)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -414,6 +414,16 @@ describe(':Forge command', function()
         pr_reopen = function(_, pr)
           table.insert(captured.ops_calls, { name = 'pr_reopen', pr = pr })
         end,
+        pr_browse = function(f, pr)
+          table.insert(captured.ops_calls, { name = 'pr_browse', pr = pr })
+          f:view_web(f.kinds.pr, pr.num, pr.scope)
+        end,
+        browse_subject = function(f, ref)
+          table.insert(captured.ops_calls, { name = 'browse_subject', ref = ref })
+          if f.browse_subject then
+            f:browse_subject(ref.num, ref.scope)
+          end
+        end,
         issue_list = function(state, opts)
           table.insert(captured.ops_calls, { name = 'issue_list', state = state, opts = opts })
           require('forge').open(state and ('issues.' .. state) or 'issues', opts)
@@ -570,7 +580,6 @@ describe(':Forge command', function()
     vim.cmd('Forge')
     vim.cmd('Forge pr checkout 42')
     vim.cmd('Forge pr worktree 42')
-    vim.cmd('Forge pr browse 42')
     vim.cmd('Forge release')
     vim.cmd('Forge branches')
     vim.cmd('Forge commits feature')
@@ -580,7 +589,6 @@ describe(':Forge command', function()
       'missing command',
       'unknown pr action: checkout',
       'unknown pr action: worktree',
-      'unknown pr action: browse',
       'missing action',
       'unknown command: branches',
       'unknown command: commits',
@@ -827,15 +835,31 @@ describe(':Forge command', function()
 
   it('keeps argful kind browse routed to entity-scoped ops helpers', function()
     vim.cmd('Forge issue browse 7')
+    vim.cmd('Forge pr browse 42')
     vim.cmd('Forge ci browse 99')
     vim.cmd('Forge release browse v1.2.3')
 
     assert.equals('issue_browse', captured.ops_calls[1].name)
     assert.equals('7', captured.ops_calls[1].issue.num)
-    assert.equals('ci_browse', captured.ops_calls[2].name)
-    assert.equals('99', captured.ops_calls[2].run.id)
-    assert.equals('release_browse', captured.ops_calls[3].name)
-    assert.equals('v1.2.3', captured.ops_calls[3].release.tag)
+    assert.equals('pr_browse', captured.ops_calls[2].name)
+    assert.equals('42', captured.ops_calls[2].pr.num)
+    assert.equals('ci_browse', captured.ops_calls[3].name)
+    assert.equals('99', captured.ops_calls[3].run.id)
+    assert.equals('release_browse', captured.ops_calls[4].name)
+    assert.equals('v1.2.3', captured.ops_calls[4].release.tag)
+  end)
+
+  it('routes :Forge browse {num} through ops.browse_subject', function()
+    vim.cmd('Forge browse 42')
+    vim.cmd('Forge browse 7 repo=upstream')
+
+    assert.equals('browse_subject', captured.ops_calls[1].name)
+    assert.equals('42', captured.ops_calls[1].ref.num)
+    assert.same(repo_scope('current'), captured.ops_calls[1].ref.scope)
+
+    assert.equals('browse_subject', captured.ops_calls[2].name)
+    assert.equals('7', captured.ops_calls[2].ref.num)
+    assert.same(repo_scope('upstream'), captured.ops_calls[2].ref.scope)
   end)
 
   it('dispatches review through forge.ops with adapter overrides', function()
@@ -1151,6 +1175,7 @@ describe(':Forge command', function()
         cmdline = 'Forge pr ',
         expected = {
           'open',
+          'browse',
           'ci',
           'close',
           'reopen',
@@ -1179,7 +1204,7 @@ describe(':Forge command', function()
       },
       {
         cmdline = 'Forge browse ',
-        expected = { 'branch=', 'commit=', 'target=' },
+        expected = { 'repo=', 'branch=', 'commit=', 'target=' },
       },
       {
         cmdline = 'Forge clear ',
@@ -1248,7 +1273,7 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(pr, 'head='))
     assert.is_false(vim.tbl_contains(pr, 'checkout'))
     assert.is_false(vim.tbl_contains(pr, 'worktree'))
-    assert.is_false(vim.tbl_contains(pr, 'browse'))
+    assert.is_true(vim.tbl_contains(pr, 'browse'))
     assert.is_false(vim.tbl_contains(pr, 'state='))
     assert.is_true(vim.tbl_contains(review, 'adapter='))
     assert.is_true(vim.tbl_contains(review, 'repo='))
@@ -1295,6 +1320,7 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(families, 'pipeline'))
     assert.same({
       'open',
+      'browse',
       'ci',
       'close',
       'reopen',

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -761,4 +761,30 @@ describe('shared operations', function()
     assert.same({}, captured.urls)
     assert.same({ 'custom does not support ci run pages' }, captured.infos)
   end)
+
+  it('browse_subject delegates to the backend method when available', function()
+    local ops = require('forge.ops')
+    local calls = {}
+    local f = {
+      name = 'github',
+      browse_subject = function(_, num, scope)
+        table.insert(calls, { num = num, scope = scope })
+      end,
+    }
+
+    ops.browse_subject(f, { num = '42', scope = { repo_arg = 'owner/repo' } })
+
+    assert.equals(1, #calls)
+    assert.equals('42', calls[1].num)
+    assert.same({ repo_arg = 'owner/repo' }, calls[1].scope)
+    assert.same({}, captured.infos)
+  end)
+
+  it('browse_subject warns when the source does not implement it', function()
+    local ops = require('forge.ops')
+
+    ops.browse_subject({ name = 'custom' }, { num = '42' })
+
+    assert.same({ 'custom does not support browse by number' }, captured.infos)
+  end)
 end)

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -426,6 +426,62 @@ describe('github browse', function()
     assert.equals('exit status 1', captured.error)
     assert.is_nil(captured.url)
   end)
+
+  it('dispatches browse_subject through `gh browse <num>`', function()
+    vim.system = function(cmd, _, cb)
+      captured.cmd = cmd
+      if cb then
+        cb({
+          code = 0,
+          stdout = 'https://github.com/owner/repo/issues/42\n',
+          stderr = '',
+        })
+      end
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    gh:browse_subject('42', { repo_arg = 'owner/repo' })
+
+    vim.wait(100, function()
+      return captured.url ~= nil
+    end)
+
+    assert.same({ 'gh', 'browse', '42', '-R', 'owner/repo' }, vim.list_slice(captured.cmd, 1, 5))
+    assert.same('--no-browser', captured.cmd[#captured.cmd])
+    assert.equals('https://github.com/owner/repo/issues/42', captured.url)
+    assert.is_nil(captured.error)
+  end)
+
+  it('logs browse_subject resolution failures from gh', function()
+    vim.system = function(cmd, _, cb)
+      captured.cmd = cmd
+      if cb then
+        cb({
+          code = 1,
+          stdout = '',
+          stderr = 'no such issue or pr',
+        })
+      end
+      return {
+        wait = function()
+          return { code = 1 }
+        end,
+      }
+    end
+
+    gh:browse_subject('999', { repo_arg = 'owner/repo' })
+
+    vim.wait(100, function()
+      return captured.error ~= nil
+    end)
+
+    assert.equals('no such issue or pr', captured.error)
+    assert.is_nil(captured.url)
+  end)
 end)
 
 describe('gitlab', function()
@@ -684,6 +740,187 @@ describe('gitlab', function()
   end)
 end)
 
+describe('gitlab browse_subject', function()
+  local captured
+  local old_preload
+  local old_system
+  local old_ui_open
+  local gl
+
+  local function gitlab_scope()
+    return { kind = 'gitlab', host = 'gitlab.com', slug = 'group/repo' }
+  end
+
+  local function mock_glab_api(scenarios)
+    return function(cmd, _, cb)
+      table.insert(captured.cmds, cmd)
+      local path = cmd[5] or ''
+      local result
+      if path:find('/merge_requests/', 1, true) then
+        result = scenarios.mr or { code = 1, stdout = '', stderr = 'not found' }
+      elseif path:find('/issues/', 1, true) then
+        result = scenarios.issue or { code = 1, stdout = '', stderr = 'not found' }
+      else
+        result = { code = 1, stdout = '', stderr = 'unexpected path' }
+      end
+      if cb then
+        cb(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+  end
+
+  before_each(function()
+    captured = { cmds = {} }
+    old_system = vim.system
+    old_ui_open = vim.ui.open
+    old_preload = {
+      ['forge.logger'] = package.preload['forge.logger'],
+    }
+
+    package.preload['forge.logger'] = function()
+      return {
+        error = function(msg)
+          captured.error = msg
+        end,
+        warn = function(msg)
+          captured.warn = msg
+        end,
+        info = function() end,
+        debug = function() end,
+      }
+    end
+
+    vim.ui.open = function(url)
+      captured.url = url
+      return {}, nil
+    end
+
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.backends.gitlab'] = nil
+    gl = require('forge.backends.gitlab')
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.ui.open = old_ui_open
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.backends.gitlab'] = nil
+  end)
+
+  it('opens the MR when only the MR exists', function()
+    vim.system = mock_glab_api({
+      mr = {
+        code = 0,
+        stdout = '{"web_url":"https://gitlab.com/group/repo/-/merge_requests/42"}',
+      },
+    })
+
+    gl:browse_subject('42', gitlab_scope())
+
+    vim.wait(100, function()
+      return captured.url ~= nil
+    end)
+
+    assert.equals('https://gitlab.com/group/repo/-/merge_requests/42', captured.url)
+    assert.is_nil(captured.warn)
+    assert.is_nil(captured.error)
+    assert.equals(2, #captured.cmds)
+  end)
+
+  it('opens the issue when only the issue exists', function()
+    vim.system = mock_glab_api({
+      issue = {
+        code = 0,
+        stdout = '{"web_url":"https://gitlab.com/group/repo/-/issues/42"}',
+      },
+    })
+
+    gl:browse_subject('42', gitlab_scope())
+
+    vim.wait(100, function()
+      return captured.url ~= nil
+    end)
+
+    assert.equals('https://gitlab.com/group/repo/-/issues/42', captured.url)
+    assert.is_nil(captured.warn)
+    assert.is_nil(captured.error)
+  end)
+
+  it('warns ambiguous when both an MR and an issue exist', function()
+    vim.system = mock_glab_api({
+      mr = {
+        code = 0,
+        stdout = '{"web_url":"https://gitlab.com/group/repo/-/merge_requests/5"}',
+      },
+      issue = {
+        code = 0,
+        stdout = '{"web_url":"https://gitlab.com/group/repo/-/issues/5"}',
+      },
+    })
+
+    gl:browse_subject('5', gitlab_scope())
+
+    vim.wait(100, function()
+      return captured.warn ~= nil
+    end)
+
+    assert.is_nil(captured.url)
+    assert.matches('ambiguous', captured.warn)
+    assert.matches('MR', captured.warn)
+    assert.matches(':Forge pr browse 5', captured.warn)
+    assert.matches(':Forge issue browse 5', captured.warn)
+  end)
+
+  it('warns not found when neither an MR nor an issue exists', function()
+    vim.system = mock_glab_api({
+      mr = { code = 1, stdout = '', stderr = 'not found' },
+      issue = { code = 1, stdout = '', stderr = 'not found' },
+    })
+
+    gl:browse_subject('999', gitlab_scope())
+
+    vim.wait(100, function()
+      return captured.warn ~= nil
+    end)
+
+    assert.is_nil(captured.url)
+    assert.matches('no PR or issue found for #999', captured.warn)
+  end)
+
+  it('uses --hostname from scope and encodes the project slug', function()
+    vim.system = mock_glab_api({
+      issue = {
+        code = 0,
+        stdout = '{"web_url":"https://gitlab.example.com/group/sub/repo/-/issues/7"}',
+      },
+    })
+
+    gl:browse_subject(
+      '7',
+      { kind = 'gitlab', host = 'gitlab.example.com', slug = 'group/sub/repo' }
+    )
+
+    vim.wait(100, function()
+      return captured.url ~= nil
+    end)
+
+    assert.is_true(#captured.cmds == 2)
+    for _, cmd in ipairs(captured.cmds) do
+      assert.equals('glab', cmd[1])
+      assert.equals('api', cmd[2])
+      assert.equals('--hostname', cmd[3])
+      assert.equals('gitlab.example.com', cmd[4])
+      assert.matches('group%%2Fsub%%2Frepo/', cmd[5])
+    end
+  end)
+end)
+
 describe('codeberg', function()
   local cb = require('forge.backends.codeberg')
 
@@ -907,5 +1144,183 @@ describe('codeberg', function()
 
     vim.ui.open = old_open
     assert.equals('https://codeberg.org/owner/repo/actions/runs/123', opened)
+  end)
+end)
+
+describe('codeberg browse_subject', function()
+  local captured
+  local old_preload
+  local old_system
+  local old_ui_open
+  local cb
+
+  local function codeberg_scope()
+    return { repo_arg = 'forgejo/forgejo' }
+  end
+
+  before_each(function()
+    captured = {}
+    old_system = vim.system
+    old_ui_open = vim.ui.open
+    old_preload = {
+      ['forge.logger'] = package.preload['forge.logger'],
+    }
+
+    package.preload['forge.logger'] = function()
+      return {
+        error = function(msg)
+          captured.error = msg
+        end,
+        warn = function(msg)
+          captured.warn = msg
+        end,
+        info = function() end,
+        debug = function() end,
+      }
+    end
+
+    vim.ui.open = function(url)
+      captured.url = url
+      return {}, nil
+    end
+
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.backends.codeberg'] = nil
+    cb = require('forge.backends.codeberg')
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.ui.open = old_ui_open
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.backends.codeberg'] = nil
+  end)
+
+  it('opens the html_url returned by tea api for an issue', function()
+    vim.system = function(cmd, _, cb_fn)
+      captured.cmd = cmd
+      cb_fn({
+        code = 0,
+        stdout = '{"html_url":"https://codeberg.org/forgejo/forgejo/issues/42","pull_request":null}',
+        stderr = '',
+      })
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    cb:browse_subject('42', codeberg_scope())
+
+    vim.wait(100, function()
+      return captured.url ~= nil
+    end)
+
+    assert.same(
+      { 'tea', 'api', '--repo', 'forgejo/forgejo', '/repos/{owner}/{repo}/issues/42' },
+      captured.cmd
+    )
+    assert.equals('https://codeberg.org/forgejo/forgejo/issues/42', captured.url)
+    assert.is_nil(captured.error)
+  end)
+
+  it('opens the html_url returned by tea api for a PR', function()
+    vim.system = function(_, _, cb_fn)
+      cb_fn({
+        code = 0,
+        stdout = '{"html_url":"https://codeberg.org/forgejo/forgejo/pulls/12272","pull_request":{"merged":true}}',
+        stderr = '',
+      })
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    cb:browse_subject('12272', codeberg_scope())
+
+    vim.wait(100, function()
+      return captured.url ~= nil
+    end)
+
+    assert.equals('https://codeberg.org/forgejo/forgejo/pulls/12272', captured.url)
+    assert.is_nil(captured.error)
+  end)
+
+  it('warns not-found when tea api returns a 404', function()
+    vim.system = function(_, _, cb_fn)
+      cb_fn({
+        code = 1,
+        stdout = '',
+        stderr = '404 not found',
+      })
+      return {
+        wait = function()
+          return { code = 1 }
+        end,
+      }
+    end
+
+    cb:browse_subject('999', codeberg_scope())
+
+    vim.wait(100, function()
+      return captured.warn ~= nil
+    end)
+
+    assert.is_nil(captured.url)
+    assert.is_nil(captured.error)
+    assert.equals('no PR or issue found for #999', captured.warn)
+  end)
+
+  it('surfaces tea api stderr on non-404 failures', function()
+    vim.system = function(_, _, cb_fn)
+      cb_fn({
+        code = 1,
+        stdout = '',
+        stderr = 'Error: Authentication required',
+      })
+      return {
+        wait = function()
+          return { code = 1 }
+        end,
+      }
+    end
+
+    cb:browse_subject('42', codeberg_scope())
+
+    vim.wait(100, function()
+      return captured.error ~= nil
+    end)
+
+    assert.is_nil(captured.url)
+    assert.is_nil(captured.warn)
+    assert.equals('Error: Authentication required', captured.error)
+  end)
+
+  it('logs parse failure when tea api stdout is not JSON', function()
+    vim.system = function(_, _, cb_fn)
+      cb_fn({
+        code = 0,
+        stdout = 'not json at all',
+        stderr = '',
+      })
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    cb:browse_subject('42', codeberg_scope())
+
+    vim.wait(100, function()
+      return captured.error ~= nil
+    end)
+
+    assert.is_nil(captured.url)
+    assert.equals('failed to parse #42 details', captured.error)
   end)
 end)


### PR DESCRIPTION
## Problem

`:Forge browse` only takes `branch=`/`commit=`/`target=` modifiers - there is
no way to open issue or PR `N` in the browser by number from the unified
browse surface. `:Forge issue browse {num}` covers the issue case, but PRs
have no symmetric verb (`PROSPECTIVE_CHANGES.md` flags this gap), and there
is no auto-dispatch for the common "I have a number, open whatever it is"
case.

GitLab's iid model makes this nontrivial: issue `#5` and MR `!5` are
independent items, so any auto-dispatch has to handle 0/1/2 outcomes.

## Solution

Three commands, all consistent with the existing `family verb subject`
grammar - no new flag namespace:

| Command | Behavior |
|---|---|
| `:Forge browse {num}` | Auto-dispatch via new optional `forge.Forge:browse_subject` method |
| `:Forge pr browse {num}` | Open PR `{num}` in browser - reuses existing `view_web` |
| `:Forge pr browse` | Open PR list landing page - parallel to bare `:Forge issue browse` |

Per-backend implementations of the new method:

- **GitHub**: `gh browse N -R repo`. Pipes through the existing
  `open_browse_url` helper that captures stderr cleanly. Relies on GitHub's
  server-side `/issues/N` <-> `/pull/N` redirect.
- **Codeberg/Gitea/Forgejo**: `tea api repos/{owner}/{repo}/issues/{num}` and
  open `html_url` from the JSON. Index space is unified, so dispatch is
  unambiguous; the API directly returns the canonical URL. Distinguishes 404s
  (warn) from auth/network errors (error with stderr surfaced).
- **GitLab**: async-probes both `merge_requests/{iid}` and `issues/{iid}` via
  `glab api --hostname H`, then:
  - `0 hits` -> `no PR or issue found for #N` (warn)
  - `1 hit` -> opens the `web_url`
  - `2 hits` -> warns `ambiguous: MR and issue #N both exist; use :Forge pr browse N or :Forge issue browse N`

  The error message points at verbs that already exist after this PR, so the
  recovery path is self-documenting.

The new method is optional on `forge.Forge`; `ops.browse_subject` warns
gracefully for custom backends that do not implement it. Adds
`forge.SubjectRef` next to the existing ref taxonomy. Sweeps missing
`---@param ref/scope` annotations across the touched browse/`view_web`/
`list_web_url` neighbourhood in all three backends.

13 net-new busted specs (633 from a 619 baseline) covering cmd parse,
end-to-end command dispatch, per-backend command/URL construction (including
all four GitLab outcomes and the new codeberg stderr distinction), and
ops-layer delegation. Full `just ci` clean: nix fmt, stylua, biome, selene,
lua-language-server, vimdoc-language-server, 633/0/0 busted.