### PR TITLE
feat(picker): patch PR approvals locally before revalidation

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -73,6 +73,14 @@ local function git_root()
   return root
 end
 
+---@param num string
+---@param scope? forge.Scope
+---@return string?
+local function pr_state_key(num, scope)
+  local root = git_root()
+  return root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
+end
+
 local function cmd_error(result, fallback)
   local msg = vim.trim(result.stderr or '')
   if msg == '' then
@@ -236,8 +244,7 @@ end
 ---@param scope? forge.Scope
 ---@return forge.PRState
 function M.pr_state(f, num, scope)
-  local root = git_root()
-  local key = root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
+  local key = pr_state_key(num, scope)
   if key then
     local cached = pr_state_cache.get(key)
     if cached ~= nil then
@@ -245,6 +252,18 @@ function M.pr_state(f, num, scope)
     end
   end
   local state = f:pr_state(num, scope)
+  if key then
+    pr_state_cache.set(key, state)
+  end
+  return state
+end
+
+---@param num string
+---@param state forge.PRState
+---@param scope? forge.Scope
+---@return forge.PRState
+function M.set_pr_state(num, state, scope)
+  local key = pr_state_key(num, scope)
   if key then
     pr_state_cache.set(key, state)
   end
@@ -260,7 +279,12 @@ function M.clear_pr_state(num, scope)
     return
   end
   if num ~= nil then
-    pr_state_cache.clear(root .. '|' .. scope_mod.key(scope) .. '|' .. num)
+    local key = pr_state_key(num, scope)
+    if key then
+      pr_state_cache.clear(key)
+      return
+    end
+    pr_state_cache.clear()
     return
   end
   if scope ~= nil then

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1040,6 +1040,22 @@ function M.pr(state, f, opts)
     )
   end
 
+  ---@param entry forge.PickerEntry
+  local function locally_approve_pr(entry)
+    local scope = entry.value.scope or ref
+    ---@type forge.PRState
+    local current_pr_state = vim.tbl_extend('force', {
+      state = entry.value.state or 'OPEN',
+      mergeable = 'UNKNOWN',
+      review_decision = '',
+      is_draft = entry.value.is_draft == true,
+    }, vim.deepcopy(forge_mod.pr_state(f, entry.value.num, scope) or {}))
+    current_pr_state.review_decision = 'APPROVED'
+    forge_mod.set_pr_state(entry.value.num, current_pr_state, scope)
+    rerender_pr_list()
+    revalidate_current_prs()
+  end
+
   local function locally_toggle_pr(entry, verb)
     local current_index, current_pr = list_row(current_prs, num_field, entry.value.num)
     if not current_index or type(current_pr) ~= 'table' then
@@ -1170,7 +1186,9 @@ function M.pr(state, f, opts)
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_approve(f, entry.value, {
-            on_success = reopen_list,
+            on_success = function()
+              locally_approve_pr(entry)
+            end,
             on_failure = reopen_list,
           })
         end

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -132,6 +132,43 @@ describe('pr_state cache', function()
     assert.same(first, second)
   end)
 
