### PR TITLE
feat(cmd): validate numeric subjects on PR/issue/browse verbs

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -192,7 +192,7 @@ local families = {
     verb_order = { 'open' },
     verbs = {
       open = {
-        subject = { min = 0, max = 1 },
+        subject = { kind = 'pr', min = 0, max = 1 },
         modifiers = { 'repo', 'branch', 'commit', 'target' },
       },
     },
@@ -217,6 +217,18 @@ local family_index = {}
 for _, family in ipairs(families) do
   family_index[family.name] = family
 end
+
+---@type table<string, string>
+local subject_kind_patterns = {
+  pr = '^%d+$',
+  issue = '^%d+$',
+}
+
+---@type table<string, string>
+local subject_kind_labels = {
+  pr = 'PR number',
+  issue = 'issue number',
+}
 
 local function copy(value)
   return vim.deepcopy(value)
@@ -858,8 +870,10 @@ function M.parse(args, opts)
   if implicit_command and verb_token ~= nil and not token_is_modifier_like(verb_token) then
     local subject = implicit_command.subject or {}
     local kind = subject.kind
-    local looks_like_subject = kind ~= 'pr' and kind ~= 'issue' and kind ~= 'run'
-      or verb_token:match('^%d+$') ~= nil
+    local only_default_verb = #(family.verb_order or {}) <= 1
+    local looks_like_subject = only_default_verb
+      or (kind ~= 'pr' and kind ~= 'issue' and kind ~= 'run')
+      or (verb_token:match('^%d+$') ~= nil)
     if not looks_like_subject then
       return error_result(unknown_verb_error(family.name, verb_token))
     end
@@ -930,6 +944,16 @@ function M.parse(args, opts)
   end
   if max ~= nil and #command.subjects > max then
     return error_result(subject_error(command.family, command.name, false))
+  end
+
+  local subject_pattern = subject.kind and subject_kind_patterns[subject.kind] or nil
+  if subject_pattern then
+    local subject_label = subject_kind_labels[subject.kind] or 'subject'
+    for _, value in ipairs(command.subjects) do
+      if not value:match(subject_pattern) then
+        return error_result(('invalid %s: %s'):format(subject_label, value))
+      end
+    end
   end
 
   for name, value in pairs(command.modifiers) do

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -369,6 +369,62 @@ describe('command schema', function()
     assert.equals('invalid commit: abc:def', commit_err.message)
   end)
 
+  it('rejects non-numeric subjects on PR-numbered verbs', function()
+    local _, browse_err = cmd.parse({ 'browse', 'main' })
+    local _, pr_browse_err = cmd.parse({ 'pr', 'browse', 'main' })
+    local _, pr_ci_err = cmd.parse({ 'pr', 'ci', 'main' })
+    local _, pr_close_err = cmd.parse({ 'pr', 'close', 'abc' })
+    local _, pr_merge_err = cmd.parse({ 'pr', 'merge', 'topic' })
+    local _, review_err = cmd.parse({ 'review', 'topic' })
+
+    assert.equals('invalid PR number: main', browse_err.message)
+    assert.equals('invalid PR number: main', pr_browse_err.message)
+    assert.equals('invalid PR number: main', pr_ci_err.message)
+    assert.equals('invalid PR number: abc', pr_close_err.message)
+    assert.equals('invalid PR number: topic', pr_merge_err.message)
+    assert.equals('invalid PR number: topic', review_err.message)
+  end)
+
+  it(
+    'preserves unknown-action errors when the family has multiple verbs and the token might be a verb typo',
+    function()
+      local _, pr_typo = cmd.parse({ 'pr', 'main' })
+      local _, issue_typo = cmd.parse({ 'issue', 'foo' })
+
+      assert.equals('unknown pr action: main', pr_typo.message)
+      assert.equals('unknown issue action: foo', issue_typo.message)
+    end
+  )
+
+  it('rejects non-numeric subjects on issue-numbered verbs', function()
+    local _, browse_err = cmd.parse({ 'issue', 'browse', 'main' })
+    local _, close_err = cmd.parse({ 'issue', 'close', 'abc' })
+    local _, edit_err = cmd.parse({ 'issue', 'edit', 'foo' })
+
+    assert.equals('invalid issue number: main', browse_err.message)
+    assert.equals('invalid issue number: abc', close_err.message)
+    assert.equals('invalid issue number: foo', edit_err.message)
+  end)
+
+  it('accepts purely numeric subjects on PR/issue verbs', function()
+    assert.is_not_nil(cmd.parse({ 'pr', '42' }))
+    assert.is_not_nil(cmd.parse({ 'pr', 'browse', '42' }))
+    assert.is_not_nil(cmd.parse({ 'pr', 'ci', '42' }))
+    assert.is_not_nil(cmd.parse({ 'pr', 'close', '42' }))
+    assert.is_not_nil(cmd.parse({ 'review', '42' }))
+    assert.is_not_nil(cmd.parse({ 'issue', 'browse', '7' }))
+    assert.is_not_nil(cmd.parse({ 'issue', 'close', '7' }))
+    assert.is_not_nil(cmd.parse({ 'browse', '42' }))
+  end)
+
+  it('leaves release tags and CI run ids unconstrained', function()
+    assert.is_not_nil(cmd.parse({ 'release', 'browse', 'v1.2.3' }))
+    assert.is_not_nil(cmd.parse({ 'release', 'browse', 'release-2024' }))
+    assert.is_not_nil(cmd.parse({ 'release', 'delete', 'v1.2.3' }))
+    assert.is_not_nil(cmd.parse({ 'ci', 'open', '24964024953' }))
+    assert.is_not_nil(cmd.parse({ 'ci', 'browse', 'abc-123' }))
+  end)
+
   it('returns nil or empty data for unknown lookups', function()
     assert.is_nil(cmd.family('missing'))
     assert.is_nil(cmd.resolve('pr', 'missing'))


### PR DESCRIPTION
## Problem

Browse-by-number commands and other PR/issue verbs accepted any string
subject without validation:

- `:Forge browse main` fell through to `browse_subject('main', scope)`,
  which fired an API call that 404'd with a confusing message.
- `:Forge issue browse main` did the same against `gh/glab/tea issue view`.
- `:Forge pr browse main` (added in #407) had the same gap.

The cmd dispatch layer accepted these subjects because the subject specs
(`subject = { kind = 'pr', min = 0, max = 1 }`) only constrained arity, not
content. Issue #410.

## Solution

**Per-kind validation in `lua/forge/cmd.lua`.** A new
`subject_kind_patterns` table drives validation:

```lua
local subject_kind_patterns = {
  pr = '^%d+$',
  issue = '^%d+$',
}

local subject_kind_labels = {
  pr = 'PR number',
  issue = 'issue number',
}
```

Validation runs in `M.parse()` after the count check. When a subject's
`kind` has a pattern and the value doesn't match, parsing fails with a
clean error mirroring the existing `invalid branch:` / `invalid commit:`
phrasing:

- `:Forge pr browse main` -> `invalid PR number: main`
- `:Forge issue browse foo` -> `invalid issue number: foo`
- `:Forge browse main` -> `invalid PR number: main`

Release tags (`kind = 'release'`) and CI run ids (`kind = 'run'`) stay
unconstrained per the issue's guidance, since tags can be `v1.2.3` etc.

The `browse` family's `open` verb gets `subject = { kind = 'pr', min = 0,
max = 1 }` (was unkinded), so `:Forge browse {num}` participates in the
same numeric validation.

**Verb-typo heuristic refinement.** `M.parse` had an existing heuristic
that treats the second token after a family with `default_verb` as
either a verb-typo or a subject, distinguishing by whether the token is
digits. With validation now producing a more useful error than the
404-from-CLI fallback, that heuristic is tightened: when a family has
only its default verb (`browse`, `review`), the second token can only be
a subject (no verb-typo possible), so it routes through subject
validation and produces `invalid PR number: main` instead of the
opaque `unknown <family> action: main`.

For multi-verb families (`pr`, `issue`, `ci`, `release`), the
existing `unknown <family> action: <token>` behavior is preserved
because `main` / `ed` / `chekout` could plausibly be verb typos there.

## Tests

5 new tests covering:

- Non-numeric subjects rejected on PR-numbered verbs (`browse`,
  `pr browse`, `pr ci`, `pr close`, `pr merge`, `review`).
- Non-numeric subjects rejected on issue-numbered verbs
  (`issue browse`, `issue close`, `issue edit`).
- Numeric subjects still accepted on all PR/issue verbs.
- Release tags and CI run ids left unconstrained
  (`release browse v1.2.3`, `release browse release-2024`,
  `ci open 24964024953`, `ci browse abc-123`).
- The verb-typo heuristic preserved for multi-verb families
  (`pr main` -> `unknown pr action: main`).

`just ci` clean: nix fmt, stylua, biome, selene, lua-language-server,
vimdoc-language-server, **638/0/0 busted** (up from 633).

Closes #410.