### PR TITLE
fix(cmd): use MR terminology in invalid-PR-number errors on GitLab

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -230,6 +230,22 @@ local subject_kind_labels = {
   issue = 'issue number',
 }
 
+---@type table<string, table<string, string>>
+local subject_kind_labels_by_forge = {
+  gitlab = { pr = 'MR number' },
+}
+
+---@param kind string
+---@param forge_name string?
+---@return string
+local function subject_kind_label(kind, forge_name)
+  local overrides = forge_name and subject_kind_labels_by_forge[forge_name] or nil
+  if overrides and overrides[kind] then
+    return overrides[kind]
+  end
+  return subject_kind_labels[kind] or 'subject'
+end
+
 local function copy(value)
   return vim.deepcopy(value)
 end
@@ -948,7 +964,7 @@ function M.parse(args, opts)
 
   local subject_pattern = subject.kind and subject_kind_patterns[subject.kind] or nil
   if subject_pattern then
-    local subject_label = subject_kind_labels[subject.kind] or 'subject'
+    local subject_label = subject_kind_label(subject.kind, opts.forge_name)
     for _, value in ipairs(command.subjects) do
       if not value:match(subject_pattern) then
         return error_result(('invalid %s: %s'):format(subject_label, value))

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -406,6 +406,33 @@ describe('command schema', function()
     assert.equals('invalid issue number: foo', edit_err.message)
   end)
 
+  it('uses MR terminology for invalid PR-number errors on GitLab', function()
+    local opts = { forge_name = 'gitlab' }
+    local _, browse_err = cmd.parse({ 'pr', 'browse', 'main' }, opts)
+    local _, mr_alias_err = cmd.parse({ 'mr', 'browse', 'main' }, opts)
+    local _, ci_err = cmd.parse({ 'pr', 'ci', 'topic' }, opts)
+    local _, review_err = cmd.parse({ 'review', 'topic' }, opts)
+    local _, browse_subject_err = cmd.parse({ 'browse', 'main' }, opts)
+    local _, issue_err = cmd.parse({ 'issue', 'browse', 'main' }, opts)
+
+    assert.equals('invalid MR number: main', browse_err.message)
+    assert.equals('invalid MR number: main', mr_alias_err.message)
+    assert.equals('invalid MR number: topic', ci_err.message)
+    assert.equals('invalid MR number: topic', review_err.message)
+    assert.equals('invalid MR number: main', browse_subject_err.message)
+    assert.equals('invalid issue number: main', issue_err.message)
+  end)
+
+  it('keeps PR terminology when no forge_name is supplied or the forge is not GitLab', function()
+    local _, no_forge = cmd.parse({ 'pr', 'browse', 'main' })
+    local _, github = cmd.parse({ 'pr', 'browse', 'main' }, { forge_name = 'github' })
+    local _, codeberg = cmd.parse({ 'pr', 'browse', 'main' }, { forge_name = 'codeberg' })
+
+    assert.equals('invalid PR number: main', no_forge.message)
+    assert.equals('invalid PR number: main', github.message)
+    assert.equals('invalid PR number: main', codeberg.message)
+  end)
+
   it('accepts purely numeric subjects on PR/issue verbs', function()
     assert.is_not_nil(cmd.parse({ 'pr', '42' }))
     assert.is_not_nil(cmd.parse({ 'pr', 'browse', '42' }))


### PR DESCRIPTION
## Problem

The cmd-layer subject validator added in #415 used a static
`subject_kind_labels` table and produced `invalid PR number: main` for
every forge. On GitLab, where the user types `:Forge mr browse main` or
`:Forge pr browse main` (`mr` being the alias for `pr`), the error
should say `invalid MR number` to match the user's mental model and
align with how `forge.labels.pr_one` is already used elsewhere - e.g.
`no open MR found for this branch` (init.lua:564) and the `ambiguous:
MR and issue #N...` message in gitlab.lua's `browse_subject`.

The cmd parser doesn't have a forge handle, but `opts.forge_name` is
already plumbed into `M.parse` from `M.run` and `M.complete`, so no new
wiring is needed.

## Solution

Adds a small per-forge override map and a `subject_kind_label(kind,
forge_name)` helper that consults it:

```lua
local subject_kind_labels_by_forge = {
  gitlab = { pr = 'MR number' },
}
```

The validation site uses the helper instead of the static table. Default
labels (`PR number`, `issue number`) stay the same. Only GitLab + `pr`
kind gets the override.

User-visible: on GitLab,
- `:Forge pr browse main` -> `invalid MR number: main`
- `:Forge mr browse main` -> `invalid MR number: main`
- `:Forge browse main` -> `invalid MR number: main`
- `:Forge pr ci topic` -> `invalid MR number: topic`
- `:Forge review topic` -> `invalid MR number: topic`
- `:Forge issue browse main` -> `invalid issue number: main` (unchanged)

On GitHub, Codeberg, and when no forge is detected: still `invalid PR
number` / `invalid issue number`.

## Tests

Two new specs: one asserts the GitLab terminology across the affected
verbs, the other asserts default/github/codeberg behavior is unchanged.

`just ci` clean: nix fmt, stylua, biome, selene, lua-language-server,
vimdoc-language-server, **640/0/0 busted** (up from 638).