### PR TITLE
feat(picker): patch PR merges locally before revalidation

### DIFF
--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -985,6 +985,22 @@ function M.pr(state, f, opts)
     return nil
   end
 
+  local function observed_merged_pr_state(rows)
+    if type(rows) ~= 'table' then
+      return nil
+    end
+    for _, pr in ipairs(rows) do
+      local value = pr[pr_state_field]
+      if type(value) == 'string' then
+        local text = vim.trim(value)
+        if text:lower() == 'merged' then
+          return text
+        end
+      end
+    end
+    return nil
+  end
+
   local function next_pr_state(current_pr, verb)
     local current_state = current_pr[pr_state_field]
     local current_text = type(current_state) == 'string' and vim.trim(current_state) or ''
@@ -1005,6 +1021,20 @@ function M.pr(state, f, opts)
       return 'OPEN'
     end
     return 'open'
+  end
+
+  local function merged_pr_state(current_pr)
+    local merged_state = observed_merged_pr_state(state == 'all' and current_prs or nil)
+      or observed_merged_pr_state(forge_mod.get_list(pr_cache_key('all')))
+    if merged_state then
+      return merged_state
+    end
+    local current_state = current_pr[pr_state_field]
+    local current_text = type(current_state) == 'string' and vim.trim(current_state) or ''
+    if current_text ~= '' and current_text == current_text:upper() then
+      return 'MERGED'
+    end
+    return 'merged'
   end
 
   local function patch_pr_cache(list_state, mutate)
@@ -1052,6 +1082,46 @@ function M.pr(state, f, opts)
     }, vim.deepcopy(forge_mod.pr_state(f, entry.value.num, scope) or {}))
     current_pr_state.review_decision = 'APPROVED'
     forge_mod.set_pr_state(entry.value.num, current_pr_state, scope)
+    rerender_pr_list()
+    revalidate_current_prs()
+  end
+
+  ---@param entry forge.PickerEntry
+  local function locally_merge_pr(entry)
+    local current_index, current_pr = list_row(current_prs, num_field, entry.value.num)
+    if not current_index or type(current_pr) ~= 'table' then
+      refresh_pr_list()
+      return
+    end
+    local scope = entry.value.scope or ref
+    if state == 'all' then
+      local updated_pr = vim.deepcopy(current_pr)
+      updated_pr[pr_state_field] = merged_pr_state(current_pr)
+      current_prs[current_index] = updated_pr
+    else
+      table.remove(current_prs, current_index)
+    end
+    if use_cache then
+      forge_mod.set_list(cache_key, current_prs)
+    end
+
+    ---@type forge.PRState
+    local current_pr_state = vim.tbl_extend('force', {
+      state = entry.value.state or 'OPEN',
+      mergeable = 'UNKNOWN',
+      review_decision = '',
+      is_draft = entry.value.is_draft == true,
+    }, vim.deepcopy(forge_mod.pr_state(f, entry.value.num, scope) or {}))
+    current_pr_state.state = merged_pr_state(current_pr)
+    current_pr_state.is_draft = false
+    forge_mod.set_pr_state(entry.value.num, current_pr_state, scope)
+
+    for _, list_state in ipairs(list_states) do
+      if list_state ~= state then
+        clear_list_cache(forge_mod, pr_cache_key(list_state))
+      end
+    end
+
     rerender_pr_list()
     revalidate_current_prs()
   end
@@ -1219,7 +1289,9 @@ function M.pr(state, f, opts)
       fn = function(entry)
         if entry and not entry.load_more then
           ops.pr_merge(f, entry.value, nil, {
-            on_success = reopen_list,
+            on_success = function()
+              locally_merge_pr(entry)
+            end,
             on_failure = reopen_list,
           })
         end

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -1525,6 +1525,159 @@ describe('pickers', function()
     end
   )
 
