### PR TITLE
fix(create): stop hiding base-branch resolution failures

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -698,8 +698,11 @@ function M.create_pr(opts)
     log.info('resolving base branch...')
     vim.system(f:default_branch_cmd(base_scope), { text = true }, function(base_result)
       local base = vim.trim(base_result.stdout or '')
-      if base == '' then
-        base = 'main'
+      if base_result.code ~= 0 or base == '' then
+        vim.schedule(function()
+          log.error(cmd_error(base_result, 'failed to resolve base branch'))
+        end)
+        return
       end
       vim.schedule(function()
         cb(base)

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -498,6 +498,41 @@ describe('create_pr', function()
     assert.is_false(vim.tbl_contains(captured.systems, 'create-pr-web'))
   end)
 
+  it('reports base-branch resolution failures before opening PR compose', function()
+    use_system_responses({
+      ['pr-for-branch feature'] = helpers.command_result('\n'),
+      ['default-branch'] = helpers.command_result('', 1, 'base failed'),
+    })
+
+    require('forge').create_pr()
+
+    vim.wait(100, function()
+      return #captured.errors > 0
+    end)
+
+    assert.same({ 'base failed' }, captured.errors)
+    assert.is_nil(captured.opened_calls)
+    assert.is_false(vim.tbl_contains(captured.systems, 'git diff --quiet origin/main..HEAD'))
+  end)
+
+  it('reports blank base-branch resolution output for web PR creation and does not push', function()
+    use_system_responses({
+      ['pr-for-branch feature'] = helpers.command_result('\n'),
+      ['default-branch'] = helpers.command_result('\n'),
+    })
+
+    require('forge').create_pr({ web = true })
+
+    vim.wait(100, function()
+      return #captured.errors > 0
+    end)
+
+    assert.same({ 'failed to resolve base branch' }, captured.errors)
+    assert.is_false(vim.tbl_contains(captured.systems, 'git diff --quiet origin/main..HEAD'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'create-pr-web'))
+  end)
+
   it('pushes and opens the web flow only when the branch is creatable', function()
     require('forge').create_pr({ web = true })
 


### PR DESCRIPTION
## Problem

create_pr was silently falling back to main when base-branch resolution failed or returned blank output. That hid the underlying error and could send later PR creation flows down the wrong base branch.

Closes #433.

## Solution

Treat default-branch resolution failures as real errors. If the command fails or returns unusable output, preserve the real stderr/stdout detail when available, log the failure, and stop before diff checks, compose, push, or web create continue. Add focused create_pr specs for both normal and web flows.