### PR TITLE
fix: inline forge.labels.pr_one at PR-number error sites

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -224,12 +224,6 @@ local subject_kind_patterns = {
   issue = '^%d+$',
 }
 
----@type table<string, string>
-local subject_kind_labels = {
-  pr = 'PR number',
-  issue = 'issue number',
-}
-
 local function copy(value)
   return vim.deepcopy(value)
 end
@@ -265,7 +259,8 @@ end
 local function subject_error(family, verb, missing)
   if family == 'pr' then
     if verb == 'edit' then
-      return 'missing PR number'
+      local f = require('forge').detect()
+      return ('missing %s number'):format((f and f.labels and f.labels.pr_one) or 'PR')
     end
     return missing and 'missing argument' or 'too many arguments'
   end
@@ -273,7 +268,11 @@ local function subject_error(family, verb, missing)
     return missing and 'missing issue number' or 'too many arguments'
   end
   if family == 'review' then
-    return missing and 'missing PR number' or 'too many arguments'
+    if missing then
+      local f = require('forge').detect()
+      return ('missing %s number'):format((f and f.labels and f.labels.pr_one) or 'PR')
+    end
+    return 'too many arguments'
   end
   if family == 'release' then
     return missing and 'missing release tag' or 'too many arguments'
@@ -948,7 +947,15 @@ function M.parse(args, opts)
 
   local subject_pattern = subject.kind and subject_kind_patterns[subject.kind] or nil
   if subject_pattern then
-    local subject_label = subject_kind_labels[subject.kind] or 'subject'
+    local subject_label
+    if subject.kind == 'pr' then
+      local f = require('forge').detect()
+      subject_label = ((f and f.labels and f.labels.pr_one) or 'PR') .. ' number'
+    elseif subject.kind == 'issue' then
+      subject_label = 'issue number'
+    else
+      subject_label = 'subject'
+    end
     for _, value in ipairs(command.subjects) do
       if not value:match(subject_pattern) then
         return error_result(('invalid %s: %s'):format(subject_label, value))

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -537,7 +537,9 @@ local function resolve_pr_action_target(opts, require_forge)
       end
     end
     if not num then
-      log.warn('missing PR number')
+      local f = forge or M.detect()
+      local label = (f and f.labels and f.labels.pr_one) or 'PR'
+      log.warn('missing ' .. label .. ' number')
       return nil
     end
     return forge, resolve_explicit_pr(opts, forge)

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -52,6 +52,9 @@ describe('command schema', function()
             },
           }
         end,
+        detect = function()
+          return nil
+        end,
       }
     end
 
