### PR TITLE
refactor(picker): make header hint ordering explicit

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -151,33 +151,41 @@ end
 ---@param actions forge.PickerActionDef[]
 ---@param bindings table<string, string|false>
 ---@param entry forge.PickerEntry?
+---@param header_order? string[]
 ---@return string?
-local function render_header_for(actions, bindings, entry)
+local function render_header_for(actions, bindings, entry, header_order)
   local picker_mod = require('forge.picker')
   local utils = require('fzf-lua.utils')
   local hls = header_hls()
+  local hints = {}
   local parts = {}
-  local seen_keys = {}
-  for _, def in ipairs(actions) do
+  for index, def in ipairs(actions) do
     local key = def.name == 'default' and '<cr>' or bindings[def.name]
     local header_key = key and to_header_key(key) or nil
     local label = header_key and picker_mod.resolve_label(def, entry) or nil
-    if header_key and label and not seen_keys[header_key] then
-      seen_keys[header_key] = true
-      local bracketed_key = header_key:match('^<(.*)>$')
-      table.insert(
-        parts,
-        bracketed_key
-            and ('<%s> %s'):format(
-              utils.ansi_from_hl(hls.bind, bracketed_key),
-              utils.ansi_from_hl(hls.text, label)
-            )
-          or ('%s %s'):format(
-            utils.ansi_from_hl(hls.bind, header_key),
-            utils.ansi_from_hl(hls.text, label)
-          )
-      )
+    if header_key and label then
+      hints[#hints + 1] = {
+        name = def.name,
+        key = header_key,
+        label = label,
+        index = index,
+      }
     end
+  end
+  for _, hint in ipairs(picker_mod.order_hints(hints, header_order)) do
+    local bracketed_key = hint.key:match('^<(.*)>$')
+    table.insert(
+      parts,
+      bracketed_key
+          and ('<%s> %s'):format(
+            utils.ansi_from_hl(hls.bind, bracketed_key),
+            utils.ansi_from_hl(hls.text, hint.label)
+          )
+        or ('%s %s'):format(
+          utils.ansi_from_hl(hls.bind, hint.key),
+          utils.ansi_from_hl(hls.text, hint.label)
+        )
+    )
   end
   if #parts == 0 then
     return nil
@@ -187,9 +195,10 @@ end
 
 ---@param actions forge.PickerActionDef[]
 ---@param bindings table<string, string|false>
+---@param header_order? string[]
 ---@return string?
-local function render_header(actions, bindings)
-  return render_header_for(actions, bindings, nil)
+local function render_header(actions, bindings, header_order)
+  return render_header_for(actions, bindings, nil, header_order)
 end
 
 ---@param actions forge.PickerActionDef[]
@@ -234,6 +243,7 @@ function M.pick(opts)
   local bindings = keys[opts.picker_name] or {}
   local entries = opts.entries or {}
   local stream = rawget(opts, 'stream')
+  local header_order = rawget(opts, 'header_order')
   local show_header = rawget(opts, 'show_header') ~= false
   local seed_entries = vim.list_extend({}, entries)
   local actions = vim.deepcopy(opts.actions or {})
@@ -286,25 +296,25 @@ function M.pick(opts)
     if not dynamic_header then
       return nil
     end
-    return transport_header(render_header_for(actions, bindings, entry))
+    return transport_header(render_header_for(actions, bindings, entry, header_order))
   end
 
   local initial_header
   if dynamic_header then
     for _, entry in ipairs(entries) do
       if not rawget(entry, 'placeholder') and not rawget(entry, 'load_more') then
-        initial_header = render_header_for(actions, bindings, entry)
+        initial_header = render_header_for(actions, bindings, entry, header_order)
         break
       end
     end
     if not initial_header and entries[1] ~= nil then
-      initial_header = render_header_for(actions, bindings, entries[1])
+      initial_header = render_header_for(actions, bindings, entries[1], header_order)
     end
     if not initial_header then
-      initial_header = render_header_for(actions, bindings, nil)
+      initial_header = render_header_for(actions, bindings, nil, header_order)
     end
   elseif show_header then
