### PR TITLE
refactor(backends): sweep ---@param/---@return annotations, remove dead tail helpers

### DIFF
--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -79,6 +79,7 @@ end
 
 ---@param state string
 ---@param limit integer?
+---@param scope forge.Scope?
 ---@return string[]
 function M:list_pr_json_cmd(state, limit, scope)
   return {
@@ -100,6 +101,7 @@ end
 
 ---@param state string
 ---@param limit integer?
+---@param scope forge.Scope?
 ---@return string[]
 function M:list_issue_json_cmd(state, limit, scope)
   return {
@@ -212,6 +214,9 @@ function M:list_web_url(kind, scope)
   return base .. path
 end
 
+---@param num string
+---@param scope forge.Scope?
+---@return string[]
 function M:checkout_cmd(num, scope)
   return { 'tea', 'pr', 'checkout', num, '--repo', repo_arg(scope) }
 end
@@ -223,12 +228,14 @@ function M:fetch_pr(num)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:pr_base_cmd(num, scope)
   return { 'tea', 'pr', num, '--fields', 'base', '--output', 'simple', '--repo', repo_arg(scope) }
 end
 
 ---@param branch string
+---@param scope forge.Scope?
 ---@return string[]
 function M:pr_for_branch_cmd(branch, scope)
   return {
@@ -243,6 +250,7 @@ function M:pr_for_branch_cmd(branch, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:checks_json_cmd(num, scope)
   local jq = [=[
@@ -279,6 +287,7 @@ end
 ---@param run_id string
 ---@param failed_only boolean
 ---@param job_id string?
+---@param scope forge.Scope?
 ---@return string[]
 function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local _ = failed_only
@@ -297,13 +306,8 @@ function M:check_log_cmd(run_id, failed_only, job_id, scope)
 end
 
 ---@param run_id string
----@return string[]
-function M:check_tail_cmd(run_id, scope)
-  return { 'tea', 'actions', 'runs', 'logs', run_id, '--follow', '--repo', repo_arg(scope) }
-end
-
----@param run_id string
 ---@param job_id string?
+---@param scope forge.Scope?
 ---@return string[]
 function M:live_tail_cmd(run_id, job_id, scope)
   local cmd = { 'tea', 'actions', 'runs', 'logs', run_id, '--follow', '--repo', repo_arg(scope) }
@@ -314,6 +318,10 @@ function M:live_tail_cmd(run_id, job_id, scope)
   return cmd
 end
 
+---@param branch string?
+---@param scope forge.Scope?
+---@param limit integer?
+---@return string[]
 function M:list_runs_json_cmd(branch, scope, limit)
   local limit_arg = tostring(limit or forge.config().display.limits.runs)
   local cmd = 'tea api --repo '
@@ -328,6 +336,7 @@ function M:list_runs_json_cmd(branch, scope, limit)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:cancel_run_cmd(id, scope)
   return {
@@ -342,6 +351,7 @@ function M:cancel_run_cmd(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:rerun_run_cmd(id, scope)
   return {
@@ -356,6 +366,7 @@ function M:rerun_run_cmd(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string?
 function M:run_web_url(id, scope)
   local base = forge.remote_web_url(scope)
@@ -366,6 +377,7 @@ function M:run_web_url(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 function M:browse_run(id, scope)
   local url = self:run_web_url(id, scope)
   if not url then
@@ -374,6 +386,8 @@ function M:browse_run(id, scope)
   vim.ui.open(url)
 end
 
+---@param entry table
+---@return forge.CIRun
 function M:normalize_run(entry)
   local status = entry.status or ''
   if status == 'completed' then
@@ -390,6 +404,10 @@ function M:normalize_run(entry)
   }
 end
 
+---@param id string
+---@param failed_only boolean
+---@param scope forge.Scope?
+---@return string[]
 function M:run_log_cmd(id, failed_only, scope)
   local _ = failed_only
   local lines = forge.config().ci.lines
@@ -400,12 +418,9 @@ function M:run_log_cmd(id, failed_only, scope)
   }
 end
 
-function M:run_tail_cmd(id, scope)
-  return { 'tea', 'actions', 'runs', 'logs', id, '--follow', '--repo', repo_arg(scope) }
-end
-
 ---@param num string
 ---@param method string
+---@param scope forge.Scope?
 ---@return string[]
 function M:merge_cmd(num, method, scope)
   local cmd = { 'tea', 'pr', 'merge', num }
@@ -419,36 +434,42 @@ function M:merge_cmd(num, method, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:approve_cmd(num, scope)
   return { 'tea', 'pr', 'approve', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:close_cmd(num, scope)
   return { 'tea', 'pulls', 'close', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:reopen_cmd(num, scope)
   return { 'tea', 'pulls', 'reopen', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:close_issue_cmd(num, scope)
   return { 'tea', 'issues', 'close', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:reopen_issue_cmd(num, scope)
   return { 'tea', 'issues', 'reopen', num, '--repo', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:fetch_pr_details_cmd(num, scope)
   return {
@@ -458,6 +479,9 @@ function M:fetch_pr_details_cmd(num, scope)
   }
 end
 
+---@param num string
+---@param scope forge.Scope?
+---@return string[]
 function M:fetch_issue_details_cmd(num, scope)
   return {
     'sh',
@@ -469,6 +493,9 @@ end
 ---@param num string
 ---@param title string
 ---@param body string
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
+---@param previous forge.CommentMetadata?
 ---@return string[]
 function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   local cmd = {
@@ -498,6 +525,13 @@ function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   return cmd
 end
 
+---@param num string
+---@param title string
+---@param body string
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
+---@param previous forge.CommentMetadata?
+---@return string[]
 function M:update_issue_cmd(num, title, body, scope, metadata, previous)
   local cmd = {
     'tea',
@@ -557,6 +591,8 @@ function M:parse_pr_details(json)
   }
 end
 
+---@param json table
+---@return forge.IssueDetails
 function M:parse_issue_details(json)
   local labels = {}
   for _, l in ipairs(json.labels or {}) do
@@ -583,6 +619,8 @@ end
 ---@param body string
 ---@param base string
 ---@param _draft boolean
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
 ---@return string[]
 function M:create_pr_cmd(title, body, base, _draft, scope, metadata)
   local cmd = {
@@ -608,6 +646,9 @@ function M:create_pr_cmd(title, body, base, _draft, scope, metadata)
   return cmd
 end
 
+---@param scope forge.Scope?
+---@param head_branch string?
+---@param base_branch string?
 ---@return string
 function M:create_pr_web_url(scope, _, head_branch, base_branch)
   local branch = head_branch or vim.trim(vim.fn.system('git branch --show-current'))
@@ -629,6 +670,8 @@ end
 ---@param title string
 ---@param body string
 ---@param labels string[]?
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
 ---@return string[]
 function M:create_issue_cmd(title, body, labels, scope, metadata)
   local cmd = {
@@ -663,6 +706,7 @@ function M:issue_template_paths()
   }
 end
 
+---@param scope forge.Scope?
 ---@return string[]
 function M:default_branch_cmd(scope)
   return {
@@ -691,6 +735,7 @@ function M:draft_toggle_cmd(_num, _is_draft)
   return nil
 end
 
+---@param scope forge.Scope?
 ---@return forge.RepoInfo
 function M:repo_info(scope)
   local result = vim
@@ -727,6 +772,7 @@ function M:repo_info(scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return forge.PRState
 function M:pr_state(num, scope)
   local result = vim
@@ -754,6 +800,9 @@ function M:pr_state(num, scope)
   }
 end
 
+---@param scope forge.Scope?
+---@param limit integer?
+---@return string[]
 function M:list_releases_json_cmd(scope, limit)
   local limit_arg = tostring(limit or forge.config().display.limits.releases)
   return {
@@ -764,12 +813,14 @@ function M:list_releases_json_cmd(scope, limit)
 end
 
 ---@param tag string
+---@param scope forge.Scope?
 function M:browse_release(tag, scope)
   local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/releases/tag/' .. tag)
 end
 
 ---@param tag string
+---@param scope forge.Scope?
 ---@return string[]
 function M:delete_release_cmd(tag, scope)
   return {

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -92,6 +92,7 @@ end
 
 ---@param state string
 ---@param limit integer?
+---@param scope forge.Scope?
 ---@return string[]
 function M:list_pr_json_cmd(state, limit, scope)
   local cmd = {
@@ -115,6 +116,7 @@ end
 
 ---@param state string
 ---@param limit integer?
+---@param scope forge.Scope?
 ---@return string[]
 function M:list_issue_json_cmd(state, limit, scope)
   local cmd = {
@@ -220,6 +222,9 @@ function M:list_web_url(kind, scope)
   return base .. path
 end
 
+---@param num string
+---@param scope forge.Scope?
+---@return string[]
 function M:checkout_cmd(num, scope)
   local cmd = { 'gh', 'pr', 'checkout', num }
   local repo = nwo(scope)
@@ -231,6 +236,7 @@ function M:checkout_cmd(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:fetch_pr(num, scope)
   local current = forge.current_scope(M.name)
@@ -246,6 +252,7 @@ function M:fetch_pr(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:pr_base_cmd(num, scope)
   return {
@@ -263,6 +270,7 @@ function M:pr_base_cmd(num, scope)
 end
 
 ---@param branch string
+---@param scope forge.Scope?
 ---@return string[]
 function M:pr_for_branch_cmd(branch, scope)
   local cmd = {
@@ -291,6 +299,7 @@ function M:checks_cmd(num)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:checks_json_cmd(num, scope)
   return {
@@ -308,6 +317,7 @@ end
 ---@param run_id string
 ---@param failed_only boolean
 ---@param job_id string?
+---@param scope forge.Scope?
 ---@return string[]
 function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local lines = forge.config().ci.lines
@@ -321,13 +331,14 @@ function M:check_log_cmd(run_id, failed_only, job_id, scope)
 end
 
 ---@param run_id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:steps_cmd(run_id, scope)
   return { 'gh', 'run', 'view', run_id, '-R', nwo(scope), '--json', 'jobs' }
 end
 
 ---@param id string
----@param opts? forge.RunViewOpts
+---@param opts forge.RunViewOpts?
 ---@return string[]
 function M:view_cmd(id, opts)
   opts = opts or {}
@@ -344,6 +355,7 @@ function M:view_cmd(id, opts)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string?
 function M:run_web_url(id, scope)
   local base = forge.remote_web_url(scope)
@@ -354,6 +366,7 @@ function M:run_web_url(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 function M:browse_run(id, scope)
   local url = self:run_web_url(id, scope)
   if not url then
@@ -364,6 +377,7 @@ end
 
 ---@param run_id string
 ---@param job_id string
+---@param scope forge.Scope?
 ---@return string?
 function M:job_web_url(run_id, job_id, scope)
   local run_url = self:run_web_url(run_id, scope)
@@ -374,6 +388,7 @@ function M:job_web_url(run_id, job_id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:summary_json_cmd(id, scope)
   local jq = table.concat({
@@ -397,29 +412,37 @@ function M:summary_json_cmd(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:watch_cmd(id, scope)
   return { 'gh', 'run', 'watch', id, '-R', nwo(scope) }
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:cancel_run_cmd(id, scope)
   return { 'gh', 'run', 'cancel', id, '-R', nwo(scope) }
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:rerun_run_cmd(id, scope)
   return { 'gh', 'run', 'rerun', id, '-R', nwo(scope) }
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:run_status_cmd(id, scope)
   return { 'gh', 'run', 'view', id, '-R', nwo(scope), '--json', 'status,conclusion' }
 end
 
+---@param id string
+---@param failed_only boolean
+---@param scope forge.Scope?
+---@return string[]
 function M:run_log_cmd(id, failed_only, scope)
   local lines = forge.config().ci.lines
   local flag = failed_only and '--log-failed' or '--log'
@@ -430,6 +453,10 @@ function M:run_log_cmd(id, failed_only, scope)
   }
 end
 
+---@param branch string?
+---@param scope forge.Scope?
+---@param limit integer?
+---@return string[]
 function M:list_runs_json_cmd(branch, scope, limit)
   local cmd = {
     'gh',
@@ -452,6 +479,8 @@ function M:list_runs_json_cmd(branch, scope, limit)
   return cmd
 end
 
+---@param entry table
+---@return forge.CIRun
 function M:normalize_run(entry)
   local status = entry.status or ''
   if status == 'completed' then
@@ -470,6 +499,7 @@ end
 
 ---@param num string
 ---@param method string
+---@param scope forge.Scope?
 ---@return string[]
 function M:merge_cmd(num, method, scope)
   local cmd = { 'gh', 'pr', 'merge', num }
@@ -485,6 +515,7 @@ function M:merge_cmd(num, method, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:approve_cmd(num, scope)
   local cmd = { 'gh', 'pr', 'review', num, '--approve' }
@@ -497,6 +528,7 @@ function M:approve_cmd(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:close_cmd(num, scope)
   local cmd = { 'gh', 'pr', 'close', num }
@@ -509,6 +541,7 @@ function M:close_cmd(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:reopen_cmd(num, scope)
   local cmd = { 'gh', 'pr', 'reopen', num }
@@ -521,6 +554,7 @@ function M:reopen_cmd(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:close_issue_cmd(num, scope)
   local cmd = { 'gh', 'issue', 'close', num }
@@ -533,6 +567,7 @@ function M:close_issue_cmd(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:reopen_issue_cmd(num, scope)
   local cmd = { 'gh', 'issue', 'reopen', num }
@@ -545,6 +580,7 @@ function M:reopen_issue_cmd(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:fetch_pr_details_cmd(num, scope)
   return {
@@ -559,6 +595,9 @@ function M:fetch_pr_details_cmd(num, scope)
   }
 end
 
+---@param num string
+---@param scope forge.Scope?
+---@return string[]
 function M:fetch_issue_details_cmd(num, scope)
   return {
     'gh',
@@ -575,6 +614,9 @@ end
 ---@param num string
 ---@param title string
 ---@param body string
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
+---@param previous forge.CommentMetadata?
 ---@return string[]
 function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   local cmd = { 'gh', 'pr', 'edit', num, '--title', title, '--body', body }
@@ -605,6 +647,13 @@ function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   return cmd
 end
 
+---@param num string
+---@param title string
+---@param body string
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
+---@param previous forge.CommentMetadata?
+---@return string[]
 function M:update_issue_cmd(num, title, body, scope, metadata, previous)
   local cmd = { 'gh', 'issue', 'edit', num, '--title', title, '--body', body }
   local current = submission.filter(self, 'issue', 'update', metadata)
@@ -663,6 +712,8 @@ function M:parse_pr_details(json)
   }
 end
 
+---@param json table
+---@return forge.IssueDetails
 function M:parse_issue_details(json)
   local labels = {}
   for _, l in ipairs(json.labels or {}) do
@@ -689,6 +740,8 @@ end
 ---@param body string
 ---@param base string
 ---@param draft boolean
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
 ---@return string[]
 function M:create_pr_cmd(title, body, base, draft, scope, metadata)
   local cmd = { 'gh', 'pr', 'create', '--title', title, '--body', body, '--base', base }
@@ -711,6 +764,10 @@ function M:create_pr_cmd(title, body, base, draft, scope, metadata)
   return cmd
 end
 
+---@param scope forge.Scope?
+---@param head_scope forge.Scope?
+---@param head_branch string?
+---@param base_branch string?
 ---@return string[]
 function M:create_pr_web_cmd(scope, head_scope, head_branch, base_branch)
   local cmd = { 'gh', 'pr', 'create', '--web' }
@@ -746,6 +803,8 @@ end
 ---@param title string
 ---@param body string
 ---@param labels string[]?
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
 ---@return string[]
 function M:create_issue_cmd(title, body, labels, scope, metadata)
   local cmd = { 'gh', 'issue', 'create', '--title', title, '--body', body }
@@ -765,6 +824,7 @@ function M:create_issue_cmd(title, body, labels, scope, metadata)
   return cmd
 end
 
+---@param scope forge.Scope?
 ---@return string?
 function M:create_issue_web_url(scope)
   local url = forge.remote_web_url(scope)
@@ -782,6 +842,7 @@ function M:issue_template_paths()
   }
 end
 
+---@param scope forge.Scope?
 ---@return string[]
 function M:default_branch_cmd(scope)
   return {
@@ -807,6 +868,7 @@ end
 
 ---@param num string
 ---@param is_draft boolean
+---@param scope forge.Scope?
 ---@return string[]?
 function M:draft_toggle_cmd(num, is_draft, scope)
   if is_draft then
@@ -815,6 +877,7 @@ function M:draft_toggle_cmd(num, is_draft, scope)
   return { 'gh', 'pr', 'ready', num, '--undo', '-R', nwo(scope) }
 end
 
+---@param scope forge.Scope?
 ---@return forge.RepoInfo
 function M:repo_info(scope)
   local result = vim
@@ -850,6 +913,7 @@ function M:repo_info(scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return forge.PRState
 function M:pr_state(num, scope)
   local result = vim
@@ -877,6 +941,9 @@ function M:pr_state(num, scope)
   }
 end
 
+---@param scope forge.Scope?
+---@param limit integer?
+---@return string[]
 function M:list_releases_json_cmd(scope, limit)
   local cmd = {
     'gh',
@@ -896,6 +963,7 @@ function M:list_releases_json_cmd(scope, limit)
 end
 
 ---@param tag string
+---@param scope forge.Scope?
 function M:browse_release(tag, scope)
   local cmd = { 'gh', 'release', 'view', tag, '--web' }
   local repo = nwo(scope)
@@ -907,6 +975,7 @@ function M:browse_release(tag, scope)
 end
 
 ---@param tag string
+---@param scope forge.Scope?
 ---@return string[]
 function M:delete_release_cmd(tag, scope)
   return { 'gh', 'release', 'delete', tag, '--yes', '-R', nwo(scope) }

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -76,6 +76,7 @@ end
 
 ---@param state string
 ---@param limit integer?
+---@param scope forge.Scope?
 ---@return string[]
 function M:list_pr_json_cmd(state, limit, scope)
   local cmd = {
@@ -102,6 +103,7 @@ end
 
 ---@param state string
 ---@param limit integer?
+---@param scope forge.Scope?
 ---@return string[]
 function M:list_issue_json_cmd(state, limit, scope)
   local cmd = {
@@ -249,11 +251,15 @@ function M:list_web_url(kind, scope)
   return base .. path
 end
 
+---@param num string
+---@param scope forge.Scope?
+---@return string[]
 function M:checkout_cmd(num, scope)
   return { 'glab', 'mr', 'checkout', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:fetch_pr(num, scope)
   local remote = 'origin'
@@ -274,6 +280,7 @@ function M:fetch_pr(num, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:pr_base_cmd(num, scope)
   return {
@@ -284,6 +291,7 @@ function M:pr_base_cmd(num, scope)
 end
 
 ---@param branch string
+---@param scope forge.Scope?
 ---@return string[]
 function M:pr_for_branch_cmd(branch, scope)
   return {
@@ -297,6 +305,7 @@ function M:pr_for_branch_cmd(branch, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:checks_json_cmd(num, scope)
   local jq = [=[
@@ -337,6 +346,7 @@ end
 ---@param run_id string
 ---@param failed_only boolean
 ---@param job_id string?
+---@param scope forge.Scope?
 ---@return string[]
 function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local _ = failed_only
@@ -350,18 +360,14 @@ function M:check_log_cmd(run_id, failed_only, job_id, scope)
 end
 
 ---@param run_id string
----@return string[]
-function M:check_tail_cmd(run_id, scope)
-  return { 'glab', 'ci', 'trace', run_id, '-R', repo_arg(scope) }
-end
-
----@param run_id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:live_tail_cmd(run_id, _, scope)
   return { 'glab', 'ci', 'trace', run_id, '-R', repo_arg(scope) }
 end
 
 ---@param id string?
+---@param scope forge.Scope?
 ---@return string[]
 function M:watch_cmd(id, scope)
   local cmd = { 'glab', 'ci', 'view' }
@@ -375,12 +381,14 @@ function M:watch_cmd(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:cancel_run_cmd(id, scope)
   return { 'glab', 'ci', 'cancel', 'pipeline', id, '-R', repo_arg(scope) }
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string[]
 function M:rerun_run_cmd(id, scope)
   return {
@@ -395,6 +403,7 @@ function M:rerun_run_cmd(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 ---@return string?
 function M:run_web_url(id, scope)
   local base = forge.remote_web_url(scope)
@@ -405,6 +414,7 @@ function M:run_web_url(id, scope)
 end
 
 ---@param id string
+---@param scope forge.Scope?
 function M:browse_run(id, scope)
   local url = self:run_web_url(id, scope)
   if not url then
@@ -413,6 +423,10 @@ function M:browse_run(id, scope)
   vim.ui.open(url)
 end
 
+---@param branch string?
+---@param scope forge.Scope?
+---@param limit integer?
+---@return string[]
 function M:list_runs_json_cmd(branch, scope, limit)
   local cmd = {
     'glab',
@@ -432,6 +446,8 @@ function M:list_runs_json_cmd(branch, scope, limit)
   return cmd
 end
 
+---@param entry table
+---@return forge.CIRun
 function M:normalize_run(entry)
   local ref = entry.ref or ''
   local mr_num = ref:match('^refs/merge%-requests/(%d+)/head$')
@@ -446,6 +462,10 @@ function M:normalize_run(entry)
   }
 end
 
+---@param id string
+---@param failed_only boolean
+---@param scope forge.Scope?
+---@return string[]
 function M:run_log_cmd(id, failed_only, scope)
   local lines = forge.config().ci.lines
   local jq_filter = failed_only and '[.[] | select(.status=="failed")][0].id // .[0].id'
@@ -464,23 +484,9 @@ function M:run_log_cmd(id, failed_only, scope)
   }
 end
 
-function M:run_tail_cmd(id, scope)
-  local jq_filter = '[.[] | select(.status=="running" or .status=="pending")][0].id // .[0].id'
-  return {
-    'sh',
-    '-c',
-    ('JOB=$(glab api --hostname %s \'projects/%s/pipelines/%s/jobs?per_page=100\' | jq -r \'%s\') && [ "$JOB" != "null" ] && glab ci trace "$JOB" -R \'%s\''):format(
-      hostname(scope) or 'gitlab.com',
-      project(scope),
-      id,
-      jq_filter,
-      repo_arg(scope)
-    ),
-  }
-end
-
 ---@param num string
 ---@param method string
+---@param scope forge.Scope?
 ---@return string[]
 function M:merge_cmd(num, method, scope)
   local cmd = { 'glab', 'mr', 'merge', num }
@@ -495,18 +501,21 @@ function M:merge_cmd(num, method, scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:approve_cmd(num, scope)
   return { 'glab', 'mr', 'approve', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:close_cmd(num, scope)
   return { 'glab', 'mr', 'close', num, '-R', repo_arg(scope) }
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:reopen_cmd(num, scope)
   return { 'glab', 'mr', 'reopen', num, '-R', repo_arg(scope) }
@@ -525,11 +534,15 @@ function M:reopen_issue_cmd(num)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return string[]
 function M:fetch_pr_details_cmd(num, scope)
   return { 'glab', 'mr', 'view', num, '--output', 'json', '-R', repo_arg(scope) }
 end
 
+---@param num string
+---@param scope forge.Scope?
+---@return string[]
 function M:fetch_issue_details_cmd(num, scope)
   return { 'glab', 'issue', 'view', num, '--output', 'json', '-R', repo_arg(scope) }
 end
@@ -537,6 +550,9 @@ end
 ---@param num string
 ---@param title string
 ---@param body string
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
+---@param previous forge.CommentMetadata?
 ---@return string[]
 function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   local cmd =
@@ -577,6 +593,13 @@ function M:update_pr_cmd(num, title, body, scope, metadata, previous)
   return cmd
 end
 
+---@param num string
+---@param title string
+---@param body string
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
+---@param previous forge.CommentMetadata?
+---@return string[]
 function M:update_issue_cmd(num, title, body, scope, metadata, previous)
   local cmd = {
     'glab',
@@ -644,6 +667,8 @@ function M:parse_pr_details(json)
   }
 end
 
+---@param json table
+---@return forge.IssueDetails
 function M:parse_issue_details(json)
   local labels = {}
   for _, l in ipairs(json.labels or {}) do
@@ -670,6 +695,8 @@ end
 ---@param body string
 ---@param base string
 ---@param draft boolean
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
 ---@return string[]
 function M:create_pr_cmd(title, body, base, draft, scope, metadata)
   local cmd = {
@@ -700,6 +727,10 @@ function M:create_pr_cmd(title, body, base, draft, scope, metadata)
   return cmd
 end
 
+---@param scope forge.Scope?
+---@param head_scope forge.Scope?
+---@param head_branch string?
+---@param base_branch string?
 ---@return string[]
 function M:create_pr_web_cmd(scope, head_scope, head_branch, base_branch)
   local cmd = { 'glab', 'mr', 'create', '--web', '-R', repo_arg(scope) }
@@ -725,6 +756,8 @@ end
 ---@param title string
 ---@param body string
 ---@param labels string[]?
+---@param scope forge.Scope?
+---@param metadata forge.CommentMetadata?
 ---@return string[]
 function M:create_issue_cmd(title, body, labels, scope, metadata)
   local cmd = {
@@ -750,6 +783,7 @@ function M:create_issue_cmd(title, body, labels, scope, metadata)
   return cmd
 end
 
+---@param scope forge.Scope?
 ---@return string[]
 function M:create_issue_web_cmd(scope)
   return { 'glab', 'issue', 'create', '--web', '-R', repo_arg(scope) }
@@ -760,6 +794,7 @@ function M:issue_template_paths()
   return { '.gitlab/issue_templates/' }
 end
 
+---@param scope forge.Scope?
 ---@return string[]
 function M:default_branch_cmd(scope)
   return {
@@ -776,6 +811,7 @@ end
 
 ---@param num string
 ---@param is_draft boolean
+---@param scope forge.Scope?
 ---@return string[]?
 function M:draft_toggle_cmd(num, is_draft, scope)
   if is_draft then
@@ -784,6 +820,7 @@ function M:draft_toggle_cmd(num, is_draft, scope)
   return { 'glab', 'mr', 'update', num, '--draft', '-R', repo_arg(scope) }
 end
 
+---@param scope forge.Scope?
 ---@return forge.RepoInfo
 function M:repo_info(scope)
   local result = vim
@@ -831,6 +868,7 @@ function M:repo_info(scope)
 end
 
 ---@param num string
+---@param scope forge.Scope?
 ---@return forge.PRState
 function M:pr_state(num, scope)
   local result = vim
@@ -848,6 +886,9 @@ function M:pr_state(num, scope)
   }
 end
 
+---@param scope forge.Scope?
+---@param limit integer?
+---@return string[]
 function M:list_releases_json_cmd(scope, limit)
   return {
     'glab',
@@ -863,12 +904,14 @@ function M:list_releases_json_cmd(scope, limit)
 end
 
 ---@param tag string
+---@param scope forge.Scope?
 function M:browse_release(tag, scope)
   local base = forge.remote_web_url(scope)
   vim.ui.open(base .. '/-/releases/' .. tag)
 end
 
 ---@param tag string
+---@param scope forge.Scope?
 ---@return string[]
 function M:delete_release_cmd(tag, scope)
   return { 'glab', 'release', 'delete', tag, '-R', repo_arg(scope) }


### PR DESCRIPTION
## Problem

Many backend methods in `lua/forge/backends/{github,gitlab,codeberg}.lua`
were missing `---@param` annotations and `---@return` annotations. PRs #407
and #413 covered the immediate browse/`view_web`/`list_web_url`
neighbourhood; the rest of each backend - PR commands, issue commands, CI
commands, repo info, fetch_pr, create/update commands, releases - was still
sparsely annotated.

`lua-language-server --check` passed because the canonical signatures live on
`forge.Forge` in `lua/forge/types.lua`, but the implementation files lost
hover-doc precision and pattern-matching across backends. Issue #408.

A second incidental finding: `M:check_tail_cmd` and `M:run_tail_cmd` exist
in `gitlab.lua` and `codeberg.lua` but are not declared on `forge.Forge`
and have zero call sites anywhere in the codebase. They are superseded by
the canonical `live_tail_cmd` field on `forge.Forge`. Dead code.

## Solution

**Mechanical annotation sweep.** Every `M:method(...)` definition in the
three backend files now has:

- `---@param` lines for every non-leading-underscore parameter, in the same
  order as the function signature, with types pulled directly from the
  matching `forge.Forge` field in `lua/forge/types.lua`
- `---@return` line matching the canonical return type when the field
  declares one (omitted for void methods)

Order normalized so `---@param`s always precede `---@return` within each
annotation block.

171 `---@param` lines and 24 `---@return` lines added across the three
files. No behavior change. lua-language-server check stays clean.

**Dead code removed** per `AGENTS.md`'s no-BC rule:

- `M:check_tail_cmd` in gitlab and codeberg backends
- `M:run_tail_cmd` in gitlab and codeberg backends

Both methods had no call sites anywhere in `lua/`, no declaration on
`forge.Forge`, and no test coverage. Live-tail goes through the canonical
`live_tail_cmd` on the interface.

## Verification

`just ci` clean: nix fmt, stylua, biome, selene, lua-language-server check
(no problems), vimdoc-language-server, **633/0/0 busted**.

Closes #408.