@@ -404,6 +407,54 @@ describe('command schema', function()
     assert.equals('invalid issue number: main', browse_err.message)
     assert.equals('invalid issue number: abc', close_err.message)
     assert.equals('invalid issue number: foo', edit_err.message)
+  end)
+
+  it('uses MR terminology when the active forge labels its PRs as MR (GitLab)', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return { targets = { aliases = {} } }
+        end,
+        detect = function()
+          return { name = 'gitlab', labels = { pr_one = 'MR' } }
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+
+    local _, browse_err = cmd.parse({ 'pr', 'browse', 'main' })
+    local _, ci_err = cmd.parse({ 'pr', 'ci', 'topic' })
+    local _, review_err = cmd.parse({ 'review', 'topic' })
+    local _, browse_subject_err = cmd.parse({ 'browse', 'main' })
+    local _, missing_edit_err = cmd.parse({ 'pr', 'edit' })
+    local _, issue_err = cmd.parse({ 'issue', 'browse', 'main' })
+
+    assert.equals('invalid MR number: main', browse_err.message)
+    assert.equals('invalid MR number: topic', ci_err.message)
+    assert.equals('invalid MR number: topic', review_err.message)
+    assert.equals('invalid MR number: main', browse_subject_err.message)
+    assert.equals('missing MR number', missing_edit_err.message)
+    assert.equals('invalid issue number: main', issue_err.message)
+  end)
+
+  it('falls back to PR when no forge is detected or labels are missing', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return { targets = { aliases = {} } }
+        end,
+        detect = function()
+          return nil
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+
+    local _, browse_err = cmd.parse({ 'pr', 'browse', 'main' })
+    local _, missing_edit_err = cmd.parse({ 'pr', 'edit' })
+
+    assert.equals('invalid PR number: main', browse_err.message)
+    assert.equals('missing PR number', missing_edit_err.message)
   end)
 
   it('accepts purely numeric subjects on PR/issue verbs', function()


### PR DESCRIPTION
## Problem

The cmd-layer subject validator added in #415 used a static
`subject_kind_labels = { pr = 'PR number' }` table that was forge-blind.
On GitLab, where the user types `:Forge mr browse main` and sees \"MR\"
in every other Forge surface, the parse error still said \"invalid PR
number\". My closed PR #416 tried to patch this with a per-forge override
map (`subject_kind_labels_by_forge = { gitlab = { pr = 'MR number' } }`)
inside cmd.lua \u2014 which leaks forge-specific knowledge outside the backend
layer, exactly the kind of structural drift `AGENTS.md` rules out.

The right model is: each backend already publishes its own label via
`forge.Forge.labels.pr_one` (`PR` on github/codeberg, `MR` on gitlab).
Logging code in any module consults the active forge directly and inlines
that label into its format strings. No mid-layer module carries
forge-specific knowledge.

## Solution

Inline `forge.labels.pr_one` at every cmd-layer site that names a PR/MR
number. No helper, no override map, no abstraction layer hiding which
forge is consulted.

Pattern at each site:

```lua
local f = require('forge').detect()
local pr_one = (f and f.labels and f.labels.pr_one) or 'PR'
return ('invalid %s number: %s'):format(pr_one, value)
```

Sites updated:

- **cmd.lua subject validation** (added in #415): the `kind == 'pr'`
  branch now fetches the forge inline. `kind == 'issue'` stays universal
  since \"issue\" is consistent across all three forges.
- **cmd.lua `subject_error`**: same inline pattern at the
  `family == 'pr', verb == 'edit'` branch and the `family == 'review'`
  missing branch (the only two sites that hardcoded `'missing PR
  number'`).
- **init.lua `resolve_pr_action_target`**: `log.warn('missing PR
  number')` was hardcoded; now `(forge or M.detect()).labels.pr_one`.

## Architectural note

Pre-existing label sites already follow this pattern:

- `cmd.lua:439` \u2014 `(f.labels and f.labels.pr_one) or 'PR'`
- `init.lua:564` \u2014 `forge.labels.pr_one or 'PR'`
- `resolve.lua:248`, `resolve.lua:252` \u2014 same

This PR just brings the four remaining holdouts into line. Per-forge
behavior dispatch in non-backend files (`ops.lua`'s `if f.name ==
'github' then github_ci_term(...)`, `pickers.lua`'s GitLab CI label
casing rule, `resolve.lua`'s per-forge `pr_head` switch) is a deeper
architectural concern \u2014 worth flagging but out of scope here.

## Tests

- `package.preload['forge']` is extended in `before_each` with
  `detect = function() return nil end` so every existing test exercises
  the fallback `'PR'` path without changing assertions.
- New spec mocks `detect` returning `{ labels = { pr_one = 'MR' } }` and
  asserts the four GitLab-labeled error messages
  (`invalid MR number: main` for `pr browse`, `pr ci`, `review`, and
  bare `browse`; `missing MR number` for `pr edit`) plus that the issue
  branch is unaffected (`invalid issue number: main`).
- Companion spec mocks `detect = function() return nil end` and asserts
  the fallback to `'PR'` for both inline and fallback branches.

`just ci` clean: nix fmt, stylua, biome, selene, lua-language-server,
vimdoc-language-server, **640/0/0 busted** (up from 638).

Replaces #416.