### PR TITLE
fix(compose): stop preselecting edit titles

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -1,5 +1,4 @@
 local M = {}
-
 local scope = require('forge.scope')
 local submission = require('forge.submission')
 local template = require('forge.template')
@@ -581,10 +580,6 @@ function M.open_issue_edit(f, num, details, ref)
       )
     end,
   })
-
-  vim.api.nvim_win_set_cursor(0, { 1, 2 })
-  vim.cmd('normal! v$h')
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-G>', true, false, true), 'n', false)
 end
 
 ---@param f forge.Forge
@@ -905,10 +900,6 @@ function M.open_pr_edit(f, num, details, current_branch, ref)
       )
     end,
   })
-
-  vim.api.nvim_win_set_cursor(0, { 1, 2 })
-  vim.cmd('normal! v$h')
-  vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes('<C-G>', true, false, true), 'n', false)
 end
 
 return M

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -130,6 +130,41 @@ describe('compose issue create', function()
     vim.cmd('enew!')
   end)
 
+  it('places the cursor on the title and enters insert mode for issue create', function()
+    local compose = require('forge.compose')
+    local old_set_cursor = vim.api.nvim_win_set_cursor
+    local old_startinsert = vim.cmd.startinsert
+    local cursor_calls = {}
+    local startinsert_calls = {}
+
+    vim.api.nvim_win_set_cursor = function(win, pos)
+      cursor_calls[#cursor_calls + 1] = { win = win, pos = { pos[1], pos[2] } }
+      return old_set_cursor(win, pos)
+    end
+    vim.cmd.startinsert = function(opts)
+      startinsert_calls[#startinsert_calls + 1] = opts
+    end
+
+    local ok, err = pcall(function()
+      compose.open_issue({
+        name = 'github',
+        create_issue_cmd = function()
+          return { 'create-issue' }
+        end,
+      })
+    end)
+
+    vim.api.nvim_win_set_cursor = old_set_cursor
+    vim.cmd.startinsert = old_startinsert
+
+    if not ok then
+      error(err)
+    end
+
+    assert.same({ { win = 0, pos = { 1, 2 } } }, cursor_calls)
+    assert.same({ { bang = true } }, startinsert_calls)
+  end)
+
   it('submits issues with an empty body', function()
     local compose = require('forge.compose')
     local f = {
@@ -508,6 +543,60 @@ describe('compose issue edit', function()
       end
     end
     vim.cmd('enew!')
+  end)
+
+  it('leaves issue edit buffers at the default cursor and mode state', function()
+    local compose = require('forge.compose')
+    local old_set_cursor = vim.api.nvim_win_set_cursor
+    local old_feedkeys = vim.api.nvim_feedkeys
+    local old_cmd = vim.cmd
+    local cursor_calls = {}
+    local feedkeys_calls = {}
+    local cmd_calls = {}
+
+    vim.api.nvim_win_set_cursor = function(win, pos)
+      cursor_calls[#cursor_calls + 1] = { win = win, pos = { pos[1], pos[2] } }
+      return old_set_cursor(win, pos)
+    end
+    vim.api.nvim_feedkeys = function(keys, mode, escape_ks)
+      feedkeys_calls[#feedkeys_calls + 1] = { keys = keys, mode = mode, escape_ks = escape_ks }
+    end
+    vim.cmd = function(cmd)
+      cmd_calls[#cmd_calls + 1] = cmd
+      return old_cmd(cmd)
+    end
+
+    local ok, err = pcall(function()
+      compose.open_issue_edit(
+        {
+          name = 'github',
+          update_issue_cmd = function()
+            return { 'update-issue' }
+          end,
+        },
+        '42',
+        {
+          title = 'existing issue',
+          body = 'body',
+          labels = {},
+          assignees = {},
+          milestone = '',
+        }
+      )
+    end)
+
+    vim.api.nvim_win_set_cursor = old_set_cursor
+    vim.api.nvim_feedkeys = old_feedkeys
+    vim.cmd = old_cmd
+
+    if not ok then
+      error(err)
+    end
+
+    assert.same({}, cursor_calls)
+    assert.same({}, feedkeys_calls)
+    assert.is_false(vim.tbl_contains(cmd_calls, 'normal! v$h'))
+    assert.same({ 1, 0 }, vim.api.nvim_win_get_cursor(0))
   end)
 
   it('only accents the forge name on the issue edit action line', function()

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -114,6 +114,48 @@ describe('compose pr create', function()
     vim.cmd('enew!')
   end)
 
+  it('pre-selects the PR title on create', function()
+    local compose = require('forge.compose')
+    local old_set_cursor = vim.api.nvim_win_set_cursor
+    local old_feedkeys_local = vim.api.nvim_feedkeys
+    local old_cmd = vim.cmd
+    local cursor_calls = {}
+    local feedkeys_calls = {}
+    local cmd_calls = {}
+
+    vim.api.nvim_win_set_cursor = function(win, pos)
+      cursor_calls[#cursor_calls + 1] = { win = win, pos = { pos[1], pos[2] } }
+      return old_set_cursor(win, pos)
+    end
+    vim.api.nvim_feedkeys = function(keys, mode, escape_ks)
+      feedkeys_calls[#feedkeys_calls + 1] = { keys = keys, mode = mode, escape_ks = escape_ks }
+    end
+    vim.cmd = function(cmd)
+      cmd_calls[#cmd_calls + 1] = cmd
+      return old_cmd(cmd)
+    end
+
+    local ok, err = pcall(function()
+      compose.open_pr({
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = false },
+        name = 'github',
+      }, 'new', 'main', false, nil, nil, 'origin', 'origin/main', 'HEAD')
+    end)
+
+    vim.api.nvim_win_set_cursor = old_set_cursor
+    vim.api.nvim_feedkeys = old_feedkeys_local
+    vim.cmd = old_cmd
+
+    if not ok then
+      error(err)
+    end
+
+    assert.same({ { win = 0, pos = { 1, 2 } } }, cursor_calls)
+    assert.is_true(vim.tbl_contains(cmd_calls, 'normal! v$h'))
+    assert.equals(1, #feedkeys_calls)
+  end)
+
   it(
     'orders the create footer from action to branch to metadata to diff stat to instructions',
     function()

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -135,6 +135,64 @@ describe('compose pr edit', function()
     vim.cmd('enew!')
   end)
 
+  it('leaves PR edit buffers at the default cursor and mode state', function()
+    local compose = require('forge.compose')
+    local old_set_cursor = vim.api.nvim_win_set_cursor
+    local old_feedkeys_local = vim.api.nvim_feedkeys
+    local old_cmd = vim.cmd
+    local cursor_calls = {}
+    local feedkeys_calls = {}
+    local cmd_calls = {}
+
+    vim.api.nvim_win_set_cursor = function(win, pos)
+      cursor_calls[#cursor_calls + 1] = { win = win, pos = { pos[1], pos[2] } }
+      return old_set_cursor(win, pos)
+    end
+    vim.api.nvim_feedkeys = function(keys, mode, escape_ks)
+      feedkeys_calls[#feedkeys_calls + 1] = { keys = keys, mode = mode, escape_ks = escape_ks }
+    end
+    vim.cmd = function(cmd)
+      cmd_calls[#cmd_calls + 1] = cmd
+      return old_cmd(cmd)
+    end
+
+    local ok, err = pcall(function()
+      compose.open_pr_edit(
+        {
+          labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+          capabilities = { draft = true, reviewers = true },
+          name = 'github',
+        },
+        '23',
+        {
+          title = 'PR title',
+          body = 'PR body',
+          draft = false,
+          head_branch = 'real-pr-head',
+          base_branch = 'main',
+          reviewers = {},
+          labels = {},
+          assignees = {},
+          milestone = '',
+        },
+        'real-pr-head'
+      )
+    end)
+
+    vim.api.nvim_win_set_cursor = old_set_cursor
+    vim.api.nvim_feedkeys = old_feedkeys_local
+    vim.cmd = old_cmd
+
+    if not ok then
+      error(err)
+    end
+
+    assert.same({}, cursor_calls)
+    assert.same({}, feedkeys_calls)
+    assert.is_false(vim.tbl_contains(cmd_calls, 'normal! v$h'))
+    assert.same({ 1, 0 }, vim.api.nvim_win_get_cursor(0))
+  end)
+
   it('shows fetched metadata in the comment header', function()
     local compose = require('forge.compose')
     compose.open_pr_edit(


### PR DESCRIPTION
## Problem

Issue and PR edit compose buffers pre-select the existing title, so the first typed character can replace it wholesale. Issue #406 expects edit buffers to open without special cursor behavior while preserving the current create-flow ergonomics. Closes #406.

## Solution

Remove the forced cursor move and select-mode setup from `open_issue_edit()` and `open_pr_edit()`. Add focused compose specs that lock in the intended matrix: issue create still enters insert mode, PR create still pre-selects the generated title, and both edit flows open at the default start position.