### PR TITLE
refactor: encapsulate forge-specific behavior in backends only

### DIFF
--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -1,6 +1,17 @@
 local forge = require('forge')
 local log = require('forge.logger')
+local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
+
+---@param value any
+---@return string?
+local function nonempty(value)
+  if type(value) ~= 'string' then
+    return nil
+  end
+  local trimmed = vim.trim(value)
+  return trimmed ~= '' and trimmed or nil
+end
 
 ---@class forge.Codeberg: forge.Forge
 local M = {
@@ -8,11 +19,13 @@ local M = {
   cli = 'tea',
   kinds = { issue = 'issues', pr = 'pulls' },
   labels = {
+    forge_name = 'Codeberg',
     issue = 'Issues',
     pr = 'PRs',
     pr_one = 'PR',
     pr_full = 'Pull Requests',
     ci = 'CI/CD',
+    ci_inline = 'CI/CD runs',
   },
   capabilities = {
     draft = false,
@@ -145,9 +158,11 @@ function M:browse_subject(num, scope)
       if result.code ~= 0 then
         local stderr = vim.trim(result.stderr or '')
         if stderr:match('404') or stderr:match('not[%s_-]?found') then
-          log.warn(('no PR or issue found for #%s'):format(num))
+          log.warn(('no %s or issue found for #%s'):format(M.labels.pr_one, num))
         else
-          log.error(stderr ~= '' and stderr or ('no PR or issue found for #%s'):format(num))
+          log.error(
+            stderr ~= '' and stderr or ('no %s or issue found for #%s'):format(M.labels.pr_one, num)
+          )
         end
         return
       end
@@ -555,6 +570,36 @@ function M:update_issue_cmd(num, title, body, scope, metadata, previous)
     table.insert(cmd, current.milestone)
   end
   return cmd
+end
+
+---@param json table
+---@param base_scope forge.Scope?
+---@return forge.HeadRef
+function M:parse_pr_head(json, base_scope)
+  local head = type(json.head) == 'table' and json.head or nil
+  local raw_branch = head and (head.ref or head.name) or json.head
+  local branch = nonempty(raw_branch)
+  local repo = head and type(head.repo) == 'table' and head.repo or nil
+  local full_name = nonempty(repo and (repo.full_name or repo.fullName))
+  local scope = nil
+  if full_name then
+    local host = type(base_scope) == 'table' and base_scope.host or 'codeberg.org'
+    scope = scope_mod.from_url('codeberg', ('https://%s/%s'):format(host, full_name))
+  end
+  return {
+    branch = branch,
+    scope = scope,
+  }
+end
+
+---@param expected forge.HeadRef
+---@param actual forge.HeadRef
+---@return boolean?, string?
+function M:match_head(expected, actual)
+  if nonempty(actual.branch) ~= expected.branch then
+    return false
+  end
+  return scope_mod.same(expected.scope, actual.scope)
 end
 
 ---@param json table

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -1,6 +1,17 @@
 local forge = require('forge')
 local log = require('forge.logger')
+local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
+
+---@param value any
+---@return string?
+local function nonempty(value)
+  if type(value) ~= 'string' then
+    return nil
+  end
+  local trimmed = vim.trim(value)
+  return trimmed ~= '' and trimmed or nil
+end
 
 ---@class forge.GitHub: forge.Forge
 local M = {
@@ -8,17 +19,20 @@ local M = {
   cli = 'gh',
   kinds = { issue = 'issue', pr = 'pr' },
   labels = {
+    forge_name = 'GitHub',
     issue = 'Issues',
     pr = 'PRs',
     pr_one = 'PR',
     pr_full = 'Pull Requests',
     ci = 'CI/CD',
+    ci_inline = 'CI/CD runs',
   },
   capabilities = {
     draft = true,
     reviewers = true,
     per_pr_checks = true,
     ci_json = true,
+    ci_terminal_view = true,
   },
   submission = {
     issue = {
@@ -678,6 +692,45 @@ function M:update_issue_cmd(num, title, body, scope, metadata, previous)
     table.insert(cmd, repo)
   end
   return cmd
+end
+
+---@param json table
+---@param base_scope forge.Scope?
+---@return forge.HeadRef
+function M:parse_pr_head(json, base_scope)
+  local branch = nonempty(json.headRefName)
+  local owner = type(json.headRepositoryOwner) == 'table'
+      and nonempty(json.headRepositoryOwner.login or json.headRepositoryOwner.name)
+    or nil
+  local repo = type(json.headRepository) == 'table' and nonempty(json.headRepository.name) or nil
+  local full_name = type(json.headRepository) == 'table'
+      and nonempty(json.headRepository.nameWithOwner)
+    or nil
+  if not owner and full_name then
+    owner = full_name:match('^([^/]+)/')
+  end
+  if not repo and full_name then
+    repo = full_name:match('/([^/]+)$')
+  end
+  local scope = nil
+  if owner and repo then
+    local host = type(base_scope) == 'table' and base_scope.host or 'github.com'
+    scope = scope_mod.from_url('github', ('https://%s/%s/%s'):format(host, owner, repo))
+  end
+  return {
+    branch = branch,
+    scope = scope,
+  }
+end
+
+---@param expected forge.HeadRef
+---@param actual forge.HeadRef
+---@return boolean?, string?
+function M:match_head(expected, actual)
+  if nonempty(actual.branch) ~= expected.branch then
+    return false
+  end
+  return scope_mod.same(expected.scope, actual.scope)
 end
 
 ---@param json table

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -3,17 +3,32 @@ local log = require('forge.logger')
 local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
 
+---@param value any
+---@return string?
+local function nonempty(value)
+  if type(value) ~= 'string' then
+    return nil
+  end
+  local trimmed = vim.trim(value)
+  return trimmed ~= '' and trimmed or nil
+end
+
+---@type table<string, string|false>
+local project_id_cache = {}
+
 ---@class forge.GitLab: forge.Forge
 local M = {
   name = 'gitlab',
   cli = 'glab',
   kinds = { issue = 'issue', pr = 'mr' },
   labels = {
+    forge_name = 'GitLab',
     issue = 'Issues',
     pr = 'Merge Requests',
     pr_one = 'MR',
     pr_full = 'Merge Requests',
     ci = 'Pipelines',
+    ci_inline = 'pipelines',
   },
   capabilities = {
     draft = true,
@@ -170,7 +185,7 @@ function M:browse_subject(num, scope)
     end
     local url = mr_url or issue_url
     if not url or url == '' then
-      log.warn(('no PR or issue found for #%s'):format(num))
+      log.warn(('no %s or issue found for #%s'):format(M.labels.pr_one, num))
       return
     end
     local _, open_err = vim.ui.open(url)
@@ -633,6 +648,75 @@ function M:update_issue_cmd(num, title, body, scope, metadata, previous)
     table.insert(cmd, current.milestone ~= '' and current.milestone or '0')
   end
   return cmd
+end
+
+---@param json table
+---@param _base_scope forge.Scope?
+---@return forge.HeadRef
+function M:parse_pr_head(json, _base_scope)
+  return {
+    branch = nonempty(json.source_branch),
+    project_id = json.source_project_id ~= nil and tostring(json.source_project_id) or nil,
+  }
+end
+
+---Resolve the GitLab numeric project ID for a scope, caching the lookup.
+---@param scope forge.Scope?
+---@return string?, string?
+local function resolve_project_id(scope)
+  local slug = type(scope) == 'table' and scope.slug or 'scope'
+  local host = type(scope) == 'table' and scope.host or 'gitlab.com'
+  local key = scope_mod.key(scope)
+  if key == '' then
+    return nil
+  end
+  if project_id_cache[key] ~= nil then
+    return project_id_cache[key] or nil
+  end
+  local encoded = scope_mod.encode_project(scope)
+  if not encoded then
+    project_id_cache[key] = false
+    return nil
+  end
+  local result = vim
+    .system({ 'glab', 'api', '--hostname', host, ('projects/%s'):format(encoded) }, { text = true })
+    :wait()
+  if result.code ~= 0 then
+    local err = vim.trim(result.stderr or '')
+    if err == '' then
+      err = vim.trim(result.stdout or '')
+    end
+    if err == '' then
+      err = ('failed to resolve GitLab project for %s'):format(slug)
+    end
+    return nil, err
+  end
+  local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+  if not ok or type(json) ~= 'table' or json.id == nil then
+    return nil, ('failed to parse GitLab project for %s'):format(slug)
+  end
+  local id = tostring(json.id)
+  project_id_cache[key] = id
+  return id
+end
+
+---@param expected forge.HeadRef
+---@param actual forge.HeadRef
+---@return boolean?, string?
+function M:match_head(expected, actual)
+  if nonempty(actual.branch) ~= expected.branch then
+    return false
+  end
+  local expected_id = expected.project_id
+  if not expected_id and expected.scope then
+    local id, err = resolve_project_id(expected.scope)
+    if err then
+      return nil, err
+    end
+    expected_id = id
+  end
+  local actual_id = nonempty(actual.project_id)
+  return expected_id ~= nil and actual_id ~= nil and expected_id == actual_id
 end
 
 ---@param json table

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -111,7 +111,20 @@ local function summary_job_at_cursor(buf)
   return require('forge.log')._summary_job_at_line(lines, vim.api.nvim_win_get_cursor(0)[1])
 end
 
-local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd, opts)
+---Open a CI run as a TTY summary terminal where each line is a job and
+---<cr>/`gx` open the underlying job log/url. Used by backends that set
+---`capabilities.ci_terminal_view` (currently only GitHub, where `gh run
+---view` and `gh run watch` provide TTY-rendered summaries that can be
+---navigated by cursor line).
+---@param f forge.Forge
+---@param cmd string[]
+---@param run forge.RunRef
+---@param run_ref forge.Scope?
+---@param url string?
+---@param in_progress boolean
+---@param status_cmd string[]?
+---@param opts { watch?: boolean }?
+local function open_ci_terminal_view(f, cmd, run, run_ref, url, in_progress, status_cmd, opts)
   opts = opts or {}
   local warned_job_watch = false
 
@@ -149,7 +162,11 @@ local function github_ci_term(f, cmd, run, run_ref, url, in_progress, status_cmd
       end
       if opts.watch and in_progress and not warned_job_watch then
         warned_job_watch = true
-        log.info('GitHub does not support per-job live watch; opening a refreshing job log instead')
+        log.info(
+          ('%s does not support per-job live watch; opening a refreshing job log instead'):format(
+            (f.labels and f.labels.forge_name) or f.name
+          )
+        )
       end
       local log_cmd, log_opts = job_log(job.id, job.failed)
       log_opts = vim.tbl_extend('force', log_opts, {
@@ -426,8 +443,8 @@ local function ci_log(f, run)
   end
   url = url ~= '' and url or nil
   local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id, run_ref) or nil
-  if f.name == 'github' and f.view_cmd then
-    github_ci_term(
+  if f.capabilities and f.capabilities.ci_terminal_view and f.view_cmd then
+    open_ci_terminal_view(
       f,
       f:view_cmd(run.id, { scope = run_ref }),
       run,
@@ -539,10 +556,17 @@ local function ci_watch(f, run)
   end
   url = url ~= '' and url or nil
   local status_cmd = f.run_status_cmd and f:run_status_cmd(run.id, run_ref) or nil
-  if f.name == 'github' then
-    github_ci_term(f, f:watch_cmd(run.id, run_ref), run, run_ref, url, in_progress, status_cmd, {
-      watch = true,
-    })
+  if f.capabilities and f.capabilities.ci_terminal_view then
+    open_ci_terminal_view(
+      f,
+      f:watch_cmd(run.id, run_ref),
+      run,
+      run_ref,
+      url,
+      in_progress,
+      status_cmd,
+      { watch = true }
+    )
     return true
   end
   require('forge.term').open(f:watch_cmd(run.id, run_ref), {
@@ -635,7 +659,7 @@ function M.ci_toggle(f, run, opts)
   opts = opts or {}
   local verb = ci.toggle_verb(run)
   if verb == nil then
-    log.info('nothing to toggle for skipped run')
+    log.warn('nothing to toggle for skipped run')
     if opts.on_failure then
       opts.on_failure()
     end

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -187,26 +187,8 @@ end
 
 ---@param f forge.Forge
 ---@return string
-local function ci_label(f)
-  return (f.labels and f.labels.ci) or 'CI'
-end
-
----@param f forge.Forge
----@return string
-local function ci_run_history_label(f)
-  if f.name == 'gitlab' then
-    return ci_label(f):lower()
-  end
-  return ci_label(f) .. ' runs'
-end
-
----@param f forge.Forge
----@return string
-local function ci_fetch_label(f)
-  if f.name == 'gitlab' then
-    return ci_label(f):lower()
-  end
-  return 'CI runs'
+local function ci_inline_label(f)
+  return (f.labels and f.labels.ci_inline) or 'runs'
 end
 
 local function expanded_limit(limit, step)
@@ -630,7 +612,7 @@ function M.ci(f, branch, filter, opts)
       entries[#entries + 1] = load_more_entry(expanded_limit(limit, limit_step), true)
     end
     local filter_label = labels[filter] or filter
-    local run_label = ci_run_history_label(f)
+    local run_label = ci_inline_label(f)
     local empty_text
     if branch and filter ~= 'all' then
       empty_text = ('No %s %s for %s'):format(filter_label, run_label, branch)
@@ -659,7 +641,7 @@ function M.ci(f, branch, filter, opts)
       emit_cached(emit)
       return
     end
-    log.info('fetching ' .. ci_fetch_label(f) .. '...')
+    log.info('fetching ' .. ci_inline_label(f) .. '...')
     picker_session.request_json(
       request_key,
       f:list_runs_json_cmd(branch, ref, current_limit + 1),
@@ -669,8 +651,8 @@ function M.ci(f, branch, filter, opts)
           return
         end
         if not ok then
-          log.error('failed to fetch ' .. ci_fetch_label(f))
-          emit(placeholder_entry('Failed to fetch ' .. ci_fetch_label(f)))
+          log.error('failed to fetch ' .. ci_inline_label(f))
+          emit(placeholder_entry('Failed to fetch ' .. ci_inline_label(f)))
           emit(nil)
           return
         end
@@ -781,7 +763,7 @@ function M.ci(f, branch, filter, opts)
       label = 'refresh',
       reload = false,
       fn = function()
-        log.info('refreshing ' .. ci_fetch_label(f) .. '...')
+        log.info('refreshing ' .. ci_inline_label(f) .. '...')
         runs_stale = true
         if refresh_picker(picker_handle) then
           return

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -3,9 +3,6 @@ local M = {}
 local scope_mod = require('forge.scope')
 local target_mod = require('forge.target')
 
----@type table<string, string|false>
-local gitlab_project_ids = {}
-
 ---@param text any
 ---@return string?
 local function trim(text)
@@ -106,75 +103,15 @@ local function add_scope(scopes, seen, value)
   scopes[#scopes + 1] = value
 end
 
----@param json table
----@param base_scope forge.Scope?
----@return forge.HeadRef
-local function github_head(json, base_scope)
-  local branch = trim(json.headRefName)
-  local owner = type(json.headRepositoryOwner) == 'table'
-      and trim(json.headRepositoryOwner.login or json.headRepositoryOwner.name)
-    or nil
-  local repo = type(json.headRepository) == 'table' and trim(json.headRepository.name) or nil
-  local full_name = type(json.headRepository) == 'table' and trim(json.headRepository.nameWithOwner)
-    or nil
-  if not owner and full_name then
-    owner = full_name:match('^([^/]+)/')
-  end
-  if not repo and full_name then
-    repo = full_name:match('/([^/]+)$')
-  end
-  local scope = nil
-  if owner and repo then
-    local host = type(base_scope) == 'table' and base_scope.host or 'github.com'
-    scope = scope_mod.from_url('github', ('https://%s/%s/%s'):format(host, owner, repo))
-  end
-  return {
-    branch = branch,
-    scope = scope,
-  }
-end
-
----@param json table
----@return forge.HeadRef
-local function gitlab_head(json)
-  return {
-    branch = trim(json.source_branch),
-    project_id = json.source_project_id ~= nil and tostring(json.source_project_id) or nil,
-  }
-end
-
----@param json table
----@param base_scope forge.Scope?
----@return forge.HeadRef
-local function codeberg_head(json, base_scope)
-  local head = type(json.head) == 'table' and json.head or nil
-  local branch = trim(head and (head.ref or head.name) or json.head)
-  local repo = head and type(head.repo) == 'table' and head.repo or nil
-  local full_name = trim(repo and (repo.full_name or repo.fullName))
-  local scope = nil
-  if full_name then
-    local host = type(base_scope) == 'table' and base_scope.host or 'codeberg.org'
-    scope = scope_mod.from_url('codeberg', ('https://%s/%s'):format(host, full_name))
-  end
-  return {
-    branch = branch,
-    scope = scope,
-  }
-end
-
+---Dispatch to the active backend's `parse_pr_head`. Falls back to a
+---universal-best-effort head when a custom backend doesn't implement it.
 ---@param forge forge.Forge
 ---@param json table
 ---@param base_scope forge.Scope?
 ---@return forge.HeadRef
 local function pr_head(forge, json, base_scope)
-  if forge.name == 'github' then
-    return github_head(json, base_scope)
-  end
-  if forge.name == 'gitlab' then
-    return gitlab_head(json)
-  end
-  if forge.name == 'codeberg' then
-    return codeberg_head(json, base_scope)
+  if type(forge.parse_pr_head) == 'function' then
+    return forge:parse_pr_head(json, base_scope)
   end
   return {
     branch = trim(json.headRefName or json.source_branch),
@@ -182,57 +119,18 @@ local function pr_head(forge, json, base_scope)
   }
 end
 
----@param scope forge.Scope?
----@return string?, string?
-local function gitlab_project_id(scope)
-  local slug = type(scope) == 'table' and scope.slug or 'scope'
-  local host = type(scope) == 'table' and scope.host or 'gitlab.com'
-  local key = scope_mod.key(scope)
-  if key == '' then
-    return nil
-  end
-  if gitlab_project_ids[key] ~= nil then
-    return gitlab_project_ids[key] or nil
-  end
-  local project = scope_mod.encode_project(scope)
-  if not project then
-    gitlab_project_ids[key] = false
-    return nil
-  end
-  local result = vim
-    .system({ 'glab', 'api', '--hostname', host, ('projects/%s'):format(project) }, { text = true })
-    :wait()
-  if result.code ~= 0 then
-    return nil, cmd_error(result, ('failed to resolve GitLab project for %s'):format(slug))
-  end
-  local ok, json = pcall(vim.json.decode, result.stdout or '{}')
-  if not ok or type(json) ~= 'table' or json.id == nil then
-    return nil, ('failed to parse GitLab project for %s'):format(slug)
-  end
-  local id = tostring(json.id)
-  gitlab_project_ids[key] = id
-  return id
-end
-
+---Dispatch to the active backend's `match_head`. Falls back to scope-only
+---comparison when a custom backend doesn't implement it.
 ---@param forge forge.Forge
 ---@param expected forge.HeadRef
 ---@param actual forge.HeadRef
 ---@return boolean?, string?
 local function head_matches(forge, expected, actual)
+  if type(forge.match_head) == 'function' then
+    return forge:match_head(expected, actual)
+  end
   if trim(actual.branch) ~= expected.branch then
     return false
-  end
-  if forge.name == 'gitlab' then
-    local expected_id = expected.project_id
-    local err
-    if not expected_id and expected.scope then
-      expected_id, err = gitlab_project_id(expected.scope)
-      if err then
-        return nil, err
-      end
-    end
-    local actual_id = trim(actual.project_id)
-    return expected_id ~= nil and actual_id ~= nil and expected_id == actual_id
   end
   return scope_mod.same(expected.scope, actual.scope)
 end

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -344,13 +344,16 @@
 ---@field reviewers boolean
 ---@field per_pr_checks boolean
 ---@field ci_json boolean
+---@field ci_terminal_view boolean?
 
 ---@class forge.Forge
 ---@field name string
 ---@field cli string
 ---@field kinds { issue: string, pr: string }
----@field labels { issue: string, pr: string, pr_one: string, pr_full: string, ci: string }
+---@field labels { forge_name: string, issue: string, pr: string, pr_one: string, pr_full: string, ci: string, ci_inline: string }
 ---@field capabilities forge.Capabilities
+---@field parse_pr_head fun(self: forge.Forge, json: table, base_scope?: forge.Scope): forge.HeadRef
+---@field match_head fun(self: forge.Forge, expected: forge.HeadRef, actual: forge.HeadRef): boolean?, string?
 ---@field submission forge.Submission?
 ---@field list_pr_json_cmd fun(self: forge.Forge, state: string, limit?: integer, scope?: forge.Scope): string[]
 ---@field list_issue_json_cmd fun(self: forge.Forge, state: string, limit?: integer, scope?: forge.Scope): string[]

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -180,6 +180,7 @@ describe('create_pr', function()
     end
 
     package.preload['forge.backends.github'] = function()
+      local scope_mod = require('forge.scope')
       return {
         name = 'github',
         cli = 'gh',
@@ -205,6 +206,41 @@ describe('create_pr', function()
             reviewers = {},
             milestone = '',
           }
+        end,
+        parse_pr_head = function(_, json, base_scope)
+          local branch = json.headRefName ~= nil and vim.trim(json.headRefName) or ''
+          if branch == '' then
+            branch = nil
+          end
+          local owner = type(json.headRepositoryOwner) == 'table'
+              and (json.headRepositoryOwner.login or json.headRepositoryOwner.name)
+            or nil
+          local repo = type(json.headRepository) == 'table' and json.headRepository.name or nil
+          local full_name = type(json.headRepository) == 'table'
+              and json.headRepository.nameWithOwner
+            or nil
+          if not owner and full_name then
+            owner = full_name:match('^([^/]+)/')
+          end
+          if not repo and full_name then
+            repo = full_name:match('/([^/]+)$')
+          end
+          local scope = nil
+          if owner and repo then
+            local host = type(base_scope) == 'table' and base_scope.host or 'github.com'
+            scope = scope_mod.from_url('github', ('https://%s/%s/%s'):format(host, owner, repo))
+          end
+          return { branch = branch, scope = scope }
+        end,
+        match_head = function(_, expected, actual)
+          local actual_branch = actual.branch ~= nil and vim.trim(actual.branch) or ''
+          if actual_branch == '' then
+            actual_branch = nil
+          end
+          if actual_branch ~= expected.branch then
+            return false
+          end
+          return scope_mod.same(expected.scope, actual.scope)
         end,
         create_pr_web_cmd = function(_, scope, head_scope, head_branch, base_branch)
           captured.web_create = {

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -456,6 +456,8 @@ describe('shared operations', function()
     local ops = require('forge.ops')
     ops.ci_open({
       name = 'github',
+      labels = { forge_name = 'GitHub' },
+      capabilities = { ci_terminal_view = true },
       view_cmd = function(_, run_id, opts)
         return { 'view', run_id, opts and opts.scope or 'none' }
       end,
@@ -496,6 +498,8 @@ describe('shared operations', function()
     local ops = require('forge.ops')
     ops.ci_open({
       name = 'github',
+      labels = { forge_name = 'GitHub' },
+      capabilities = { ci_terminal_view = true },
       watch_cmd = function(_, run_id, scope)
         return { 'watch', run_id, scope or 'none' }
       end,

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1884,7 +1884,7 @@ describe('pickers', function()
     pickers.ci(
       fake_ci_forge({
         name = 'gitlab',
-        labels = { ci = 'Pipelines', pr_one = 'MR' },
+        labels = { ci = 'Pipelines', ci_inline = 'pipelines', pr_one = 'MR' },
       }),
       'main',
       'fail'

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -11,6 +11,9 @@ local loaded_modules = {
   'forge.resolve',
   'forge.scope',
   'forge.target',
+  'forge.backends.github',
+  'forge.backends.gitlab',
+  'forge.backends.codeberg',
 }
 
 local function github_scope(repo)
@@ -30,50 +33,19 @@ describe('current_pr resolver', function()
   local old_system
   local old_preload
 
-  local github = {
-    name = 'github',
-    labels = {
-      pr = 'PRs',
-      pr_one = 'PR',
-      pr_full = 'PRs',
-    },
-    pr_for_branch_cmd = function(_, branch, scope)
-      return { 'pr-for-branch', branch, scope and scope.slug or '' }
-    end,
-    fetch_pr_details_cmd = function(_, num, scope)
-      return { 'fetch-pr', num, scope and scope.slug or '' }
-    end,
-  }
+  local function fake_backend(name)
+    local backend = require('forge.backends.' .. name)
+    return vim.tbl_extend('force', backend, {
+      pr_for_branch_cmd = function(_, branch, scope)
+        return { 'pr-for-branch', branch, scope and scope.slug or '' }
+      end,
+      fetch_pr_details_cmd = function(_, num, scope)
+        return { 'fetch-pr', num, scope and scope.slug or '' }
+      end,
+    })
+  end
 
-  local gitlab = {
-    name = 'gitlab',
-    labels = {
-      pr = 'Merge Requests',
-      pr_one = 'MR',
-      pr_full = 'Merge Requests',
-    },
-    pr_for_branch_cmd = function(_, branch, scope)
-      return { 'pr-for-branch', branch, scope and scope.slug or '' }
-    end,
-    fetch_pr_details_cmd = function(_, num, scope)
-      return { 'fetch-pr', num, scope and scope.slug or '' }
-    end,
-  }
-
-  local codeberg = {
-    name = 'codeberg',
-    labels = {
-      pr = 'PRs',
-      pr_one = 'PR',
-      pr_full = 'Pull Requests',
-    },
-    pr_for_branch_cmd = function(_, branch, scope)
-      return { 'pr-for-branch', branch, scope and scope.slug or '' }
-    end,
-    fetch_pr_details_cmd = function(_, num, scope)
-      return { 'fetch-pr', num, scope and scope.slug or '' }
-    end,
-  }
+  local github, gitlab, codeberg
 
   before_each(function()
     captured = {
@@ -93,6 +65,10 @@ describe('current_pr resolver', function()
     end
 
     helpers.clear_loaded(loaded_modules)
+
+    github = fake_backend('github')
+    gitlab = fake_backend('gitlab')
+    codeberg = fake_backend('codeberg')
   end)
 
   after_each(function()

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -16,6 +16,45 @@ describe('github', function()
     assert.equals('github', gh.name)
     assert.equals('pr', gh.kinds.pr)
     assert.equals('issue', gh.kinds.issue)
+    assert.equals('GitHub', gh.labels.forge_name)
+    assert.equals('CI/CD runs', gh.labels.ci_inline)
+    assert.is_true(gh.capabilities.ci_terminal_view)
+  end)
+
+  it('parses PR head with scope from headRepository fields', function()
+    local head = gh:parse_pr_head({
+      headRefName = 'feature',
+      headRepository = { name = 'fork', nameWithOwner = 'contributor/fork' },
+      headRepositoryOwner = { login = 'contributor' },
+    })
+    assert.equals('feature', head.branch)
+    assert.equals('contributor/fork', head.scope.slug)
+    assert.equals('github.com', head.scope.host)
+  end)
+
+  it('respects base_scope host when constructing the head scope', function()
+    local head = gh:parse_pr_head({
+      headRefName = 'feature',
+      headRepository = { name = 'fork', nameWithOwner = 'contributor/fork' },
+      headRepositoryOwner = { login = 'contributor' },
+    }, { kind = 'github', host = 'ghe.example.com' })
+    assert.equals('ghe.example.com', head.scope.host)
+  end)
+
+  it('match_head compares branch and scope', function()
+    local scope = gh:parse_pr_head({
+      headRefName = 'feature',
+      headRepository = { name = 'fork', nameWithOwner = 'contributor/fork' },
+      headRepositoryOwner = { login = 'contributor' },
+    }).scope
+    assert.is_true(gh:match_head({ branch = 'feature', scope = scope }, {
+      branch = 'feature',
+      scope = scope,
+    }))
+    assert.is_false(gh:match_head({ branch = 'feature', scope = scope }, {
+      branch = 'other',
+      scope = scope,
+    }))
   end)
 
   it('builds list_pr_json_cmd', function()
@@ -495,6 +534,34 @@ describe('gitlab', function()
     assert.equals('Merge Requests', gl.labels.pr)
     assert.equals('Merge Requests', gl.labels.pr_full)
     assert.equals('Pipelines', gl.labels.ci)
+    assert.equals('GitLab', gl.labels.forge_name)
+    assert.equals('pipelines', gl.labels.ci_inline)
+    assert.is_nil(gl.capabilities.ci_terminal_view)
+  end)
+
+  it('parses MR head with project_id from source fields', function()
+    local head = gl:parse_pr_head({
+      source_branch = 'topic',
+      source_project_id = 12345,
+    })
+    assert.equals('topic', head.branch)
+    assert.equals('12345', head.project_id)
+    assert.is_nil(head.scope)
+  end)
+
+  it('match_head compares by project_id when both sides have one', function()
+    assert.is_true(gl:match_head({ branch = 'topic', project_id = '42' }, {
+      branch = 'topic',
+      project_id = '42',
+    }))
+    assert.is_false(gl:match_head({ branch = 'topic', project_id = '42' }, {
+      branch = 'topic',
+      project_id = '99',
+    }))
+    assert.is_false(gl:match_head({ branch = 'topic', project_id = '42' }, {
+      branch = 'other',
+      project_id = '42',
+    }))
   end)
 
   it('builds list_pr_json_cmd with state variants', function()
@@ -890,7 +957,7 @@ describe('gitlab browse_subject', function()
     end)
 
     assert.is_nil(captured.url)
-    assert.matches('no PR or issue found for #999', captured.warn)
+    assert.matches('no MR or issue found for #999', captured.warn)
   end)
 
   it('uses --hostname from scope and encodes the project slug', function()
@@ -929,6 +996,48 @@ describe('codeberg', function()
     assert.equals('codeberg', cb.name)
     assert.equals('pulls', cb.kinds.pr)
     assert.equals('issues', cb.kinds.issue)
+    assert.equals('Codeberg', cb.labels.forge_name)
+    assert.equals('CI/CD runs', cb.labels.ci_inline)
+    assert.is_nil(cb.capabilities.ci_terminal_view)
+  end)
+
+  it('parses PR head with scope from head.repo.full_name', function()
+    local head = cb:parse_pr_head({
+      head = {
+        ref = 'feature',
+        repo = { full_name = 'contributor/fork' },
+      },
+    })
+    assert.equals('feature', head.branch)
+    assert.equals('contributor/fork', head.scope.slug)
+    assert.equals('codeberg.org', head.scope.host)
+  end)
+
+  it('respects base_scope host when constructing the head scope', function()
+    local head = cb:parse_pr_head({
+      head = {
+        ref = 'feature',
+        repo = { full_name = 'contributor/fork' },
+      },
+    }, { kind = 'codeberg', host = 'gitea.example.com' })
+    assert.equals('gitea.example.com', head.scope.host)
+  end)
+
+  it('match_head compares branch and scope', function()
+    local scope = cb:parse_pr_head({
+      head = {
+        ref = 'feature',
+        repo = { full_name = 'contributor/fork' },
+      },
+    }).scope
+    assert.is_true(cb:match_head({ branch = 'feature', scope = scope }, {
+      branch = 'feature',
+      scope = scope,
+    }))
+    assert.is_false(cb:match_head({ branch = 'feature', scope = scope }, {
+      branch = 'other',
+      scope = scope,
+    }))
   end)
 
   it('builds list_pr_json_cmd with --fields', function()


### PR DESCRIPTION
## Problem

`AGENTS.md` mandates that forge-specific behavior live exclusively in
`lua/forge/backends/`. Multiple modules outside the backend layer were
violating that:

- **Hardcoded "PR" labels in user-facing strings** — `gitlab.lua` and
  `codeberg.lua` wrote `"no PR or issue found for #N"` instead of
  consulting `M.labels.pr_one` (so GitLab said "PR" instead of "MR").
- **`f.name == 'github'` dispatch in `ops.lua`** — two sites switched to
  a `github_ci_term` helper based on the forge name. The helper itself
  lived in `ops.lua`.
- **`f.name == 'gitlab'` dispatch in `pickers.lua`** — `ci_run_history_label`
  and `ci_fetch_label` checked the forge name to pick lowercase
  `"pipelines"` vs `"CI/CD runs"`.
- **`forge.name == 'github'/'gitlab'/'codeberg'` switch in `resolve.lua`** —
  per-forge head-extraction and head-matching logic (`github_head`,
  `gitlab_head`, `codeberg_head`, `gitlab_project_id`) all defined and
  dispatched in `resolve.lua`.
- **`log.info` for "nothing to toggle for skipped run"** — the only
  `info`-tier message in a cluster of `warn`-tier "you asked me to do
  something I can't" siblings (`ops.lua:573`/`589`/`613`).

## Solution

### Backend interface additions (`lua/forge/types.lua`)

- `forge.Capabilities.ci_terminal_view: boolean?` — opts the backend
  into the TTY summary view in `ops.lua`. Set on **github only**.
- `forge.Forge.labels.forge_name: string` — human-readable forge name
  used in user-facing strings (`'GitHub'`, `'GitLab'`, `'Codeberg'`).
- `forge.Forge.labels.ci_inline: string` — lowercase-ish inline term
  for runs/pipelines used in `'fetching X...'` / `'No failed X for Y'`.
- `forge.Forge:parse_pr_head(json, base_scope?) -> forge.HeadRef` —
  extracts the head ref from PR detail JSON. Each backend knows its
  own field names (`headRefName` / `source_branch` / `head.ref`).
- `forge.Forge:match_head(expected, actual) -> boolean?, string?` —
  decides whether a PR's head matches an expected head. GitHub and
  Codeberg compare by scope; GitLab compares by `source_project_id`,
  resolving it via `glab api` when the expected head only carries a
  scope (with the cache living inside the gitlab backend, not
  `resolve.lua`).

### Migration of forge-specific code into backends

| Concern | From | To |
|---|---|---|
| `parse_pr_head` for github | `resolve.lua:github_head` | `github.lua:M:parse_pr_head` |
| `parse_pr_head` for gitlab | `resolve.lua:gitlab_head` | `gitlab.lua:M:parse_pr_head` |
| `parse_pr_head` for codeberg | `resolve.lua:codeberg_head` | `codeberg.lua:M:parse_pr_head` |
| project_id lookup + cache | `resolve.lua:gitlab_project_id` | `gitlab.lua:resolve_project_id` (file-local) |
| `match_head` switch | `resolve.lua:head_matches` (per-forge if-else) | `M:match_head` per backend |
| github CI terminal view | `ops.lua:github_ci_term` (hardcoded gating) | `ops.lua:open_ci_terminal_view` (gated by capability) |
| GitLab CI inline label | `pickers.lua` `f.name == 'gitlab'` casing rule | `gitlab.lua:labels.ci_inline = 'pipelines'` |
| "GitHub does not support per-job live watch" | hardcoded string | `f.labels.forge_name` |
| "no PR or issue found for #N" | hardcoded "PR" | `M.labels.pr_one` (`"MR"` on gitlab) |
| `nothing to toggle for skipped run` | `log.info` | `log.warn` (matches sibling messages) |

### Module-level summary

- **`ops.lua`**: `github_ci_term` -> `open_ci_terminal_view`, dispatched
  via `f.capabilities.ci_terminal_view`. The "per-job live watch" log
  now uses `f.labels.forge_name`. `nothing to toggle` is `log.warn`.
- **`pickers.lua`**: `ci_run_history_label` and `ci_fetch_label` are
  collapsed into one `ci_inline_label` reading `f.labels.ci_inline`.
  Drops the `ci_label` helper (was unused after consolidation).
- **`resolve.lua`**: `pr_head` and `head_matches` become thin
  dispatchers that call `forge:parse_pr_head` / `forge:match_head`,
  with safe fallbacks for custom backends that do not implement
  them. The github_head / gitlab_head / codeberg_head /
  gitlab_project_id helpers and the per-forge if-else are gone.
- **`backends/github.lua`**: gains `parse_pr_head`, `match_head`,
  `capabilities.ci_terminal_view = true`, `labels.forge_name = 'GitHub'`,
  `labels.ci_inline = 'CI/CD runs'`, plus a small file-local
  `nonempty` helper.
- **`backends/gitlab.lua`**: gains `parse_pr_head`, `match_head` (with
  internal `resolve_project_id` + `project_id_cache`),
  `labels.forge_name = 'GitLab'`, `labels.ci_inline = 'pipelines'`.
  The "no MR or issue found ..." message uses `M.labels.pr_one`.
- **`backends/codeberg.lua`**: gains `parse_pr_head`, `match_head`,
  `labels.forge_name = 'Codeberg'`, `labels.ci_inline = 'CI/CD runs'`.
  The "no PR or issue found ..." message uses `M.labels.pr_one`
  (no string change since `pr_one = 'PR'`; symmetry fix).

### Verification

After this PR there are zero `f.name == '<forge>'` or
`forge.name == '<forge>'` checks in `lua/forge/` outside the
`backends/` directory:

```
$ rg "f\.name == '(github|gitlab|codeberg)'|forge\.name == '(github|gitlab|codeberg)'" lua/forge/
(no matches)
```

The remaining `'github'/'gitlab'/'codeberg'` literal occurrences in
non-backend files are scope kinds (`scope.lua`'s URL parsing,
`types.lua`'s `forge.ScopeKind` alias, `health.lua`'s builtin-source
check, `init.lua`'s `builtin_hosts`). Those are addressing
concerns, not behavior dispatch.

### Tests

- `resolve_spec.lua` now uses the real backend modules as fixtures
  (with two cmd methods stubbed) so `parse_pr_head` and `match_head`
  are exercised end-to-end against the real implementations. The 5
  per-forge resolver specs that previously stubbed minimal forge
  tables now run through the real github/gitlab/codeberg backends.
- `sources_spec.lua` adds per-backend specs for `parse_pr_head`,
  `match_head`, `labels.forge_name`, `labels.ci_inline`, and
  `capabilities.ci_terminal_view`.
- `ops_spec.lua`: the two GitHub-CI-terminal tests now set
  `capabilities = { ci_terminal_view = true }` and
  `labels = { forge_name = 'GitHub' }` instead of relying on
  `name = 'github'`.
- `pickers_spec.lua`: GitLab pipeline-terminology test mock gets
  `labels.ci_inline = 'pipelines'` so the new helper resolves to it.
- `create_pr_spec.lua`: the preloaded github backend mock gets
  `parse_pr_head` and `match_head` mirroring the real backend so
  current-PR resolution still finds the existing PR.

`just ci` clean: nix fmt, stylua, biome, selene, lua-language-server,
vimdoc-language-server, **656/0/0 busted** (up from 640).