### PR TITLE
feat(picker): refresh mutable lists in place

### DIFF
--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -3,6 +3,7 @@ local M = {}
 local fzf_args = (vim.env.FZF_DEFAULT_OPTS or '')
   :gsub('%-%-bind=[^%s]+', '')
   :gsub('%-%-color=[^%s]+', '')
+local refresh_scope_id = 0
 
 local special_keys = {
   ['<cr>'] = { fzf = 'enter', header = '<cr>' },
@@ -223,7 +224,13 @@ local function transport_header(text)
   return (sanitized:gsub('\\', '\\\\'):gsub('\27', '\\033'))
 end
 
+local function next_refresh_scope()
+  refresh_scope_id = refresh_scope_id + 1
+  return ('forge.reload.%d'):format(refresh_scope_id)
+end
+
 ---@param opts forge.PickerOpts
+---@return forge.PickerHandle?
 function M.pick(opts)
   local cfg = require('forge').config()
   local keys = cfg.keys
@@ -443,7 +450,28 @@ function M.pick(opts)
     }
   end
 
+  local handle
+  if stream then
+    local ok, win = pcall(require, 'fzf-lua.win')
+    if ok and type(win.on_SIGWINCH) == 'function' and type(win.SIGWINCH) == 'function' then
+      local refresh_scope = next_refresh_scope()
+      win.on_SIGWINCH(fzf_exec_opts, refresh_scope, function()
+        local contents = rawget(fzf_exec_opts, '_contents')
+        if type(contents) ~= 'string' or contents == '' then
+          return nil
+        end
+        return 'reload:' .. contents
+      end)
+      handle = {
+        refresh = function()
+          return win.SIGWINCH({ refresh_scope }) == true
+        end,
+      }
+    end
+  end
+
   require('fzf-lua').fzf_exec(lines, fzf_exec_opts)
+  return handle
 end
 
 return M

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -26,6 +26,9 @@ local surface = require('forge.surface')
 ---@field reload boolean?
 ---@field fn fun(entry: forge.PickerEntry?)
 
+---@class forge.PickerHandle
+---@field refresh fun(): boolean?
+
 ---@class forge.PickerOpts
 ---@field prompt string?
 ---@field entries forge.PickerEntry[]
@@ -303,8 +306,9 @@ function M.ci_toggle_verb(entry)
 end
 
 ---@param opts forge.PickerOpts
+---@return forge.PickerHandle?
 function M.pick(opts)
-  require('forge.picker.fzf').pick(opts)
+  return require('forge.picker.fzf').pick(opts)
 end
 
 return M

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -117,6 +117,10 @@ local function clear_list_cache(forge_mod, key)
   picker_session.invalidate(key)
 end
 
+local function refresh_picker(handle)
+  return handle and type(handle.refresh) == 'function' and handle.refresh() == true
+end
+
 local function limit_settings(base_limit, requested_limit)
   local visible_limit = requested_limit or base_limit
   return {
@@ -524,6 +528,7 @@ function M.ci(f, branch, filter, opts)
   local current_limit = visible_limit
   local current_runs
   local runs_stale = true
+  local picker_handle
 
   local function ci_prompt(count)
     local filter_label = prompt_labels[filter]
@@ -704,10 +709,15 @@ function M.ci(f, branch, filter, opts)
         if not entry or entry.load_more then
           return
         end
-        local reopen = function()
-          M.ci(f, branch, filter, { limit = current_limit, back = opts.back, scope = ref })
+        local refresh_current = function()
+          runs_stale = true
+          refresh_picker(picker_handle)
         end
-        ops.ci_toggle(f, entry.value, { on_success = reopen, on_failure = reopen })
+        ops.ci_toggle(
+          f,
+          entry.value,
+          { on_success = refresh_current, on_failure = refresh_current }
+        )
       end,
     },
     {
@@ -716,13 +726,17 @@ function M.ci(f, branch, filter, opts)
       reload = false,
       fn = function()
         log.info('refreshing ' .. ci_fetch_label(f) .. '...')
+        runs_stale = true
+        if refresh_picker(picker_handle) then
+          return
+        end
         M.ci(f, branch, filter, { limit = current_limit, back = opts.back, scope = ref })
       end,
     },
   }
 
   if f.list_runs_json_cmd then
