### PR TITLE
refactor: rename backend ref->scope, hard-remove legacy --name modifier syntax

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -362,10 +362,6 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     - `:Forge ci` opens current-branch CI history
     - `:Forge browse` opens the current file/line context
 
-    Compatibility sugar is still accepted, but it is not the primary
-    interface:
-    - legacy `--name` / `--name=value` forms for modifiers
-
     When the detected forge is GitLab, the Ex command surface also accepts
     provider-native family aliases:
     - `:Forge mr ...` as an alias for `:Forge pr ...`

--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -65,8 +65,8 @@ local M = {
   },
 }
 
-local function repo_arg(ref)
-  local current = ref or forge.current_scope(M.name)
+local function repo_arg(scope)
+  local current = scope or forge.current_scope(M.name)
   return forge.scope_repo_arg(current) or ''
 end
 
@@ -80,7 +80,7 @@ end
 ---@param state string
 ---@param limit integer?
 ---@return string[]
-function M:list_pr_json_cmd(state, limit, ref)
+function M:list_pr_json_cmd(state, limit, scope)
   return {
     'tea',
     'pulls',
@@ -94,14 +94,14 @@ function M:list_pr_json_cmd(state, limit, ref)
     '--fields',
     'index,title,head,state,poster,created_at',
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
   }
 end
 
 ---@param state string
 ---@param limit integer?
 ---@return string[]
-function M:list_issue_json_cmd(state, limit, ref)
+function M:list_issue_json_cmd(state, limit, scope)
   return {
     'tea',
     'issues',
@@ -115,26 +115,26 @@ function M:list_issue_json_cmd(state, limit, ref)
     '--fields',
     'index,title,state,poster,created_at',
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
   }
 end
 
 ---@param kind string
 ---@param num string
