### PR TITLE
feat(picker): patch PR draft state locally before revalidation

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1056,6 +1056,22 @@ function M.pr(state, f, opts)
     revalidate_current_prs()
   end
 
+  ---@param entry forge.PickerEntry
+  local function locally_toggle_pr_draft(entry)
+    local scope = entry.value.scope or ref
+    ---@type forge.PRState
+    local current_pr_state = vim.tbl_extend('force', {
+      state = entry.value.state or 'OPEN',
+      mergeable = 'UNKNOWN',
+      review_decision = '',
+      is_draft = entry.value.is_draft == true,
+    }, vim.deepcopy(forge_mod.pr_state(f, entry.value.num, scope) or {}))
+    current_pr_state.is_draft = not current_pr_state.is_draft
+    forge_mod.set_pr_state(entry.value.num, current_pr_state, scope)
+    rerender_pr_list()
+    revalidate_current_prs()
+  end
+
   local function locally_toggle_pr(entry, verb)
     local current_index, current_pr = list_row(current_prs, num_field, entry.value.num)
     if not current_index or type(current_pr) ~= 'table' then
@@ -1255,7 +1271,9 @@ function M.pr(state, f, opts)
       fn = function(entry)
         if entry and not entry.load_more and f.capabilities.draft then
           pr_toggle_draft_action(f, entry.value, {
-            on_success = reopen_list,
+            on_success = function()
+              locally_toggle_pr_draft(entry)
+            end,
             on_failure = reopen_list,
           })
         end

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1352,6 +1352,178 @@ describe('pickers', function()
     end
   )
 
+  it(
+    'patches shared PR state locally and revalidates the live PR picker after marking draft',
+    function()
+      cache['pr:open'] = {
+        {
+          number = 42,
+          title = 'Ready PR',
+          state = 'OPEN',
+          author = 'alice',
+          created_at = '',
+        },
+      }
+      cache['pr:closed'] = {}
+
+      local old_system = vim.system
+      local calls = {}
+      vim.system = function(cmd, _, cb)
+        calls[#calls + 1] = { cmd = cmd, cb = cb }
+        return {
+          wait = function()
+            return { code = 0 }
+          end,
+        }
+      end
+
+      local pickers = require('forge.pickers')
+      pickers.pr(
+        'open',
+        fake_forge({
+          pr_states = {
+            ['42'] = {
+              state = 'OPEN',
+              mergeable = 'UNKNOWN',
+              review_decision = '',
+              is_draft = false,
+            },
+          },
+        })
+      )
+      captured.stream(function() end)
+
+      local labels = helpers.action_labels(captured.actions, captured.entries[1])
+      assert.equals('approve', labels.approve)
+      assert.equals('merge', labels.merge)
+      assert.equals('draft', labels.draft)
+
+      action_by_name('draft').fn(captured.entries[1])
+
+      labels = helpers.action_labels(captured.actions, captured.entries[1])
+      assert.equals('approve', labels.approve)
+      assert.is_nil(labels.merge)
+      assert.equals('ready', labels.draft)
+      assert.same({
+        {
+          name = 'pr_toggle_draft',
+          pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+          is_draft = false,
+        },
+      }, op_calls)
+      assert.equals(1, picker_pick_calls)
+      assert.equals(1, picker_refresh_calls)
+      assert.same({ 'prs', 'open' }, calls[1].cmd)
+
+      calls[1].cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            number = 42,
+            title = 'Authoritative draft',
+            state = 'OPEN',
+            author = 'alice',
+            created_at = '',
+          },
+        }),
+      })
+
+      vim.wait(100, function()
+        return cache['pr:open'][1].title == 'Authoritative draft'
+      end)
+      vim.system = old_system
+
+      assert.equals('Authoritative draft', cache['pr:open'][1].title)
+      assert.equals(2, picker_refresh_calls)
+    end
+  )
+
+  it(
+    'patches shared PR state locally and revalidates the live PR picker after marking ready',
+    function()
+      cache['pr:open'] = {
+        {
+          number = 42,
+          title = 'Draft PR',
+          state = 'OPEN',
+          author = 'alice',
+          created_at = '',
+        },
+      }
+      cache['pr:closed'] = {}
+
+      local old_system = vim.system
+      local calls = {}
+      vim.system = function(cmd, _, cb)
+        calls[#calls + 1] = { cmd = cmd, cb = cb }
+        return {
+          wait = function()
+            return { code = 0 }
+          end,
+        }
+      end
+
+      local pickers = require('forge.pickers')
+      pickers.pr(
+        'open',
+        fake_forge({
+          pr_states = {
+            ['42'] = {
+              state = 'OPEN',
+              mergeable = 'UNKNOWN',
+              review_decision = '',
+              is_draft = true,
+            },
+          },
+        })
+      )
+      captured.stream(function() end)
+
+      local labels = helpers.action_labels(captured.actions, captured.entries[1])
+      assert.equals('approve', labels.approve)
+      assert.is_nil(labels.merge)
+      assert.equals('ready', labels.draft)
+
+      action_by_name('draft').fn(captured.entries[1])
+
+      labels = helpers.action_labels(captured.actions, captured.entries[1])
+      assert.equals('approve', labels.approve)
+      assert.equals('merge', labels.merge)
+      assert.equals('draft', labels.draft)
+      assert.same({
+        {
+          name = 'pr_toggle_draft',
+          pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+          is_draft = true,
+        },
+      }, op_calls)
+      assert.equals(1, picker_pick_calls)
+      assert.equals(1, picker_refresh_calls)
+      assert.same({ 'prs', 'open' }, calls[1].cmd)
+
+      calls[1].cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            number = 42,
+            title = 'Authoritative ready',
+            state = 'OPEN',
+            author = 'alice',
+            created_at = '',
+          },
+        }),
+      })
+
+      vim.wait(100, function()
+        return cache['pr:open'][1].title == 'Authoritative ready'
+      end)
+      vim.system = old_system
+
+      assert.equals('Authoritative ready', cache['pr:open'][1].title)
+      assert.equals(2, picker_refresh_calls)
+    end
+  )
+
   it('patches PR caches locally and revalidates the live PR picker after close succeeds', function()
     cache['pr:open'] = {
       { number = 42, title = 'Fix api drift', state = 'OPEN', author = 'alice', created_at = '' },


### PR DESCRIPTION
## Problem

Toggling a PR between draft and ready still reopened the picker, so draft-dependent actions and labels stayed stale until a full refetch completed.

## Solution

Flip the shared cached `pr_state.is_draft` value on successful draft toggles, rerender the live PR picker in place, and then revalidate the current list. Add focused picker specs for both draft and ready transitions.