-    picker.pick({
+    picker_handle = picker.pick({
       prompt = ci_prompt(),
       entries = {},
       actions = actions,
@@ -757,6 +771,7 @@ function M.pr(state, f, opts)
   local current_limit = visible_limit
   local current_prs
   local prs_stale = true
+  local picker_handle
 
   local function build_pr_entries(prs, limit)
     limit = limit or current_limit
@@ -857,7 +872,8 @@ function M.pr(state, f, opts)
   local function reopen_list()
     clear_state_caches(forge_mod, 'pr', scoped_key(forge_mod, ref))
     forge_mod.clear_pr_state(nil, ref)
-    M.pr(state, f, { limit = current_limit, back = opts.back, scope = ref })
+    prs_stale = true
+    refresh_picker(picker_handle)
   end
 
   local function back_to_list()
@@ -1024,6 +1040,10 @@ function M.pr(state, f, opts)
       fn = function()
         clear_state_caches(forge_mod, 'pr', scoped_key(forge_mod, ref))
         forge_mod.clear_pr_state(nil, ref)
+        prs_stale = true
+        if refresh_picker(picker_handle) then
+          return
+        end
         M.pr(state, f, { limit = current_limit, back = opts.back, scope = ref })
       end,
     },
@@ -1043,7 +1063,7 @@ function M.pr(state, f, opts)
     initial_prompt = ('%s %s> '):format(state_label, f.labels.pr)
   end
 
-  picker.pick({
+  picker_handle = picker.pick({
     prompt = initial_prompt,
     entries = {},
     actions = actions,
@@ -1079,6 +1099,7 @@ function M.issue(state, f, opts)
   local current_limit = visible_limit
   local current_issues
   local issues_stale = true
+  local picker_handle
 
   local function build_issue_entries(issues, limit)
     limit = limit or current_limit
@@ -1173,7 +1194,8 @@ function M.issue(state, f, opts)
 
   local function reopen_list()
     clear_state_caches(forge_mod, 'issue', scoped_key(forge_mod, ref))
-    M.issue(state, f, { limit = current_limit, back = opts.back, scope = ref })
+    issues_stale = true
+    refresh_picker(picker_handle)
   end
 
   local actions = {
@@ -1252,6 +1274,10 @@ function M.issue(state, f, opts)
       reload = false,
       fn = function()
         clear_state_caches(forge_mod, 'issue', scoped_key(forge_mod, ref))
+        issues_stale = true
+        if refresh_picker(picker_handle) then
+          return
+        end
         M.issue(state, f, { limit = current_limit, back = opts.back, scope = ref })
       end,
     },
@@ -1271,7 +1297,7 @@ function M.issue(state, f, opts)
     initial_prompt = ('%s %s> '):format(state_label, f.labels.issue)
   end
 
-  picker.pick({
+  picker_handle = picker.pick({
     prompt = initial_prompt,
     entries = {},
     actions = actions,
@@ -1339,6 +1365,7 @@ function M.release(state, f, opts)
   local current_limit = visible_limit
   local current_releases
   local releases_stale = true
+  local picker_handle
 
   local function remember_release_fetch(releases, requested_limit)
     if type(releases) == 'table' then
@@ -1456,7 +1483,8 @@ function M.release(state, f, opts)
 
   local function reopen_list()
     clear_list_cache(forge_mod, cache_key)
-    M.release(state, f, { limit = current_limit, back = opts.back, scope = ref })
+    releases_stale = true
+    refresh_picker(picker_handle)
   end
 
   local actions = {
@@ -1514,6 +1542,10 @@ function M.release(state, f, opts)
       reload = false,
       fn = function()
         clear_list_cache(forge_mod, cache_key)
+        releases_stale = true
+        if refresh_picker(picker_handle) then
+          return
+        end
         M.release(state, f, { limit = current_limit, back = opts.back, scope = ref })
       end,
     },
@@ -1533,7 +1565,7 @@ function M.release(state, f, opts)
     initial_prompt = release_prompt()
   end
 
-  picker.pick({
+  picker_handle = picker.pick({
     prompt = initial_prompt,
     entries = {},
     actions = actions,

--- a/spec/fzf_picker_spec.lua
+++ b/spec/fzf_picker_spec.lua
@@ -4,6 +4,8 @@ local close_calls = 0
 local ctx_clears = 0
 local ansi_headers = false
 local fzf_config
+local sigwinch_calls = {}
+local sigwinch_handlers = {}
 local function header_hls(bind, text, separator)
   return {
     header_bind = bind or 'FzfLuaHeaderBind',
@@ -89,6 +91,19 @@ package.preload['fzf-lua'] = function()
   }
 end
 
+package.preload['fzf-lua.win'] = function()
+  return {
+    on_SIGWINCH = function(opts, scope, cb)
+      sigwinch_handlers[scope] = { opts = opts, cb = cb }
+      return true
+    end,
+    SIGWINCH = function(scopes)
+      sigwinch_calls[#sigwinch_calls + 1] = scopes
+      return true
+    end,
+  }
+end
+
 describe('fzf picker', function()
   local selected
 
@@ -98,10 +113,13 @@ describe('fzf picker', function()
     close_calls = 0
     ctx_clears = 0
     ansi_headers = false
+    sigwinch_calls = {}
+    sigwinch_handlers = {}
     package.loaded['forge'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.picker.fzf'] = nil
     package.loaded['fzf-lua.config'] = nil
+    package.loaded['fzf-lua.win'] = nil
     vim.g.forge = nil
     set_header_hls()
   end)
@@ -580,6 +598,34 @@ describe('fzf picker', function()
       and captured.opts.keymap.fzf
       and captured.opts.keymap.fzf.focus
     assert.is_falsy(has_focus)
+  end)
+
+  it('returns a refresh handle for streamed pickers', function()
+    local picker = require('forge.picker.fzf')
+    local handle = picker.pick({
+      prompt = 'CI> ',
+      entries = {},
+      actions = {},
+      picker_name = 'ci',
+      stream = function(emit)
+        emit({
+          display = { { 'build' } },
+          value = '1',
+        })
+        emit(nil)
+      end,
+    })
+
+    assert.is_not_nil(handle)
+    assert.is_function(handle.refresh)
+    captured.opts._contents = 'printf build'
+
+    local scope = next(sigwinch_handlers)
+    assert.is_string(scope)
+    assert.same(captured.opts, sigwinch_handlers[scope].opts)
+    assert.equals('reload:printf build', sigwinch_handlers[scope].cb({}))
+    assert.is_true(handle.refresh())
+    assert.same({ scope }, sigwinch_calls[1])
   end)
 
   it('renders branch rows with visible labels and hidden selection ids', function()

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -11,6 +11,8 @@ local op_calls
 local pr_create_calls
 local pr_create_opts
 local default_system
+local picker_pick_calls
+local picker_refresh_calls
 local preload_modules = {
   'fzf-lua.utils',
   'forge',
@@ -170,6 +172,8 @@ describe('pickers', function()
     op_calls = {}
     pr_create_calls = 0
     pr_create_opts = nil
+    picker_pick_calls = 0
+    picker_refresh_calls = 0
     default_system = vim.system
     vim.system = function(_, _, cb)
       if cb then
@@ -227,6 +231,7 @@ describe('pickers', function()
           return 'fzf-lua'
         end,
         pick = function(opts)
+          picker_pick_calls = picker_pick_calls + 1
           captured = opts
           if type(opts.stream) == 'function' then
             local inner = opts.stream
@@ -243,6 +248,15 @@ describe('pickers', function()
               end)
             end
           end
+          return {
+            refresh = function()
+              picker_refresh_calls = picker_refresh_calls + 1
+              if type(captured.stream) == 'function' then
+                captured.stream(function() end)
+              end
+              return true
+            end,
+          }
         end,
         available = available,
         resolve_label = function(def, entry)
@@ -924,27 +938,16 @@ describe('pickers', function()
     local pickers = require('forge.pickers')
     pickers.pr('open', fake_forge())
 
-    local first = captured
-    local first_streamed = {}
-    first.stream(function(entry)
+    local streamed = {}
+    captured.stream(function(entry)
       if entry == nil then
-        first_streamed.done = true
+        streamed.done = true
         return
       end
-      first_streamed[#first_streamed + 1] = entry
+      streamed[#streamed + 1] = entry
     end)
 
     action_by_name('refresh').fn()
-
-    local second = captured
-    local second_streamed = {}
-    second.stream(function(entry)
-      if entry == nil then
-        second_streamed.done = true
-        return
-      end
-      second_streamed[#second_streamed + 1] = entry
-    end)
 
     calls[1].cb({
       code = 0,
@@ -960,12 +963,13 @@ describe('pickers', function()
     })
 
     vim.wait(100, function()
-      return first_streamed.done == true and second_streamed.done == true
+      return streamed.done == true and captured.entries[1] ~= nil
     end)
     vim.system = old_system
 
-    assert.is_nil(first_streamed[1])
-    assert.equals('42', second_streamed[1].value.num)
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
+    assert.equals('42', captured.entries[1].value.num)
     assert.same(42, cache['pr:open'][1].number)
   end)
 
@@ -1168,8 +1172,30 @@ describe('pickers', function()
     assert.is_nil(cache['pr:open'])
     assert.is_nil(cache['pr:closed'])
     assert.is_nil(cache['pr:all'])
-    assert.equals('Open PRs> ', captured.prompt)
-    assert.same('function', type(captured.stream))
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
+  end)
+
+  it('refreshes the live PR picker in place after toggle succeeds', function()
+    cache['pr:closed'] = {
+      { number = 43, title = 'Old closed', state = 'CLOSED', author = 'alice', created_at = '' },
+    }
+    cache['pr:all'] = {
+      { number = 42, title = 'Fix api drift', state = 'OPEN', author = 'alice', created_at = '' },
+      { number = 43, title = 'Old closed', state = 'CLOSED', author = 'alice', created_at = '' },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+    captured.stream(function() end)
+
+    action_by_name('toggle').fn(captured.entries[1])
+
+    assert.is_nil(cache['pr:open'])
+    assert.is_nil(cache['pr:closed'])
+    assert.is_nil(cache['pr:all'])
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
   end)
 
   it('marks PR refresh and checks transitions as hard reopen actions', function()
@@ -1447,6 +1473,31 @@ describe('pickers', function()
     assert.is_false(action_by_name('refresh').reload)
   end)
 
+  it('refreshes the live issue picker in place after toggle succeeds', function()
+    cache['issue:open'] = {
+      { number = 7, title = 'Bug', state = 'OPEN', author = 'alice', created_at = '' },
+    }
+    cache['issue:closed'] = {
+      { number = 6, title = 'Done', state = 'CLOSED', author = 'bob', created_at = '' },
+    }
+    cache['issue:all'] = {
+      { number = 7, title = 'Bug', state = 'OPEN', author = 'alice', created_at = '' },
+      { number = 6, title = 'Done', state = 'CLOSED', author = 'bob', created_at = '' },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.issue('open', fake_issue_forge())
+    captured.stream(function() end)
+
+    action_by_name('toggle').fn(captured.entries[1])
+
+    assert.is_nil(cache['issue:open'])
+    assert.is_nil(cache['issue:closed'])
+    assert.is_nil(cache['issue:all'])
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
+  end)
+
   it('dispatches flattened issue actions directly from the root picker', function()
     cache['issue:open'] = {
       { number = 42, title = 'Fix api drift', state = 'OPEN', author = 'alice', created_at = '' },
@@ -1662,6 +1713,26 @@ describe('pickers', function()
       url = 'https://example.com',
     }, op_calls[#op_calls].run)
     assert.equals('ci_toggle', op_calls[#op_calls].name)
+  end)
+
+  it('refreshes the live CI picker in place after toggle succeeds', function()
+    local pickers = require('forge.pickers')
+    pickers.ci(fake_ci_forge(), 'main', 'all')
+
+    local toggle = action_by_name('toggle')
+    assert.is_not_nil(toggle)
+    toggle.fn({
+      value = {
+        id = '5',
+        name = 'CI',
+        branch = 'main',
+        status = 'in_progress',
+        url = 'https://example.com',
+      },
+    })
+
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
   end)
 
   it('labels the CI toggle action from the highlighted run status', function()
@@ -2486,5 +2557,21 @@ describe('pickers', function()
     assert.is_not_nil(captured)
     assert.is_false(action_by_name('filter').reload)
     assert.is_false(action_by_name('refresh').reload)
+  end)
+
+  it('refreshes the live release picker in place after delete succeeds', function()
+    cache['release:list'] = {
+      { tag = 'v1.0.0', title = 'First', is_draft = false, is_prerelease = false },
+    }
+
+    local pickers = require('forge.pickers')
+    pickers.release('all', fake_release_forge())
+    captured.stream(function() end)
+
+    action_by_name('delete').fn(captured.entries[1])
+
+    assert.is_nil(cache['release:list'])
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
   end)
 end)


### PR DESCRIPTION
## Problem

Mutable picker actions still invalidate caches and reopen the picker, which flashes the UI and discards the active picker session even though the mutation itself already runs asynchronously.

## Solution

Add a streamed picker refresh handle in `lua/forge/picker/fzf.lua` and thread it through `lua/forge/picker/init.lua` so the PR, issue, CI, and release pickers can revalidate in place. Update the picker specs to cover the refresh handle and confirm mutable list actions refresh the active picker session instead of reopening it.