-    initial_header = render_header(actions, bindings)
+    initial_header = render_header(actions, bindings, header_order)
   end
 
   local lines

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -30,9 +30,16 @@ local surface = require('forge.surface')
 ---@field prompt string?
 ---@field entries forge.PickerEntry[]
 ---@field actions forge.PickerActionDef[]
+---@field header_order? string[]
 ---@field picker_name string
 ---@field back fun()?
 ---@field stream? fun(emit: fun(entry: forge.PickerEntry?))
+
+---@class forge.PickerHint
+---@field name string
+---@field key string
+---@field label string
+---@field index integer?
 
 ---@type table<string, string[]>
 local root_search_terms = {
@@ -228,6 +235,44 @@ end
 ---@return boolean
 function M.has_dynamic_label(def)
   return type(rawget(def, 'label')) == 'function' or type(rawget(def, 'available')) == 'function'
+end
+
+---@param hints forge.PickerHint[]
+---@param order? string[]
+---@return forge.PickerHint[]
+function M.order_hints(hints, order)
+  local ranks = {}
+  for index, name in ipairs(order or {}) do
+    if type(name) == 'string' and ranks[name] == nil then
+      ranks[name] = index
+    end
+  end
+
+  local sorted = {}
+  for index, hint in ipairs(hints or {}) do
+    if type(hint) == 'table' and type(hint.name) == 'string' and type(hint.key) == 'string' then
+      sorted[#sorted + 1] = vim.tbl_extend('keep', { index = index }, hint)
+    end
+  end
+
+  table.sort(sorted, function(a, b)
+    local a_rank = ranks[a.name] or math.huge
+    local b_rank = ranks[b.name] or math.huge
+    if a_rank ~= b_rank then
+      return a_rank < b_rank
+    end
+    return (a.index or 0) < (b.index or 0)
+  end)
+
+  local ordered = {}
+  local seen_keys = {}
+  for _, hint in ipairs(sorted) do
+    if not seen_keys[hint.key] then
+      seen_keys[hint.key] = true
+      ordered[#ordered + 1] = hint
+    end
+  end
+  return ordered
 end
 
 ---@param entry forge.PickerEntry?

--- a/lua/forge/picker/session.lua
+++ b/lua/forge/picker/session.lua
@@ -156,6 +156,7 @@ function M.pick_json(opts)
     prompt = resolve(opts.loading_prompt) or '',
     entries = {},
     actions = opts.actions,
+    header_order = opts.header_order,
     picker_name = opts.picker_name,
     back = opts.back,
     stream = opts.stream or function(emit)

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -14,6 +14,60 @@ local next_ci_filter = {
   pending = 'all',
 }
 
+local pr_header_order = {
+  'default',
+  'ci',
+  'edit',
+  'approve',
+  'merge',
+  'toggle',
+  'draft',
+  'create',
+  'filter',
+  'refresh',
+}
+
+local issue_header_order = {
+  'default',
+  'browse',
+  'edit',
+  'toggle',
+  'create',
+  'filter',
+  'refresh',
+}
+
+local ci_header_order = {
+  'default',
+  'browse',
+  'toggle',
+  'filter',
+  'failed',
+  'passed',
+  'running',
+  'all',
+  'refresh',
+}
+
+local checks_header_order = {
+  'default',
+  'browse',
+  'filter',
+  'failed',
+  'passed',
+  'running',
+  'all',
+  'refresh',
+}
+
+local release_header_order = {
+  'browse',
+  'yank',
+  'delete',
+  'filter',
+  'refresh',
+}
+
 ---@param text string
 ---@param kind? 'empty'|'error'
 ---@return forge.PickerEntry
@@ -447,6 +501,7 @@ function M.checks(f, num, filter, cached_checks, opts)
       prompt = checks_prompt(count),
       entries = entries,
       actions = actions,
+      header_order = checks_header_order,
       picker_name = 'ci',
       back = opts.back,
     })
@@ -463,6 +518,7 @@ function M.checks(f, num, filter, cached_checks, opts)
       key = request_key,
       loading_prompt = checks_prompt,
       actions = actions,
+      header_order = checks_header_order,
       picker_name = 'ci',
       back = opts.back,
       cmd = function()
@@ -726,6 +782,7 @@ function M.ci(f, branch, filter, opts)
       prompt = ci_prompt(),
       entries = {},
       actions = actions,
+      header_order = ci_header_order,
       picker_name = 'ci',
       back = opts.back,
       stream = stream_runs,
@@ -1047,6 +1104,7 @@ function M.pr(state, f, opts)
     prompt = initial_prompt,
     entries = {},
     actions = actions,
+    header_order = pr_header_order,
     picker_name = 'pr',
     back = opts.back,
     stream = stream_prs,
@@ -1275,6 +1333,7 @@ function M.issue(state, f, opts)
     prompt = initial_prompt,
     entries = {},
     actions = actions,
+    header_order = issue_header_order,
     picker_name = 'issue',
     back = opts.back,
     stream = stream_issues,
@@ -1537,6 +1596,7 @@ function M.release(state, f, opts)
     prompt = initial_prompt,
     entries = {},
     actions = actions,
+    header_order = release_header_order,
     picker_name = 'release',
     back = opts.back,
     stream = stream_releases,

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -181,6 +181,47 @@ describe('fzf picker', function()
     assert.is_function(captured.opts.actions.tab)
   end)
 
+  it(
+    'orders rendered header hints by explicit header_order instead of action array order',
+    function()
+      local picker = require('forge.picker.fzf')
+      picker.pick({
+        prompt = 'Open Issues> ',
+        entries = {
+          {
+            display = { { '#7' }, { ' Bug' } },
+            value = '7',
+          },
+        },
+        actions = {
+          { name = 'refresh', label = 'refresh', fn = function() end },
+          { name = 'filter', label = 'filter', fn = function() end },
+          { name = 'create', label = 'create', fn = function() end },
+          { name = 'toggle', label = 'close', fn = function() end },
+          { name = 'edit', label = 'edit', fn = function() end },
+          { name = 'browse', label = 'web', fn = function() end },
+          { name = 'default', label = 'open', fn = function() end },
+        },
+        header_order = {
+          'default',
+          'browse',
+          'edit',
+          'toggle',
+          'create',
+          'filter',
+          'refresh',
+        },
+        picker_name = 'issue',
+      })
+
+      assert.is_not_nil(captured)
+      assert.equals(
+        ':: <[FzfLuaHeaderBind:cr]> [FzfLuaHeaderText:open]|[FzfLuaHeaderBind:^X] [FzfLuaHeaderText:web]|[FzfLuaHeaderBind:^E] [FzfLuaHeaderText:edit]|[FzfLuaHeaderBind:^S] [FzfLuaHeaderText:close]|[FzfLuaHeaderBind:^A] [FzfLuaHeaderText:create]|<[FzfLuaHeaderBind:tab]> [FzfLuaHeaderText:filter]|[FzfLuaHeaderBind:^R] [FzfLuaHeaderText:refresh]',
+        captured.opts.fzf_opts['--header']
+      )
+    end
+  )
+
   it('uses resolved fzf-lua header highlight config for binds and labels', function()
     set_header_hls('ForgeTestHeaderBind', 'ForgeTestHeaderText', 'ForgeTestHeaderSep')
 

--- a/spec/picker_init_spec.lua
+++ b/spec/picker_init_spec.lua
@@ -1,5 +1,11 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local function names(items)
+  return vim.tbl_map(function(item)
+    return item.name
+  end, items)
+end
+
 describe('forge.picker.pr_toggle_verb', function()
   local picker
 
@@ -196,5 +202,48 @@ describe('forge.picker.resolve_label', function()
     assert.is_false(picker.has_dynamic_label({ name = 'b', label = 'static' }))
     assert.is_true(picker.has_dynamic_label({ name = 'c', available = function() end }))
     assert.is_false(picker.has_dynamic_label({ name = 'd' }))
+  end)
+end)
+
+describe('forge.picker.order_hints', function()
+  local picker
+
+  before_each(function()
+    package.loaded['forge.picker'] = nil
+    picker = require('forge.picker')
+  end)
+
+  it('orders hints by explicit semantic rank', function()
+    local ordered = picker.order_hints({
+      { name = 'refresh', key = '^R', label = 'refresh' },
+      { name = 'filter', key = '<tab>', label = 'filter' },
+      { name = 'browse', key = '^X', label = 'web' },
+      { name = 'default', key = '<cr>', label = 'open' },
+    }, {
+      'default',
+      'browse',
+      'filter',
+      'refresh',
+    })
+
+    assert.same({ 'default', 'browse', 'filter', 'refresh' }, names(ordered))
+  end)
+
+  it('preserves original order for unranked hints and dedupes by rendered key', function()
+    local ordered = picker.order_hints({
+      { name = 'filter', key = '<tab>', label = 'filter' },
+      { name = 'mystery_a', key = '^M', label = 'alpha' },
+      { name = 'create', key = '^A', label = 'create' },
+      { name = 'mystery_b', key = '^M', label = 'beta' },
+      { name = 'refresh', key = '^R', label = 'refresh' },
+      { name = 'default', key = '<cr>', label = 'open' },
+    }, {
+      'default',
+      'create',
+      'filter',
+      'refresh',
+    })
+
+    assert.same({ 'default', 'create', 'filter', 'refresh', 'mystery_a' }, names(ordered))
   end)
 end)

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -532,6 +532,18 @@ describe('pickers', function()
 
     assert.is_not_nil(captured)
     assert.equals('Open PRs (1)> ', captured.prompt)
+    assert.same({
+      'default',
+      'ci',
+      'edit',
+      'approve',
+      'merge',
+      'toggle',
+      'draft',
+      'create',
+      'filter',
+      'refresh',
+    }, captured.header_order)
     captured.stream(function() end)
     local labels = helpers.action_labels(captured.actions, captured.entries[1])
     assert.equals('checkout', labels.default)
@@ -886,6 +898,18 @@ describe('pickers', function()
     })
 
     assert.is_not_nil(captured)
+    assert.same({
+      'default',
+      'ci',
+      'edit',
+      'approve',
+      'merge',
+      'toggle',
+      'draft',
+      'create',
+      'filter',
+      'refresh',
+    }, captured.header_order)
     assert.is_function(captured.back)
 
     captured.back()
@@ -1862,6 +1886,16 @@ describe('pickers', function()
 
     assert.is_not_nil(captured)
     assert.equals('PR #42 Checks> ', captured.prompt)
+    assert.same({
+      'default',
+      'browse',
+      'filter',
+      'failed',
+      'passed',
+      'running',
+      'all',
+      'refresh',
+    }, captured.header_order)
     assert.same({}, captured.entries)
     assert.same('function', type(captured.stream))
     assert.is_false(rawget(action_by_name('browse'), 'close'))
@@ -1975,6 +2009,17 @@ describe('pickers', function()
 
     assert.is_not_nil(captured)
     assert.equals('CI for main> ', captured.prompt)
+    assert.same({
+      'default',
+      'browse',
+      'toggle',
+      'filter',
+      'failed',
+      'passed',
+      'running',
+      'all',
+      'refresh',
+    }, captured.header_order)
     assert.same({}, captured.entries)
     assert.same('function', type(captured.stream))
 
@@ -2276,6 +2321,13 @@ describe('pickers', function()
     pickers.release('all', fake_release_forge())
 
     assert.is_not_nil(captured)
+    assert.same({
+      'browse',
+      'yank',
+      'delete',
+      'filter',
+      'refresh',
+    }, captured.header_order)
     assert.is_false(rawget(action_by_name('browse'), 'close'))
     assert.is_false(rawget(action_by_name('yank'), 'close'))
     assert.is_nil(rawget(action_by_name('delete'), 'close'))


### PR DESCRIPTION
## Problem

Picker header hint order was implicit in action array order, which made the UX contract hard to reason about and easy to change accidentally.

## Solution

Add shared header-ordering logic in the picker layer, let each picker declare its canonical semantic order, and lock the behavior in picker and fzf specs.
