### PR TITLE
fix(picker): preserve request failure details

### DIFF
--- a/lua/forge/picker/session.lua
+++ b/lua/forge/picker/session.lua
@@ -2,6 +2,51 @@ local M = {}
 
 local state = {}
 
+---@param text any
+---@return string?
+local function trim(text)
+  if type(text) ~= 'string' then
+    return nil
+  end
+  local value = vim.trim(text)
+  if value == '' then
+    return nil
+  end
+  return value
+end
+
+---@param value any
+---@return string?
+local function stringify(value)
+  if value == nil then
+    return nil
+  end
+  return trim(tostring(value))
+end
+
+---@param result forge.SystemResult
+---@return forge.PickerSessionFailure
+local function command_failure(result)
+  return {
+    kind = 'command',
+    result = result,
+    message = trim(result.stderr) or trim(result.stdout),
+  }
+end
+
+---@param result forge.SystemResult
+---@param decode_error any
+---@return forge.PickerSessionFailure
+local function decode_failure(result, decode_error)
+  local decode_message = stringify(decode_error)
+  return {
+    kind = 'decode',
+    result = result,
+    message = trim(result.stderr) or decode_message or trim(result.stdout),
+    decode_error = decode_message,
+  }
+end
+
 local function scope(key)
   local item = state[key]
   if not item then
@@ -31,11 +76,11 @@ local function request_json(key, cmd, callback)
     vim.schedule(function()
       M.finish(key, token)
       if not M.current(key, token) then
-        callback(false, nil, result, true)
+        callback(false, nil, nil, true)
         return
       end
-      local ok, data = M.decode_json(result)
-      callback(ok, data, result, false)
+      local ok, data, failure = M.decode_json(result)
+      callback(ok, data, failure, false)
     end)
   end)
 end
@@ -71,11 +116,22 @@ function M.inflight(key)
 end
 
 function M.decode_json(result)
+  if result.code ~= 0 then
+    return false, nil, command_failure(result)
+  end
   local ok, data = pcall(vim.json.decode, result.stdout or '[]')
-  if result.code == 0 and ok and data then
+  if ok then
     return true, data
   end
-  return false, nil
+  return false, nil, decode_failure(result, data)
+end
+
+---@param failure forge.PickerSessionFailure?
+---@param fallback string
+---@return string
+function M.failure_message(failure, fallback)
+  local message = type(failure) == 'table' and trim(failure.message) or nil
+  return message or fallback
 end
 
 function M.prefetch_json(opts)

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -82,6 +82,20 @@ local function placeholder_entry(text, kind)
   }
 end
 
+---@param failure forge.PickerSessionFailure?
+---@param fallback string
+---@return string
+local function picker_failure_text(failure, fallback)
+  return picker_session.failure_message(failure, fallback)
+end
+
+---@param failure forge.PickerSessionFailure?
+---@param fallback string
+---@return forge.PickerEntry
+local function picker_failure_entry(failure, fallback)
+  return placeholder_entry(picker_failure_text(failure, fallback), 'error')
+end
+
 ---@param next_limit integer
 ---@param keep_open boolean?
 ---@return forge.PickerEntry
@@ -562,11 +576,16 @@ function M.checks(f, num, filter, cached_checks, opts)
         return entries
       end,
       open = open_picker,
-      on_failure = function()
-        log.info('no checks found')
+      on_failure = function(failure)
+        log.error(
+          picker_failure_text(
+            failure,
+            ('failed to fetch checks for %s #%s'):format(f.labels.pr_one, num)
+          )
+        )
       end,
-      error_entry = function()
-        return placeholder_entry(('No checks for #%s'):format(num))
+      error_entry = function(failure)
+        return picker_failure_entry(failure, ('Failed to fetch checks for #%s'):format(num))
       end,
     })
   else