+  it('sets scoped PR state entries without refetching', function()
+    local calls = 0
+    local fake = {
+      pr_state = function()
+        calls = calls + 1
+        return {
+          state = 'OPEN',
+          mergeable = 'UNKNOWN',
+          review_decision = '',
+          is_draft = false,
+        }
+      end,
+    }
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'barrettruth/forge.nvim',
+    }
+
+    forge.set_pr_state('42', {
+      state = 'OPEN',
+      mergeable = 'UNKNOWN',
+      review_decision = 'APPROVED',
+      is_draft = true,
+    }, scope)
+
+    local state = forge.pr_state(fake, '42', scope)
+
+    assert.equals(0, calls)
+    assert.same({
+      state = 'OPEN',
+      mergeable = 'UNKNOWN',
+      review_decision = 'APPROVED',
+      is_draft = true,
+    }, state)
+  end)
+
   it('clears scoped PR state entries without touching other scopes', function()
     local calls = 0
     local fake = {

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -13,6 +13,8 @@ local pr_create_opts
 local default_system
 local picker_pick_calls
 local picker_refresh_calls
+---@type table<string, forge.PRState>
+local pr_state_cache
 local preload_modules = {
   'fzf-lua.utils',
   'forge',
@@ -152,6 +154,26 @@ local function fake_release_forge()
   }
 end
 
+---@param scope forge.Scope?
+---@return string
+local function pr_state_scope_key(scope)
+  if type(scope) ~= 'table' then
+    return '|||'
+  end
+  return table.concat({
+    scope.kind or '',
+    scope.host or '',
+    scope.slug or '',
+  }, '|') .. '|'
+end
+
+---@param scope forge.Scope?
+---@param num string|integer?
+---@return string
+local function pr_state_key(scope, num)
+  return pr_state_scope_key(scope) .. tostring(num or '')
+end
+
 local function action_by_name(name)
   return helpers.action_by_name(captured.actions, name)
 end
@@ -174,6 +196,7 @@ describe('pickers', function()
     pr_create_opts = nil
     picker_pick_calls = 0
     picker_refresh_calls = 0
+    pr_state_cache = {}
     default_system = vim.system
     vim.system = function(_, _, cb)
       if cb then
@@ -507,9 +530,35 @@ describe('pickers', function()
           return f:repo_info()
         end,
         pr_state = function(f, num, scope)
-          return f:pr_state(num, scope)
+          local key = pr_state_key(scope, num)
+          local cached = pr_state_cache[key]
+          if cached ~= nil then
+            return cached
+          end
+          local state = f:pr_state(num, scope)
+          pr_state_cache[key] = state
+          return state
         end,
-        clear_pr_state = function() end,
+        set_pr_state = function(num, state, scope)
+          pr_state_cache[pr_state_key(scope, num)] = state
+          return state
+        end,
+        clear_pr_state = function(num, scope)
+          if num ~= nil then
+            pr_state_cache[pr_state_key(scope, num)] = nil
+            return
+          end
+          if scope ~= nil then
+            local prefix = pr_state_scope_key(scope)
+            for key in pairs(pr_state_cache) do
+              if key:sub(1, #prefix) == prefix then
+                pr_state_cache[key] = nil
+              end
+            end
+            return
+          end
+          pr_state_cache = {}
+        end,
         create_issue = function(...)
           issue_create_calls = issue_create_calls + 1
           issue_create_opts = select(1, ...)
@@ -1220,6 +1269,88 @@ describe('pickers', function()
     assert.equals(1, picker_pick_calls)
     assert.equals(1, picker_refresh_calls)
   end)
+
+  it(
+    'patches shared PR state locally and revalidates the live PR picker after approve succeeds',
+    function()
+      cache['pr:open'] = {
+        {
+          number = 42,
+          title = 'Draft approval',
+          state = 'OPEN',
+          author = 'alice',
+          created_at = '',
+        },
+      }
+      cache['pr:closed'] = {}
+
+      local old_system = vim.system
+      local calls = {}
+      vim.system = function(cmd, _, cb)
+        calls[#calls + 1] = { cmd = cmd, cb = cb }
+        return {
+          wait = function()
+            return { code = 0 }
+          end,
+        }
+      end
+
+      local pickers = require('forge.pickers')
+      pickers.pr(
+        'open',
+        fake_forge({
+          pr_states = {
+            ['42'] = {
+              state = 'OPEN',
+              mergeable = 'UNKNOWN',
+              review_decision = '',
+              is_draft = true,
+            },
+          },
+        })
+      )
+      captured.stream(function() end)
+
+      local labels = helpers.action_labels(captured.actions, captured.entries[1])
+      assert.equals('approve', labels.approve)
+      assert.is_nil(labels.merge)
+      assert.equals('ready', labels.draft)
+
+      action_by_name('approve').fn(captured.entries[1])
+
+      labels = helpers.action_labels(captured.actions, captured.entries[1])
+      assert.is_nil(labels.approve)
+      assert.is_nil(labels.merge)
+      assert.equals('ready', labels.draft)
+      assert.same({
+        { name = 'pr_approve', pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil } },
+      }, op_calls)
+      assert.equals(1, picker_pick_calls)
+      assert.equals(1, picker_refresh_calls)
+      assert.same({ 'prs', 'open' }, calls[1].cmd)
+
+      calls[1].cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            number = 42,
+            title = 'Authoritative',
+            state = 'OPEN',
+            author = 'alice',
+            created_at = '',
+          },
+        }),
+      })
+
+      vim.wait(100, function()
+        return cache['pr:open'][1].title == 'Authoritative'
+      end)
+      vim.system = old_system
+
+      assert.equals('Authoritative', cache['pr:open'][1].title)
+      assert.equals(2, picker_refresh_calls)
+    end
+  )
 
   it('patches PR caches locally and revalidates the live PR picker after close succeeds', function()
     cache['pr:open'] = {


### PR DESCRIPTION
## Problem

Approving a PR still hard-reopened the picker, so approve and related labels stayed stale until a full refetch finished.

## Solution

Add a shared `forge.set_pr_state(...)` cache writer, update the cached PR state to `APPROVED` on approve success, and rerender plus revalidate the live PR picker in place. Cover the new cache write path and approve reducer flow in `spec/init_spec.lua` and `spec/pickers_spec.lua`, including the added LuaCATS on the new helpers.