+  it('patches the open PR list locally and revalidates after merge succeeds', function()
+    cache['pr:open'] = {
+      { number = 42, title = 'Merge me', state = 'OPEN', author = 'alice', created_at = '' },
+      { number = 41, title = 'Keep me', state = 'OPEN', author = 'cora', created_at = '' },
+    }
+    cache['pr:closed'] = {
+      { number = 40, title = 'Old closed', state = 'CLOSED', author = 'bob', created_at = '' },
+    }
+    cache['pr:all'] = {
+      { number = 42, title = 'Merge me', state = 'OPEN', author = 'alice', created_at = '' },
+      { number = 41, title = 'Keep me', state = 'OPEN', author = 'cora', created_at = '' },
+      { number = 40, title = 'Old closed', state = 'CLOSED', author = 'bob', created_at = '' },
+    }
+
+    local old_system = vim.system
+    local calls = {}
+    vim.system = function(cmd, _, cb)
+      calls[#calls + 1] = { cmd = cmd, cb = cb }
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+    captured.stream(function() end)
+
+    action_by_name('merge').fn(captured.entries[1])
+
+    assert.same(
+      { 41 },
+      vim.tbl_map(function(pr)
+        return pr.number
+      end, cache['pr:open'])
+    )
+    assert.is_nil(cache['pr:closed'])
+    assert.is_nil(cache['pr:all'])
+    assert.equals('41', captured.entries[1].value.num)
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
+    assert.same({
+      {
+        name = 'pr_merge',
+        pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+        method = nil,
+      },
+    }, op_calls)
+    assert.same({ 'prs', 'open' }, calls[1].cmd)
+
+    calls[1].cb({
+      code = 0,
+      stdout = vim.json.encode({
+        { number = 41, title = 'Authoritative', state = 'OPEN', author = 'cora', created_at = '' },
+      }),
+    })
+
+    vim.wait(100, function()
+      return cache['pr:open'][1].title == 'Authoritative'
+    end)
+    vim.system = old_system
+
+    assert.equals('Authoritative', cache['pr:open'][1].title)
+    assert.equals(2, picker_refresh_calls)
+  end)
+
+  it('updates all-PR rows in place and revalidates after merge succeeds', function()
+    cache['pr:open'] = {
+      { number = 42, title = 'Merge me', state = 'OPEN', author = 'alice', created_at = '' },
+      { number = 41, title = 'Keep me', state = 'OPEN', author = 'cora', created_at = '' },
+    }
+    cache['pr:closed'] = {
+      { number = 40, title = 'Old closed', state = 'CLOSED', author = 'bob', created_at = '' },
+    }
+    cache['pr:all'] = {
+      { number = 42, title = 'Merge me', state = 'OPEN', author = 'alice', created_at = '' },
+      { number = 41, title = 'Already merged', state = 'MERGED', author = 'drew', created_at = '' },
+      { number = 40, title = 'Old closed', state = 'CLOSED', author = 'bob', created_at = '' },
+    }
+
+    local old_system = vim.system
+    local calls = {}
+    vim.system = function(cmd, _, cb)
+      calls[#calls + 1] = { cmd = cmd, cb = cb }
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.pr('all', fake_forge())
+    captured.stream(function() end)
+
+    action_by_name('merge').fn(captured.entries[1])
+
+    assert.equals(
+      'MERGED',
+      vim.tbl_filter(function(pr)
+        return pr.number == 42
+      end, cache['pr:all'])[1].state
+    )
+    assert.is_nil(cache['pr:open'])
+    assert.is_nil(cache['pr:closed'])
+    assert.equals('42', captured.entries[1].value.num)
+    local labels = helpers.action_labels(captured.actions, captured.entries[1])
+    assert.is_nil(labels.approve)
+    assert.is_nil(labels.merge)
+    assert.is_nil(labels.toggle)
+    assert.is_nil(labels.draft)
+    assert.equals(1, picker_pick_calls)
+    assert.equals(1, picker_refresh_calls)
+    assert.same({
+      {
+        name = 'pr_merge',
+        pr = { num = '42', scope = nil, state = 'OPEN', is_draft = nil },
+        method = nil,
+      },
+    }, op_calls)
+    assert.same({ 'prs', 'all' }, calls[1].cmd)
+
+    calls[1].cb({
+      code = 0,
+      stdout = vim.json.encode({
+        {
+          number = 42,
+          title = 'Authoritative merge',
+          state = 'MERGED',
+          author = 'alice',
+          created_at = '',
+        },
+        {
+          number = 41,
+          title = 'Already merged',
+          state = 'MERGED',
+          author = 'drew',
+          created_at = '',
+        },
+        { number = 40, title = 'Old closed', state = 'CLOSED', author = 'bob', created_at = '' },
+      }),
+    })
+
+    vim.wait(100, function()
+      return cache['pr:all'][1].title == 'Authoritative merge'
+    end)
+    vim.system = old_system
+
+    assert.equals('Authoritative merge', cache['pr:all'][1].title)
+    assert.equals(2, picker_refresh_calls)
+  end)
+
   it('patches PR caches locally and revalidates the live PR picker after close succeeds', function()
     cache['pr:open'] = {
       { number = 42, title = 'Fix api drift', state = 'OPEN', author = 'alice', created_at = '' },


### PR DESCRIPTION
## Problem

Successful PR merges still cleared caches and reopened the picker, which threw away local picker context even when the current view could be updated safely first.

## Solution

Apply the safe local merge effect to the active PR view, invalidate sibling PR shards instead of synthesizing their placement, and then revalidate the active list in place. Add focused picker coverage for both `prs.open` and `prs.all` merge behavior.