@@ -695,14 +714,14 @@ function M.ci(f, branch, filter, opts)
     picker_session.request_json(
       request_key,
       f:list_runs_json_cmd(branch, ref, current_limit + 1),
-      function(ok, runs, _, stale)
+      function(ok, runs, failure, stale)
         if stale then
           emit(nil)
           return
         end
         if not ok then
-          log.error('failed to fetch ' .. ci_inline_label(f))
-          emit(placeholder_entry('Failed to fetch ' .. ci_inline_label(f)))
+          log.error(picker_failure_text(failure, 'failed to fetch ' .. ci_inline_label(f)))
+          emit(picker_failure_entry(failure, 'Failed to fetch ' .. ci_inline_label(f)))
           emit(nil)
           return
         end
@@ -726,12 +745,12 @@ function M.ci(f, branch, filter, opts)
     picker_session.request_json(
       request_key,
       f:list_runs_json_cmd(branch, ref, current_limit + 1),
-      function(ok, runs, _, stale)
+      function(ok, runs, failure, stale)
         if stale then
           return
         end
         if not ok then
-          log.error('failed to fetch ' .. ci_inline_label(f))
+          log.error(picker_failure_text(failure, 'failed to fetch ' .. ci_inline_label(f)))
           return
         end
         current_runs = normalize_ci_runs(runs)
@@ -1013,14 +1032,14 @@ function M.pr(state, f, opts)
     picker_session.request_json(
       cache_key,
       f:list_pr_json_cmd(state, current_limit + 1, ref),
-      function(ok, prs, _, stale)
+      function(ok, prs, failure, stale)
         if stale then
           emit(nil)
           return
         end
         if not ok then
-          log.error('failed to fetch ' .. f.labels.pr)
-          emit(placeholder_entry('Failed to fetch ' .. f.labels.pr, 'error'))
+          log.error(picker_failure_text(failure, 'failed to fetch ' .. f.labels.pr))
+          emit(picker_failure_entry(failure, 'Failed to fetch ' .. f.labels.pr))
           emit(nil)
           return
         end
@@ -1140,12 +1159,12 @@ function M.pr(state, f, opts)
     picker_session.request_json(
       cache_key,
       f:list_pr_json_cmd(state, current_limit + 1, ref),
-      function(ok, prs, _, stale)
+      function(ok, prs, failure, stale)
         if stale then
           return
         end
         if not ok then
-          log.error('failed to fetch ' .. f.labels.pr)
+          log.error(picker_failure_text(failure, 'failed to fetch ' .. f.labels.pr))
           return
         end
         current_prs = prs
@@ -1586,14 +1605,14 @@ function M.issue(state, f, opts)
     picker_session.request_json(
       cache_key,
       f:list_issue_json_cmd(state, current_limit + 1, ref),
-      function(ok, issues, _, stale)
+      function(ok, issues, failure, stale)
         if stale then
           emit(nil)
           return
         end
         if not ok then
-          log.error('failed to fetch issues')
-          emit(placeholder_entry('Failed to fetch issues'))
+          log.error(picker_failure_text(failure, 'failed to fetch issues'))
+          emit(picker_failure_entry(failure, 'Failed to fetch issues'))
           emit(nil)
           return
         end
@@ -1677,12 +1696,12 @@ function M.issue(state, f, opts)
     picker_session.request_json(
       cache_key,
       f:list_issue_json_cmd(state, current_limit + 1, ref),
-      function(ok, issues, _, stale)
+      function(ok, issues, failure, stale)
         if stale then
           return
         end
         if not ok then
-          log.error('failed to fetch issues')
+          log.error(picker_failure_text(failure, 'failed to fetch issues'))
           return
         end
         current_issues = issues
@@ -2019,14 +2038,14 @@ function M.release(state, f, opts)
     picker_session.request_json(
       cache_key,
       f:list_releases_json_cmd(ref, requested),
-      function(ok, releases, _, stale)
+      function(ok, releases, failure, stale)
         if stale then
           emit(nil)
           return
         end
         if not ok then
-          log.error('failed to fetch releases')
-          emit(placeholder_entry('Failed to fetch releases'))
+          log.error(picker_failure_text(failure, 'failed to fetch releases'))
+          emit(picker_failure_entry(failure, 'Failed to fetch releases'))
           emit(nil)
           return
         end
@@ -2050,12 +2069,12 @@ function M.release(state, f, opts)
     picker_session.request_json(
       cache_key,
       f:list_releases_json_cmd(ref, requested),
-      function(ok, releases, _, stale)
+      function(ok, releases, failure, stale)
         if stale then
           return
         end
         if not ok then
-          log.error('failed to fetch releases')
+          log.error(picker_failure_text(failure, 'failed to fetch releases'))
           return
         end
         current_releases = remember_release_fetch(releases, requested)

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -143,6 +143,14 @@
 ---@field stdout string?
 ---@field stderr string?
 
+---@alias forge.PickerSessionFailureKind 'command'|'decode'
+
+---@class forge.PickerSessionFailure
+---@field kind forge.PickerSessionFailureKind
+---@field result forge.SystemResult
+---@field message string?
+---@field decode_error string?
+
 ---@class forge.CommandSubjectSpec
 ---@field kind string?
 ---@field min integer?

--- a/spec/picker_session_spec.lua
+++ b/spec/picker_session_spec.lua
@@ -57,31 +57,51 @@ describe('picker session', function()
 
   it('decodes successful json results', function()
     local session = require('forge.picker.session')
-    local ok, data = session.decode_json({
+    local ok, data, failure = session.decode_json({
       code = 0,
       stdout = '[{"id":1}]',
     })
 
     assert.is_true(ok)
     assert.same({ { id = 1 } }, data)
+    assert.is_nil(failure)
   end)
 
-  it('rejects failed or invalid json results', function()
+  it('returns command failure details for failed json results', function()
     local session = require('forge.picker.session')
 
-    local ok_failed, data_failed = session.decode_json({
+    local ok_failed, data_failed, failure_failed = session.decode_json({
       code = 1,
       stdout = '[{"id":1}]',
-    })
-    local ok_invalid, data_invalid = session.decode_json({
-      code = 0,
-      stdout = '{',
+      stderr = 'boom',
     })
 
     assert.is_false(ok_failed)
     assert.is_nil(data_failed)
+    assert.same('command', failure_failed.kind)
+    assert.equals('boom', failure_failed.message)
+    assert.same({
+      code = 1,
+      stdout = '[{"id":1}]',
+      stderr = 'boom',
+    }, failure_failed.result)
+  end)
+
+  it('returns decode failure details for invalid json results', function()
+    local session = require('forge.picker.session')
+
+    local ok_invalid, data_invalid, failure_invalid = session.decode_json({
+      code = 0,
+      stdout = '{',
+    })
+
     assert.is_false(ok_invalid)
     assert.is_nil(data_invalid)
+    assert.same('decode', failure_invalid.kind)
+    assert.equals(failure_invalid.decode_error, failure_invalid.message)
+    assert.is_true(
+      type(failure_invalid.decode_error) == 'string' and failure_invalid.decode_error ~= ''
+    )
   end)
 
   it('prefetches json and forwards successful data once', function()
@@ -112,6 +132,31 @@ describe('picker session', function()
     assert.same({ { number = 42 } }, success)
     assert.equals(0, failures)
     assert.is_false(session.inflight('prs.open'))
+  end)
+
+  it('forwards structured failures through request_json', function()
+    local session = require('forge.picker.session')
+    local captured_failure
+    local stale_state
+
+    session.request_json('prs.open', { 'prs', 'open' }, function(ok, data, failure, stale)
+      assert.is_false(ok)
+      assert.is_nil(data)
+      captured_failure = failure
+      stale_state = stale
+    end)
+
+    captured.callbacks[1]({
+      code = 0,
+      stdout = '{',
+      stderr = '',
+    })
+
+    assert.is_false(stale_state)
+    assert.same('decode', captured_failure.kind)
+    assert.is_true(
+      type(captured_failure.decode_error) == 'string' and captured_failure.decode_error ~= ''
+    )
   end)
 
   it('skips prefetch when skip_if passes or the key is already inflight', function()
@@ -167,6 +212,28 @@ describe('picker session', function()
     assert.equals(0, success)
     assert.equals(0, failure)
     assert.is_false(session.inflight('prs.open'))
+  end)
+
+  it('forwards structured failures to prefetch failure handlers', function()
+    local session = require('forge.picker.session')
+    local failure
+
+    assert.is_true(session.prefetch_json({
+      key = 'prs.open',
+      cmd = { 'prs', 'open' },
+      on_failure = function(err)
+        failure = err
+      end,
+    }))
+
+    captured.callbacks[1]({
+      code = 1,
+      stdout = '',
+      stderr = 'boom',
+    })
+
+    assert.same('command', failure.kind)
+    assert.equals('boom', failure.message)
   end)
 
   it('opens cached data immediately without requesting json', function()
@@ -254,8 +321,8 @@ describe('picker session', function()
       build_entries = function()
         return {}
       end,
-      error_entry = function(result)
-        return { display = { { result.stderr } }, value = false }
+      error_entry = function(failure)
+        return { display = { { session.failure_message(failure, 'fallback') } }, value = false }
       end,
       open = function() end,
     })

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -892,6 +892,8 @@ describe('pickers', function()
     vim.schedule = old_schedule
 
     assert.equals('error', streamed[1].placeholder_kind)
+    assert.equals('boom', streamed[1].display[1][1])
+    assert.same({ 'boom' }, logger_messages.error)
     local labels = helpers.action_labels(captured.actions, streamed[1])
     assert.is_nil(labels.default)
     assert.is_nil(labels.ci)
@@ -903,6 +905,46 @@ describe('pickers', function()
     assert.equals('create', labels.create)
     assert.is_nil(labels.filter)
     assert.equals('refresh', labels.refresh)
+  end)
+
+  it('shows PR decode failures in the picker instead of a generic fetch error', function()
+    cache['pr:open'] = nil
+
+    local old_system = vim.system
+    local old_schedule = vim.schedule
+    vim.schedule = function(fn)
+      fn()
+    end
+    vim.system = function(_, _, cb)
+      if cb then
+        cb({ code = 0, stdout = '{', stderr = '' })
+      end
+      return {
+        wait = function()
+          return { code = 0, stdout = '{', stderr = '' }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.pr('open', fake_forge())
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+    vim.system = old_system
+    vim.schedule = old_schedule
+
+    assert.equals('error', streamed[1].placeholder_kind)
+    assert.equals(logger_messages.error[1], streamed[1].display[1][1])
+    assert.not_equals('failed to fetch PRs', logger_messages.error[1])
   end)
 
   it('opens the PR picker immediately on fzf before the fetch completes', function()
@@ -2817,6 +2859,45 @@ describe('pickers', function()
     pickers.checks({ labels = { pr_one = 'PR' } }, '42', 'all')
 
     assert.same({ 'structured checks not available for this forge' }, logger_messages.warn)
+  end)
+
+  it('shows real checks fetch failures instead of no-checks placeholders', function()
+    local old_system = vim.system
+    local old_schedule = vim.schedule
+    vim.schedule = function(fn)
+      fn()
+    end
+    vim.system = function(_, _, cb)
+      if cb then
+        cb({ code = 1, stdout = '', stderr = 'boom' })
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '', stderr = 'boom' }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.checks(fake_ci_forge(), '42', 'all')
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+    vim.system = old_system
+    vim.schedule = old_schedule
+
+    assert.equals('error', streamed[1].placeholder_kind)
+    assert.equals('boom', streamed[1].display[1][1])
+    assert.same({ 'fetching checks for PR #42...' }, logger_messages.info)
+    assert.same({ 'boom' }, logger_messages.error)
   end)
 
   it('warns when structured CI data is unavailable for a forge', function()


### PR DESCRIPTION
## Problem

`forge.picker.session` was collapsing command and decode failures before pickers could surface the real error. That left every picker-session caller stuck with generic fetch failures, and checks fetch errors in particular were still being treated like empty results.

Closes #431.
Closes #432.

## Solution

Carry structured failure details through `decode_json`, `request_json`, `prefetch_json`, and `pick_json`, add a shared message helper for picker callers, and update every picker-session caller to log and render the preserved failure detail. Add session and picker specs covering command failures, decode failures, and checks fetch failures.