----@param ref forge.Scope?
-function M:view_web(kind, num, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:view_web(kind, num, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(('%s/%s/%s'):format(base, kind, num))
 end
 
 ---@param num string
----@param ref forge.Scope?
-function M:browse_subject(num, ref)
+---@param scope forge.Scope?
+function M:browse_subject(num, scope)
   local cmd = {
     'tea',
     'api',
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
     ('/repos/{owner}/{repo}/issues/%s'):format(num),
   }
   local parse_err = ('failed to parse #%s details'):format(num)
@@ -169,24 +169,24 @@ end
 
 ---@param loc string
 ---@param branch string
----@param ref forge.Scope?
-function M:browse(loc, branch, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:browse(loc, branch, scope)
+  local base = forge.remote_web_url(scope)
   local file, lines = loc:match('^(.+):(.+)$')
   vim.ui.open(('%s/src/branch/%s/%s#L%s'):format(base, branch, file, lines))
 end
 
 ---@param branch string
----@param ref forge.Scope?
-function M:browse_branch(branch, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:browse_branch(branch, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/src/branch/' .. branch)
 end
 
 ---@param commit string
----@param ref forge.Scope?
-function M:browse_commit(commit, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:browse_commit(commit, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/commit/' .. commit)
 end
 
@@ -198,10 +198,10 @@ local LIST_PATHS = {
 }
 
 ---@param kind forge.WebKind
----@param ref forge.Scope?
+---@param scope forge.Scope?
 ---@return string?
-function M:list_web_url(kind, ref)
-  local base = forge.remote_web_url(ref)
+function M:list_web_url(kind, scope)
+  local base = forge.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -212,8 +212,8 @@ function M:list_web_url(kind, ref)
   return base .. path
 end
 
-function M:checkout_cmd(num, ref)
-  return { 'tea', 'pr', 'checkout', num, '--repo', repo_arg(ref) }
+function M:checkout_cmd(num, scope)
+  return { 'tea', 'pr', 'checkout', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
@@ -224,18 +224,18 @@ end
 
 ---@param num string
 ---@return string[]
-function M:pr_base_cmd(num, ref)
-  return { 'tea', 'pr', num, '--fields', 'base', '--output', 'simple', '--repo', repo_arg(ref) }
+function M:pr_base_cmd(num, scope)
+  return { 'tea', 'pr', num, '--fields', 'base', '--output', 'simple', '--repo', repo_arg(scope) }
 end
 
 ---@param branch string
 ---@return string[]
-function M:pr_for_branch_cmd(branch, ref)
+function M:pr_for_branch_cmd(branch, scope)
   return {
     'sh',
     '-c',
     ('tea pr list --state open --output json --fields index,head --repo %s | jq -r \'.[] | select(.head=="%s" or .head.name=="%s") | .index // empty\''):format(
-      repo_arg(ref),
+      repo_arg(scope),
       branch,
       branch
     ),
@@ -244,7 +244,7 @@ end
 
 ---@param num string
 ---@return string[]
-function M:checks_json_cmd(num, ref)
+function M:checks_json_cmd(num, scope)
   local jq = [=[
     [.statuses // [] | .[] | {
       name: .context,
@@ -261,9 +261,9 @@ function M:checks_json_cmd(num, ref)
     'sh',
     '-c',
     ('SHA=$(tea api --repo %s "/repos/{owner}/{repo}/pulls/%s" 2>/dev/null | jq -r ".head.sha // empty") && [ -n "$SHA" ] && tea api --repo %s "/repos/{owner}/{repo}/commits/$SHA/status" 2>/dev/null | jq -r \'%s\''):format(
-      repo_arg(ref),
+      repo_arg(scope),
       num,
-      repo_arg(ref),
+      repo_arg(scope),
       jq:gsub('%s+', ' ')
     ),
   }
@@ -280,7 +280,7 @@ end
 ---@param failed_only boolean
 ---@param job_id string?
 ---@return string[]
-function M:check_log_cmd(run_id, failed_only, job_id, ref)
+function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local _ = failed_only
   local lines = forge.config().ci.lines
   local job_flag = job_id and (' --job %s'):format(job_id) or ''
@@ -289,7 +289,7 @@ function M:check_log_cmd(run_id, failed_only, job_id, ref)
     '-c',
     ('tea actions runs logs %s --repo %s%s | tail -n %d'):format(
       run_id,
-      repo_arg(ref),
+      repo_arg(scope),
       job_flag,
       lines
     ),
@@ -298,15 +298,15 @@ end
 
 ---@param run_id string
 ---@return string[]
-function M:check_tail_cmd(run_id, ref)
-  return { 'tea', 'actions', 'runs', 'logs', run_id, '--follow', '--repo', repo_arg(ref) }
+function M:check_tail_cmd(run_id, scope)
+  return { 'tea', 'actions', 'runs', 'logs', run_id, '--follow', '--repo', repo_arg(scope) }
 end
 
 ---@param run_id string
 ---@param job_id string?
 ---@return string[]
-function M:live_tail_cmd(run_id, job_id, ref)
-  local cmd = { 'tea', 'actions', 'runs', 'logs', run_id, '--follow', '--repo', repo_arg(ref) }
+function M:live_tail_cmd(run_id, job_id, scope)
+  local cmd = { 'tea', 'actions', 'runs', 'logs', run_id, '--follow', '--repo', repo_arg(scope) }
   if job_id then
     table.insert(cmd, '--job')
     table.insert(cmd, job_id)
@@ -314,10 +314,10 @@ function M:live_tail_cmd(run_id, job_id, ref)
   return cmd
 end
 
-function M:list_runs_json_cmd(branch, ref, limit)
+function M:list_runs_json_cmd(branch, scope, limit)
   local limit_arg = tostring(limit or forge.config().display.limits.runs)
   local cmd = 'tea api --repo '
-    .. repo_arg(ref)
+    .. repo_arg(scope)
     .. ' "/repos/{owner}/{repo}/actions/runs?limit='
     .. limit_arg
   if branch then
@@ -329,12 +329,12 @@ end
 
 ---@param id string
 ---@return string[]
-function M:cancel_run_cmd(id, ref)
+function M:cancel_run_cmd(id, scope)
   return {
     'tea',
     'api',
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
     '-X',
     'POST',
     ('/repos/{owner}/{repo}/actions/runs/%s/cancel'):format(id),
@@ -343,12 +343,12 @@ end
 
 ---@param id string
 ---@return string[]
-function M:rerun_run_cmd(id, ref)
+function M:rerun_run_cmd(id, scope)
   return {
     'tea',
     'api',
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
     '-X',
     'POST',
     ('/repos/{owner}/{repo}/actions/runs/%s/rerun'):format(id),
@@ -357,8 +357,8 @@ end
 
 ---@param id string
 ---@return string?
-function M:run_web_url(id, ref)
-  local base = forge.remote_web_url(ref)
+function M:run_web_url(id, scope)
+  local base = forge.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -366,8 +366,8 @@ function M:run_web_url(id, ref)
 end
 
 ---@param id string
-function M:browse_run(id, ref)
-  local url = self:run_web_url(id, ref)
+function M:browse_run(id, scope)
+  local url = self:run_web_url(id, scope)
   if not url then
     return
   end
@@ -390,79 +390,79 @@ function M:normalize_run(entry)
   }
 end
 
-function M:run_log_cmd(id, failed_only, ref)
+function M:run_log_cmd(id, failed_only, scope)
   local _ = failed_only
   local lines = forge.config().ci.lines
   return {
     'sh',
     '-c',
-    ('tea actions runs logs %s --repo %s | tail -n %d'):format(id, repo_arg(ref), lines),
+    ('tea actions runs logs %s --repo %s | tail -n %d'):format(id, repo_arg(scope), lines),
   }
 end
 
-function M:run_tail_cmd(id, ref)
-  return { 'tea', 'actions', 'runs', 'logs', id, '--follow', '--repo', repo_arg(ref) }
+function M:run_tail_cmd(id, scope)
+  return { 'tea', 'actions', 'runs', 'logs', id, '--follow', '--repo', repo_arg(scope) }
 end
 
 ---@param num string
 ---@param method string
 ---@return string[]
-function M:merge_cmd(num, method, ref)
+function M:merge_cmd(num, method, scope)
   local cmd = { 'tea', 'pr', 'merge', num }
   if method and method ~= '' then
     table.insert(cmd, '--style')
     table.insert(cmd, method)
   end
   table.insert(cmd, '--repo')
-  table.insert(cmd, repo_arg(ref))
+  table.insert(cmd, repo_arg(scope))
   return cmd
 end
 
 ---@param num string
 ---@return string[]
-function M:approve_cmd(num, ref)
-  return { 'tea', 'pr', 'approve', num, '--repo', repo_arg(ref) }
+function M:approve_cmd(num, scope)
+  return { 'tea', 'pr', 'approve', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:close_cmd(num, ref)
-  return { 'tea', 'pulls', 'close', num, '--repo', repo_arg(ref) }
+function M:close_cmd(num, scope)
+  return { 'tea', 'pulls', 'close', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:reopen_cmd(num, ref)
-  return { 'tea', 'pulls', 'reopen', num, '--repo', repo_arg(ref) }
+function M:reopen_cmd(num, scope)
+  return { 'tea', 'pulls', 'reopen', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:close_issue_cmd(num, ref)
-  return { 'tea', 'issues', 'close', num, '--repo', repo_arg(ref) }
+function M:close_issue_cmd(num, scope)
+  return { 'tea', 'issues', 'close', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:reopen_issue_cmd(num, ref)
-  return { 'tea', 'issues', 'reopen', num, '--repo', repo_arg(ref) }
+function M:reopen_issue_cmd(num, scope)
+  return { 'tea', 'issues', 'reopen', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:fetch_pr_details_cmd(num, ref)
+function M:fetch_pr_details_cmd(num, scope)
   return {
     'sh',
     '-c',
-    ('tea api --repo %s "/repos/{owner}/{repo}/pulls/%s"'):format(repo_arg(ref), num),
+    ('tea api --repo %s "/repos/{owner}/{repo}/pulls/%s"'):format(repo_arg(scope), num),
   }
 end
 
-function M:fetch_issue_details_cmd(num, ref)
+function M:fetch_issue_details_cmd(num, scope)
   return {
     'sh',
     '-c',
-    ('tea api --repo %s "/repos/{owner}/{repo}/issues/%s"'):format(repo_arg(ref), num),
+    ('tea api --repo %s "/repos/{owner}/{repo}/issues/%s"'):format(repo_arg(scope), num),
   }
 end
 
@@ -470,7 +470,7 @@ end
 ---@param title string
 ---@param body string
 ---@return string[]
-function M:update_pr_cmd(num, title, body, ref, metadata, previous)
+function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   local cmd = {
     'tea',
     'pr',
@@ -481,7 +481,7 @@ function M:update_pr_cmd(num, title, body, ref, metadata, previous)
     '--description',
     body,
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   local current = submission.filter(self, 'pr', 'update', metadata)
   local before = previous or { labels = {}, reviewers = {}, milestone = '' }
@@ -498,7 +498,7 @@ function M:update_pr_cmd(num, title, body, ref, metadata, previous)
   return cmd
 end
 
-function M:update_issue_cmd(num, title, body, ref, metadata, previous)
+function M:update_issue_cmd(num, title, body, scope, metadata, previous)
   local cmd = {
     'tea',
     'issues',
@@ -509,7 +509,7 @@ function M:update_issue_cmd(num, title, body, ref, metadata, previous)
     '--description',
     body,
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   local current = submission.filter(self, 'issue', 'update', metadata)
   local before = previous or { labels = {}, milestone = '' }
@@ -584,7 +584,7 @@ end
 ---@param base string
 ---@param _draft boolean
 ---@return string[]
-function M:create_pr_cmd(title, body, base, _draft, ref, metadata)
+function M:create_pr_cmd(title, body, base, _draft, scope, metadata)
   local cmd = {
     'tea',
     'pr',
@@ -596,7 +596,7 @@ function M:create_pr_cmd(title, body, base, _draft, ref, metadata)
     '--base',
     base,
     '--repo',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   local current = metadata and submission.filter(self, 'pr', 'create', metadata) or nil
   append_csv(cmd, '--labels', current and current.labels or {})
@@ -609,14 +609,14 @@ function M:create_pr_cmd(title, body, base, _draft, ref, metadata)
 end
 
 ---@return string
-function M:create_pr_web_url(ref, _, head_branch, base_branch)
+function M:create_pr_web_url(scope, _, head_branch, base_branch)
   local branch = head_branch or vim.trim(vim.fn.system('git branch --show-current'))
-  local base_url = forge.remote_web_url(ref)
+  local base_url = forge.remote_web_url(scope)
   local default = base_branch
   if not default or default == '' then
     default = vim.trim(
       vim.fn.system(
-        "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'"
+        "git symbolic-scope refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'"
       )
     )
     if default == '' then
@@ -630,9 +630,18 @@ end
 ---@param body string
 ---@param labels string[]?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, ref, metadata)
-  local cmd =
-    { 'tea', 'issues', 'create', '--title', title, '--description', body, '--repo', repo_arg(ref) }
+function M:create_issue_cmd(title, body, labels, scope, metadata)
+  local cmd = {
+    'tea',
+    'issues',
+    'create',
+    '--title',
+    title,
+    '--description',
+    body,
+    '--repo',
+    repo_arg(scope),
+  }
   local current = metadata and submission.filter(self, 'issue', 'create', metadata) or nil
   local effective_labels = current and current.labels or labels or {}
   append_csv(cmd, '--labels', effective_labels)
@@ -655,13 +664,13 @@ function M:issue_template_paths()
 end
 
 ---@return string[]
-function M:default_branch_cmd(ref)
+function M:default_branch_cmd(scope)
   return {
     'sh',
     '-c',
-    "git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'"
+    "git symbolic-scope refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||'"
       .. ' || tea api --repo '
-      .. repo_arg(ref)
+      .. repo_arg(scope)
       .. " /repos/{owner}/{repo} 2>/dev/null | jq -r '.default_branch // empty'",
   }
 end
@@ -683,9 +692,9 @@ function M:draft_toggle_cmd(_num, _is_draft)
 end
 
 ---@return forge.RepoInfo
-function M:repo_info(ref)
+function M:repo_info(scope)
   local result = vim
-    .system({ 'tea', 'api', '--repo', repo_arg(ref), '/repos/{owner}/{repo}' }, { text = true })
+    .system({ 'tea', 'api', '--repo', repo_arg(scope), '/repos/{owner}/{repo}' }, { text = true })
     :wait()
   local ok, data = pcall(vim.json.decode, result.stdout or '{}')
   if not ok or type(data) ~= 'table' then
@@ -719,7 +728,7 @@ end
 
 ---@param num string
 ---@return forge.PRState
-function M:pr_state(num, ref)
+function M:pr_state(num, scope)
   local result = vim
     .system({
       'tea',
@@ -730,7 +739,7 @@ function M:pr_state(num, ref)
       '--output',
       'json',
       '--repo',
-      repo_arg(ref),
+      repo_arg(scope),
     }, { text = true })
     :wait()
   local ok, data = pcall(vim.json.decode, result.stdout or '{}')
@@ -745,28 +754,28 @@ function M:pr_state(num, ref)
   }
 end
 
-function M:list_releases_json_cmd(ref, limit)
+function M:list_releases_json_cmd(scope, limit)
   local limit_arg = tostring(limit or forge.config().display.limits.releases)
   return {
     'sh',
     '-c',
-    'tea releases list --limit ' .. limit_arg .. ' --output json --repo ' .. repo_arg(ref),
+    'tea releases list --limit ' .. limit_arg .. ' --output json --repo ' .. repo_arg(scope),
   }
 end
 
 ---@param tag string
-function M:browse_release(tag, ref)
-  local base = forge.remote_web_url(ref)
+function M:browse_release(tag, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/releases/tag/' .. tag)
 end
 
 ---@param tag string
 ---@return string[]
-function M:delete_release_cmd(tag, ref)
+function M:delete_release_cmd(tag, scope)
   return {
     'sh',
     '-c',
-    'tea releases delete --confirm --repo ' .. repo_arg(ref) .. ' ' .. tag,
+    'tea releases delete --confirm --repo ' .. repo_arg(scope) .. ' ' .. tag,
   }
 end
 

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -1,6 +1,6 @@
 local forge = require('forge')
 local log = require('forge.logger')
-local scope = require('forge.scope')
+local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
 
 ---@class forge.GitLab: forge.Forge
@@ -53,17 +53,17 @@ local M = {
   },
 }
 
-local function repo_arg(ref)
-  return forge.scope_repo_arg(ref) or forge.remote_web_url()
+local function repo_arg(scope)
+  return forge.scope_repo_arg(scope) or forge.remote_web_url()
 end
 
-local function project(ref)
-  local current = ref or forge.current_scope(M.name)
-  return scope.encode_project(current) or ''
+local function project(scope)
+  local current = scope or forge.current_scope(M.name)
+  return scope_mod.encode_project(current) or ''
 end
 
-local function hostname(ref)
-  local current = ref or forge.current_scope(M.name)
+local function hostname(scope)
+  local current = scope or forge.current_scope(M.name)
   return current and current.host or nil
 end
 
@@ -77,7 +77,7 @@ end
 ---@param state string
 ---@param limit integer?
 ---@return string[]
-function M:list_pr_json_cmd(state, limit, ref)
+function M:list_pr_json_cmd(state, limit, scope)
   local cmd = {
     'glab',
     'mr',
@@ -87,7 +87,7 @@ function M:list_pr_json_cmd(state, limit, ref)
     '--output',
     'json',
   }
-  local repo = repo_arg(ref)
+  local repo = repo_arg(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
@@ -103,7 +103,7 @@ end
 ---@param state string
 ---@param limit integer?
 ---@return string[]
-function M:list_issue_json_cmd(state, limit, ref)
+function M:list_issue_json_cmd(state, limit, scope)
   local cmd = {
     'glab',
     'issue',
@@ -113,7 +113,7 @@ function M:list_issue_json_cmd(state, limit, ref)
     '--output',
     'json',
   }
-  local repo = repo_arg(ref)
+  local repo = repo_arg(scope)
   if repo ~= '' then
     table.insert(cmd, '-R')
     table.insert(cmd, repo)
@@ -128,15 +128,15 @@ end
 
 ---@param kind string
 ---@param num string
----@param ref forge.Scope?
-function M:view_web(kind, num, ref)
-  vim.system({ 'glab', kind, 'view', num, '--web', '-R', repo_arg(ref) })
+---@param scope forge.Scope?
+function M:view_web(kind, num, scope)
+  vim.system({ 'glab', kind, 'view', num, '--web', '-R', repo_arg(scope) })
 end
 
 ---@param num string
----@param ref forge.Scope?
-function M:browse_subject(num, ref)
-  local current = ref or forge.current_scope(M.name)
+---@param scope forge.Scope?
+function M:browse_subject(num, scope)
+  local current = scope or forge.current_scope(M.name)
   local pid = project(current)
   local host = hostname(current) or 'gitlab.com'
   if pid == '' then
@@ -206,24 +206,24 @@ end
 
 ---@param loc string
 ---@param branch string
----@param ref forge.Scope?
-function M:browse(loc, branch, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:browse(loc, branch, scope)
+  local base = forge.remote_web_url(scope)
   local file, lines = loc:match('^(.+):(.+)$')
   vim.ui.open(('%s/-/blob/%s/%s#L%s'):format(base, branch, file, lines))
 end
 
 ---@param branch string
----@param ref forge.Scope?
-function M:browse_branch(branch, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:browse_branch(branch, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/-/tree/' .. branch)
 end
 
 ---@param commit string
----@param ref forge.Scope?
-function M:browse_commit(commit, ref)
-  local base = forge.remote_web_url(ref)
+---@param scope forge.Scope?
+function M:browse_commit(commit, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/-/commit/' .. commit)
 end
 
@@ -235,10 +235,10 @@ local LIST_PATHS = {
 }
 
 ---@param kind forge.WebKind
----@param ref forge.Scope?
+---@param scope forge.Scope?
 ---@return string?
-function M:list_web_url(kind, ref)
-  local base = forge.remote_web_url(ref)
+function M:list_web_url(kind, scope)
+  local base = forge.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -249,17 +249,21 @@ function M:list_web_url(kind, ref)
   return base .. path
 end
 
-function M:checkout_cmd(num, ref)
-  return { 'glab', 'mr', 'checkout', num, '-R', repo_arg(ref) }
+function M:checkout_cmd(num, scope)
+  return { 'glab', 'mr', 'checkout', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:fetch_pr(num, ref)
+function M:fetch_pr(num, scope)
   local remote = 'origin'
   local current = forge.current_scope(M.name)
-  if ref and forge.scope_key(ref) ~= '' and forge.scope_key(ref) ~= forge.scope_key(current) then
-    remote = forge.remote_web_url(ref) .. '.git'
+  if
+    scope
+    and forge.scope_key(scope) ~= ''
+    and forge.scope_key(scope) ~= forge.scope_key(current)
+  then
+    remote = forge.remote_web_url(scope) .. '.git'
   end
   return {
     'git',
@@ -271,30 +275,30 @@ end
 
 ---@param num string
 ---@return string[]
-function M:pr_base_cmd(num, ref)
+function M:pr_base_cmd(num, scope)
   return {
     'sh',
     '-c',
-    ("glab mr view %s -F json -R '%s' | jq -r .target_branch"):format(num, repo_arg(ref)),
+    ("glab mr view %s -F json -R '%s' | jq -r .target_branch"):format(num, repo_arg(scope)),
   }
 end
 
 ---@param branch string
 ---@return string[]
-function M:pr_for_branch_cmd(branch, ref)
+function M:pr_for_branch_cmd(branch, scope)
   return {
     'sh',
     '-c',
     ("glab mr list --source-branch '%s' -F json -R '%s' | jq -r '.[].iid // empty'"):format(
       branch,
-      repo_arg(ref)
+      repo_arg(scope)
     ),
   }
 end
 
 ---@param num string
 ---@return string[]
-function M:checks_json_cmd(num, ref)
+function M:checks_json_cmd(num, scope)
   local jq = [=[
     [.[] | {
       name: .name,
@@ -313,11 +317,11 @@ function M:checks_json_cmd(num, ref)
     'sh',
     '-c',
     ('PID=$(glab api --hostname %s "projects/%s/merge_requests/%s/pipelines?per_page=1" 2>/dev/null | jq -r ".[0].id // empty") && [ -n "$PID" ] && glab api --hostname %s "projects/%s/pipelines/$PID/jobs?per_page=100" 2>/dev/null | jq -r \'%s\''):format(
-      hostname(ref) or 'gitlab.com',
-      project(ref),
+      hostname(scope) or 'gitlab.com',
+      project(scope),
       num,
-      hostname(ref) or 'gitlab.com',
-      project(ref),
+      hostname(scope) or 'gitlab.com',
+      project(scope),
       jq:gsub('%s+', ' ')
     ),
   }
@@ -334,35 +338,35 @@ end
 ---@param failed_only boolean
 ---@param job_id string?
 ---@return string[]
-function M:check_log_cmd(run_id, failed_only, job_id, ref)
+function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local _ = failed_only
   local lines = forge.config().ci.lines
   local id = job_id or run_id
   return {
     'sh',
     '-c',
-    ("glab ci trace %s -R '%s' | tail -n %d"):format(id, repo_arg(ref), lines),
+    ("glab ci trace %s -R '%s' | tail -n %d"):format(id, repo_arg(scope), lines),
   }
 end
 
 ---@param run_id string
 ---@return string[]
-function M:check_tail_cmd(run_id, ref)
-  return { 'glab', 'ci', 'trace', run_id, '-R', repo_arg(ref) }
+function M:check_tail_cmd(run_id, scope)
+  return { 'glab', 'ci', 'trace', run_id, '-R', repo_arg(scope) }
 end
 
 ---@param run_id string
 ---@return string[]
-function M:live_tail_cmd(run_id, _, ref)
-  return { 'glab', 'ci', 'trace', run_id, '-R', repo_arg(ref) }
+function M:live_tail_cmd(run_id, _, scope)
+  return { 'glab', 'ci', 'trace', run_id, '-R', repo_arg(scope) }
 end
 
 ---@param id string?
 ---@return string[]
-function M:watch_cmd(id, ref)
+function M:watch_cmd(id, scope)
   local cmd = { 'glab', 'ci', 'view' }
   table.insert(cmd, '-R')
-  table.insert(cmd, repo_arg(ref))
+  table.insert(cmd, repo_arg(scope))
   if id then
     table.insert(cmd, '-p')
     table.insert(cmd, id)
@@ -372,28 +376,28 @@ end
 
 ---@param id string
 ---@return string[]
-function M:cancel_run_cmd(id, ref)
-  return { 'glab', 'ci', 'cancel', 'pipeline', id, '-R', repo_arg(ref) }
+function M:cancel_run_cmd(id, scope)
+  return { 'glab', 'ci', 'cancel', 'pipeline', id, '-R', repo_arg(scope) }
 end
 
 ---@param id string
 ---@return string[]
-function M:rerun_run_cmd(id, ref)
+function M:rerun_run_cmd(id, scope)
   return {
     'glab',
     'api',
     '--hostname',
-    hostname(ref) or 'gitlab.com',
+    hostname(scope) or 'gitlab.com',
     '--method',
     'POST',
-    ('projects/%s/pipelines/%s/retry'):format(project(ref), id),
+    ('projects/%s/pipelines/%s/retry'):format(project(scope), id),
   }
 end
 
 ---@param id string
 ---@return string?
-function M:run_web_url(id, ref)
-  local base = forge.remote_web_url(ref)
+function M:run_web_url(id, scope)
+  local base = forge.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -401,15 +405,15 @@ function M:run_web_url(id, ref)
 end
 
 ---@param id string
-function M:browse_run(id, ref)
-  local url = self:run_web_url(id, ref)
+function M:browse_run(id, scope)
+  local url = self:run_web_url(id, scope)
   if not url then
     return
   end
   vim.ui.open(url)
 end
 
-function M:list_runs_json_cmd(branch, ref, limit)
+function M:list_runs_json_cmd(branch, scope, limit)
   local cmd = {
     'glab',
     'ci',
@@ -419,7 +423,7 @@ function M:list_runs_json_cmd(branch, ref, limit)
     '--per-page',
     tostring(limit or forge.config().display.limits.runs),
     '-R',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   if branch then
     table.insert(cmd, '--ref')
@@ -442,7 +446,7 @@ function M:normalize_run(entry)
   }
 end
 
-function M:run_log_cmd(id, failed_only, ref)
+function M:run_log_cmd(id, failed_only, scope)
   local lines = forge.config().ci.lines
   local jq_filter = failed_only and '[.[] | select(.status=="failed")][0].id // .[0].id'
     or '.[0].id'
@@ -450,27 +454,27 @@ function M:run_log_cmd(id, failed_only, ref)
     'sh',
     '-c',
     ('JOB=$(glab api --hostname %s \'projects/%s/pipelines/%s/jobs?per_page=100\' | jq -r \'%s\') && [ "$JOB" != "null" ] && glab ci trace "$JOB" -R \'%s\' | tail -n %d'):format(
-      hostname(ref) or 'gitlab.com',
-      project(ref),
+      hostname(scope) or 'gitlab.com',
+      project(scope),
       id,
       jq_filter,
-      repo_arg(ref),
+      repo_arg(scope),
       lines
     ),
   }
 end
 
-function M:run_tail_cmd(id, ref)
+function M:run_tail_cmd(id, scope)
   local jq_filter = '[.[] | select(.status=="running" or .status=="pending")][0].id // .[0].id'
   return {
     'sh',
     '-c',
     ('JOB=$(glab api --hostname %s \'projects/%s/pipelines/%s/jobs?per_page=100\' | jq -r \'%s\') && [ "$JOB" != "null" ] && glab ci trace "$JOB" -R \'%s\''):format(
-      hostname(ref) or 'gitlab.com',
-      project(ref),
+      hostname(scope) or 'gitlab.com',
+      project(scope),
       id,
       jq_filter,
-      repo_arg(ref)
+      repo_arg(scope)
     ),
   }
 end
@@ -478,10 +482,10 @@ end
 ---@param num string
 ---@param method string
 ---@return string[]
-function M:merge_cmd(num, method, ref)
+function M:merge_cmd(num, method, scope)
   local cmd = { 'glab', 'mr', 'merge', num }
   table.insert(cmd, '-R')
-  table.insert(cmd, repo_arg(ref))
+  table.insert(cmd, repo_arg(scope))
   if method == 'squash' then
     table.insert(cmd, '--squash')
   elseif method == 'rebase' then
@@ -492,20 +496,20 @@ end
 
 ---@param num string
 ---@return string[]
-function M:approve_cmd(num, ref)
-  return { 'glab', 'mr', 'approve', num, '-R', repo_arg(ref) }
+function M:approve_cmd(num, scope)
+  return { 'glab', 'mr', 'approve', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:close_cmd(num, ref)
-  return { 'glab', 'mr', 'close', num, '-R', repo_arg(ref) }
+function M:close_cmd(num, scope)
+  return { 'glab', 'mr', 'close', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
 ---@return string[]
-function M:reopen_cmd(num, ref)
-  return { 'glab', 'mr', 'reopen', num, '-R', repo_arg(ref) }
+function M:reopen_cmd(num, scope)
+  return { 'glab', 'mr', 'reopen', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
@@ -522,21 +526,21 @@ end
 
 ---@param num string
 ---@return string[]
-function M:fetch_pr_details_cmd(num, ref)
-  return { 'glab', 'mr', 'view', num, '--output', 'json', '-R', repo_arg(ref) }
+function M:fetch_pr_details_cmd(num, scope)
+  return { 'glab', 'mr', 'view', num, '--output', 'json', '-R', repo_arg(scope) }
 end
 
-function M:fetch_issue_details_cmd(num, ref)
-  return { 'glab', 'issue', 'view', num, '--output', 'json', '-R', repo_arg(ref) }
+function M:fetch_issue_details_cmd(num, scope)
+  return { 'glab', 'issue', 'view', num, '--output', 'json', '-R', repo_arg(scope) }
 end
 
 ---@param num string
 ---@param title string
 ---@param body string
 ---@return string[]
-function M:update_pr_cmd(num, title, body, ref, metadata, previous)
+function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   local cmd =
-    { 'glab', 'mr', 'update', num, '--title', title, '--description', body, '-R', repo_arg(ref) }
+    { 'glab', 'mr', 'update', num, '--title', title, '--description', body, '-R', repo_arg(scope) }
   local current = submission.filter(self, 'pr', 'update', metadata)
   local before = previous or { labels = {}, assignees = {}, reviewers = {}, milestone = '' }
   local add_labels, remove_labels = submission.diff(before.labels, current.labels)
@@ -573,7 +577,7 @@ function M:update_pr_cmd(num, title, body, ref, metadata, previous)
   return cmd
 end
 
-function M:update_issue_cmd(num, title, body, ref, metadata, previous)
+function M:update_issue_cmd(num, title, body, scope, metadata, previous)
   local cmd = {
     'glab',
     'issue',
@@ -584,7 +588,7 @@ function M:update_issue_cmd(num, title, body, ref, metadata, previous)
     '--description',
     body,
     '-R',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   local current = submission.filter(self, 'issue', 'update', metadata)
   local before = previous or { labels = {}, assignees = {}, milestone = '' }
@@ -667,7 +671,7 @@ end
 ---@param base string
 ---@param draft boolean
 ---@return string[]
-function M:create_pr_cmd(title, body, base, draft, ref, metadata)
+function M:create_pr_cmd(title, body, base, draft, scope, metadata)
   local cmd = {
     'glab',
     'mr',
@@ -680,7 +684,7 @@ function M:create_pr_cmd(title, body, base, draft, ref, metadata)
     base,
     '--yes',
     '-R',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   local current = metadata and submission.filter(self, 'pr', 'create', metadata) or nil
   if (current and current.draft) or (not current and draft) then
@@ -697,12 +701,12 @@ function M:create_pr_cmd(title, body, base, draft, ref, metadata)
 end
 
 ---@return string[]
-function M:create_pr_web_cmd(ref, head_scope, head_branch, base_branch)
-  local cmd = { 'glab', 'mr', 'create', '--web', '-R', repo_arg(ref) }
+function M:create_pr_web_cmd(scope, head_scope, head_branch, base_branch)
+  local cmd = { 'glab', 'mr', 'create', '--web', '-R', repo_arg(scope) }
   if
     head_scope
     and forge.scope_key(head_scope) ~= ''
-    and forge.scope_key(head_scope) ~= forge.scope_key(ref)
+    and forge.scope_key(head_scope) ~= forge.scope_key(scope)
   then
     table.insert(cmd, '--head')
     table.insert(cmd, repo_arg(head_scope))
@@ -722,7 +726,7 @@ end
 ---@param body string
 ---@param labels string[]?
 ---@return string[]
-function M:create_issue_cmd(title, body, labels, ref, metadata)
+function M:create_issue_cmd(title, body, labels, scope, metadata)
   local cmd = {
     'glab',
     'issue',
@@ -733,7 +737,7 @@ function M:create_issue_cmd(title, body, labels, ref, metadata)
     body,
     '--yes',
     '-R',
-    repo_arg(ref),
+    repo_arg(scope),
   }
   local current = metadata and submission.filter(self, 'issue', 'create', metadata) or nil
   local effective_labels = current and current.labels or labels or {}
@@ -747,8 +751,8 @@ function M:create_issue_cmd(title, body, labels, ref, metadata)
 end
 
 ---@return string[]
-function M:create_issue_web_cmd(ref)
-  return { 'glab', 'issue', 'create', '--web', '-R', repo_arg(ref) }
+function M:create_issue_web_cmd(scope)
+  return { 'glab', 'issue', 'create', '--web', '-R', repo_arg(scope) }
 end
 
 ---@return string[]
@@ -757,11 +761,11 @@ function M:issue_template_paths()
 end
 
 ---@return string[]
-function M:default_branch_cmd(ref)
+function M:default_branch_cmd(scope)
   return {
     'sh',
     '-c',
-    "glab repo view -F json -R '" .. repo_arg(ref) .. "' | jq -r '.default_branch'",
+    "glab repo view -F json -R '" .. repo_arg(scope) .. "' | jq -r '.default_branch'",
   }
 end
 
@@ -773,22 +777,22 @@ end
 ---@param num string
 ---@param is_draft boolean
 ---@return string[]?
-function M:draft_toggle_cmd(num, is_draft, ref)
+function M:draft_toggle_cmd(num, is_draft, scope)
   if is_draft then
-    return { 'glab', 'mr', 'update', num, '--ready', '-R', repo_arg(ref) }
+    return { 'glab', 'mr', 'update', num, '--ready', '-R', repo_arg(scope) }
   end
-  return { 'glab', 'mr', 'update', num, '--draft', '-R', repo_arg(ref) }
+  return { 'glab', 'mr', 'update', num, '--draft', '-R', repo_arg(scope) }
 end
 
 ---@return forge.RepoInfo
-function M:repo_info(ref)
+function M:repo_info(scope)
   local result = vim
     .system({
       'glab',
       'api',
       '--hostname',
-      hostname(ref) or 'gitlab.com',
-      'projects/' .. project(ref),
+      hostname(scope) or 'gitlab.com',
+      'projects/' .. project(scope),
     }, { text = true })
     :wait()
   local ok, data = pcall(vim.json.decode, result.stdout or '{}')
@@ -828,9 +832,9 @@ end
 
 ---@param num string
 ---@return forge.PRState
-function M:pr_state(num, ref)
+function M:pr_state(num, scope)
   local result = vim
-    .system({ 'glab', 'mr', 'view', num, '--output', 'json', '-R', repo_arg(ref) }, { text = true })
+    .system({ 'glab', 'mr', 'view', num, '--output', 'json', '-R', repo_arg(scope) }, { text = true })
     :wait()
   local ok, data = pcall(vim.json.decode, result.stdout or '{}')
   if not ok or type(data) ~= 'table' then
@@ -844,7 +848,7 @@ function M:pr_state(num, ref)
   }
 end
 
-function M:list_releases_json_cmd(ref, limit)
+function M:list_releases_json_cmd(scope, limit)
   return {
     'glab',
     'release',
@@ -854,20 +858,20 @@ function M:list_releases_json_cmd(ref, limit)
     '--per-page',
     tostring(limit or forge.config().display.limits.releases),
     '-R',
-    repo_arg(ref),
+    repo_arg(scope),
   }
 end
 
 ---@param tag string
-function M:browse_release(tag, ref)
-  local base = forge.remote_web_url(ref)
+function M:browse_release(tag, scope)
+  local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/-/releases/' .. tag)
 end
 
 ---@param tag string
 ---@return string[]
-function M:delete_release_cmd(tag, ref)
-  return { 'glab', 'release', 'delete', tag, '-R', repo_arg(ref) }
+function M:delete_release_cmd(tag, scope)
+  return { 'glab', 'release', 'delete', tag, '-R', repo_arg(scope) }
 end
 
 return M

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -234,7 +234,7 @@ local function token_is_modifier_like(token)
   if type(token) ~= 'string' then
     return false
   end
-  return token:match('^%-%-') ~= nil or token:find('=', 1, true) ~= nil
+  return token:find('=', 1, true) ~= nil
 end
 
 local function list_contains(items, value)
@@ -831,18 +831,6 @@ function M.modifier_names(family_name, verb_name, opts)
   return copy(command.modifiers or {})
 end
 
----@param family_name string
----@param verb_name string?
----@param opts? forge.SurfaceOpts
----@return string[]
-function M.legacy_modifier_names(family_name, verb_name, opts)
-  local command = M.resolve(family_name, verb_name, opts)
-  if not command then
-    return {}
-  end
-  return copy(command.legacy_modifiers or {})
-end
-
 ---@param args string[]
 ---@param opts? forge.SurfaceOpts
 ---@return forge.Command?, forge.CmdError?
@@ -896,41 +884,24 @@ function M.parse(args, opts)
   command.raw = copy(args)
 
   local declared_modifiers = command.modifiers or {}
-  local legacy_modifiers = command.legacy_modifiers or {}
   local allowed_modifiers = {}
   for _, name in ipairs(declared_modifiers) do
-    allowed_modifiers[name] = true
-  end
-  for _, name in ipairs(legacy_modifiers) do
     allowed_modifiers[name] = true
   end
 
   command.modifiers = {}
   command.declared_modifiers = declared_modifiers
-  command.declared_legacy_modifiers = legacy_modifiers
 
   for i = rest_index, #args do
     local token = args[i]
     local name, value
-    if token:match('^%-%-') then
-      local body = token:sub(3)
-      local eq = body:find('=', 1, true)
-      if eq then
-        name = body:sub(1, eq - 1)
-        value = body:sub(eq + 1)
-      else
-        name = body
-        value = true
-      end
-    else
-      local eq = token:find('=', 1, true)
-      if eq then
-        name = token:sub(1, eq - 1)
-        value = token:sub(eq + 1)
-      elseif allowed_modifiers[token] and modifiers[token] and modifiers[token].kind == 'flag' then
-        name = token
-        value = true
-      end
+    local eq = token:find('=', 1, true)
+    if eq then
+      name = token:sub(1, eq - 1)
+      value = token:sub(eq + 1)
+    elseif allowed_modifiers[token] and modifiers[token] and modifiers[token].kind == 'flag' then
+      name = token
+      value = true
     end
 
     if name then
@@ -1040,30 +1011,12 @@ local function completion_state(command, args)
   }
   for _, token in ipairs(args) do
     local name, value
-    if token:match('^%-%-') then
-      local body = token:sub(3)
-      local eq = body:find('=', 1, true)
-      if eq then
-        name = body:sub(1, eq - 1)
-        value = body:sub(eq + 1)
-      else
-        name = body
-        value = true
-      end
-    else
-      local eq = token:find('=', 1, true)
-      if eq then
-        name = token:sub(1, eq - 1)
-        value = token:sub(eq + 1)
-      end
+    local eq = token:find('=', 1, true)
+    if eq then
+      name = token:sub(1, eq - 1)
+      value = token:sub(eq + 1)
     end
-    if
-      name
-      and (
-        list_contains(command.declared_modifiers or {}, name)
-        or list_contains(command.declared_legacy_modifiers or {}, name)
-      )
-    then
+    if name and list_contains(command.declared_modifiers or {}, name) then
       if state.modifiers[name] == nil then
         state.modifiers[name] = value
       end
@@ -1074,18 +1027,16 @@ local function completion_state(command, args)
   return state
 end
 
-local function filtered_modifier_completion_items(command, state, legacy)
+local function filtered_modifier_completion_items(command, state)
   local items = {}
-  local names = legacy and (command.declared_legacy_modifiers or command.legacy_modifiers)
-    or (command.declared_modifiers or command.modifiers)
+  local names = command.declared_modifiers or command.modifiers
   for _, name in ipairs(names or {}) do
     if state.modifiers[name] == nil then
       local spec = modifiers[name]
-      local prefix = legacy and '--' or ''
       if spec and spec.kind == 'flag' then
-        items[#items + 1] = prefix .. name
+        items[#items + 1] = name
       else
-        items[#items + 1] = prefix .. name .. '='
+        items[#items + 1] = name .. '='
       end
     end
   end
@@ -1538,16 +1489,6 @@ function M.complete(arglead, cmdline, _)
       and words[3]
     or nil
 
-  local legacy_flag, legacy_prefix = arglead:match('^(%-%-[^=]+)=(.*)$')
-  if legacy_flag then
-    local values =
-      completion_values(family_name, explicit_verb, legacy_flag:sub(3), legacy_prefix, surface_opts)
-    if values then
-      return vim.tbl_map(function(v)
-        return legacy_flag .. '=' .. v
-      end, values)
-    end
-  end
   local flag, value_prefix = arglead:match('^([%w%-_]+)=(.*)$')
   if flag then
     local values = completion_values(family_name, explicit_verb, flag, value_prefix, surface_opts)
@@ -1580,17 +1521,11 @@ function M.complete(arglead, cmdline, _)
       end
     end
     if command then
-      if arglead:match('^%-%-') then
-        if slot_policy.include_modifiers then
-          vim.list_extend(candidates, filtered_modifier_completion_items(command, state, true))
-        end
-      else
-        if slot_policy.include_modifiers then
-          vim.list_extend(candidates, filtered_modifier_completion_items(command, state, false))
-        end
-        if slot_policy.include_subjects then
-          vim.list_extend(candidates, subject_completion_items(command, state, arglead))
-        end
+      if slot_policy.include_modifiers then
+        vim.list_extend(candidates, filtered_modifier_completion_items(command, state))
+      end
+      if slot_policy.include_subjects then
+        vim.list_extend(candidates, subject_completion_items(command, state, arglead))
       end
     end
     return filter(candidates, arglead)
@@ -1600,7 +1535,6 @@ function M.complete(arglead, cmdline, _)
     return {}
   end
   command.declared_modifiers = command.modifiers or {}
-  command.declared_legacy_modifiers = command.legacy_modifiers or {}
   local rest_index = explicit_verb and 4 or 3
   local consumed = {}
   for i = rest_index, arglead == '' and #words or (#words - 1) do
@@ -1608,15 +1542,9 @@ function M.complete(arglead, cmdline, _)
   end
   local state = completion_state(command, consumed)
   local slot_policy = require('forge.completion_policy').argument_slot(command, state)
-  if arglead:match('^%-%-') then
-    if not slot_policy.include_modifiers then
-      return {}
-    end
-    return filter(filtered_modifier_completion_items(command, state, true), arglead)
-  end
   local candidates = {}
   if slot_policy.include_modifiers then
-    vim.list_extend(candidates, filtered_modifier_completion_items(command, state, false))
+    vim.list_extend(candidates, filtered_modifier_completion_items(command, state))
   end
   if slot_policy.include_subjects then
     vim.list_extend(candidates, subject_completion_items(command, state, arglead))

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -49,7 +49,6 @@ local function declares_modifier(command, flag_name)
     return false
   end
   return list_contains(command.declared_modifiers or command.modifiers, flag_name)
-    or list_contains(command.declared_legacy_modifiers or command.legacy_modifiers, flag_name)
 end
 
 function M.family_slot(command)

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -156,7 +156,6 @@
 ---@class forge.CommandVerbDef
 ---@field subject forge.CommandSubjectSpec?
 ---@field modifiers string[]?
----@field legacy_modifiers string[]?
 ---@field required_modifiers string[]?
 ---@field modifier_values table<string, string[]>?
 
@@ -181,8 +180,6 @@
 ---@field raw string[]
 ---@field modifiers table<string, any>
 ---@field declared_modifiers string[]
----@field declared_legacy_modifiers string[]
----@field legacy_modifiers string[]?
 ---@field parsed_modifiers table<string, any>
 ---@field modifier_values table<string, string[]>?
 ---@field required_modifiers string[]?

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -339,9 +339,8 @@ describe('command schema', function()
     assert.is_not_nil(pr)
   end)
 
-  it('keeps legacy browse modifiers separate from canonical ones', function()
+  it('exposes browse modifiers in declared order', function()
     assert.same({ 'repo', 'branch', 'commit', 'target' }, cmd.modifier_names('browse'))
-    assert.same({}, cmd.legacy_modifier_names('browse'))
   end)
 
   it('exposes modifier value metadata where the grammar constrains it', function()
@@ -351,7 +350,7 @@ describe('command schema', function()
   end)
 
   it('rejects invalid modifiers and duplicate modifiers', function()
-    local _, unknown = cmd.parse({ 'review', '42', '--wat=1' })
+    local _, unknown = cmd.parse({ 'review', '42', 'wat=1' })
     local _, duplicate = cmd.parse({ 'pr', 'create', 'repo=origin', 'repo=upstream' })
 
     assert.equals('unknown modifier: wat', unknown.message)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -919,8 +919,8 @@ describe(':Forge command', function()
   end)
 
   it('dispatches normalized create and clear commands through the command layer', function()
-    vim.cmd('Forge pr create --draft --fill --web')
-    vim.cmd('Forge issue create --blank --template=bug')
+    vim.cmd('Forge pr create draft fill web')
+    vim.cmd('Forge issue create blank template=bug')
     vim.cmd('Forge clear')
 
     assert.same({


### PR DESCRIPTION
## Problem

Two related cleanups, no backwards compatibility kept (per `AGENTS.md`'s
"Backwards compatibility" rule).

**(1)** The `forge.Forge` interface in `lua/forge/types.lua` declares
methods with `scope?: forge.Scope`, and the github backend already uses
`scope`. The gitlab and codeberg backends used `ref` as the local
parameter name, an unforced inconsistency that costs readability and
pattern-matching across backends. Issue #409.

**(2)** `:Forge` accepted a legacy `--name` / `--name=value` modifier
syntax in parallel with the canonical `name=value` form. The legacy
syntax was carried as documented "compatibility sugar", supported by a
parallel `legacy_modifiers` field on `forge.CommandVerbDef` /
`forge.Command`, a separate `M.legacy_modifier_names` public function,
dedicated branches in the parser and completion, and a separate
"`legacy_flag`" path in `M.complete`. None of the verbs in the families
table actually declared `legacy_modifiers`, so the field was dormant
production-wise — but the parsing/completion paths still accepted
`--name=value` for any modifier, providing a second way to do the same
thing.

## Solution

**(1)** Mechanically rename `ref` -> `scope` across all method
signatures and bodies in `lua/forge/backends/gitlab.lua` and
`lua/forge/backends/codeberg.lua`, plus the local `repo_arg(scope)` /
`project(scope)` / `hostname(scope)` helpers. Surgical reverts for
`'--ref'` (CLI flag for `glab ci list`), `entry.ref` /
`json.head.ref` / `json.base.ref` (external API field names), and
`normalize_run`'s local `ref` (a git ref like
`refs/merge-requests/N/head`, not a scope). Renamed `gitlab.lua`'s
module import from `local scope = require('forge.scope')` to
`local scope_mod = ...` to free `scope` for parameter use and to match
the convention already in `init.lua`, `resolve.lua`, and `log.lua`.

**(2)** Hard-remove the legacy `--name` syntax. No deprecation, no
shims:

- `forge.CommandVerbDef.legacy_modifiers` and
  `forge.Command.declared_legacy_modifiers` /
  `forge.Command.legacy_modifiers` fields removed from
  `lua/forge/types.lua`.
- `M.legacy_modifier_names` removed from `lua/forge/cmd.lua`.
- `token_is_modifier_like` no longer treats `^--` as modifier-like;
  only `name=value` and bare flag tokens are considered.
- Parser body simplified: the `if token:match('^--')` branch and the
  parallel `legacy_modifiers` allowed-set are gone. Only `name=value`
  and bare flag tokens (when the modifier is declared `kind = 'flag'`)
  parse.
- `completion_state` and `filtered_modifier_completion_items` lose
  the legacy branch and the `legacy` parameter.
- `M.complete` loses the `legacy_flag` block at the top and the two
  `if arglead:match('^--')` branches in family-slot and
  argument-slot completion.
- `completion_policy.declares_modifier` no longer falls back to
  legacy-modifier checks.
- Help text drops the "Compatibility sugar is still accepted ..."
  paragraph from the canonical-syntax section.
- `:Forge pr create --draft --fill --web` and
  `:Forge issue create --blank --template=bug` test cases updated to
  canonical `draft fill web` / `blank template=bug`.
- `cmd.parse({ 'review', '42', '--wat=1' })` test updated to
  `wat=1`.

User-visible: any `:Forge` invocation that used `--name` / `--name=value`
must switch to `name=value` (or bare flag for `draft` / `fill` / `web` /
`blank` / `all`). Any tab-completion that previously offered `--name`
candidates after `--` arglead no longer does. No migration window. The
canonical syntax has been the documented primary interface throughout.

`just ci` clean: nix fmt, stylua, biome, selene, lua-language-server
check, vimdoc-language-server, **633/0/0 busted**.

Closes #409.