### PR TITLE
refactor: centralize command error extraction

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -9,6 +9,7 @@ local format_mod = require('forge.format')
 local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
 local scope_mod = require('forge.scope')
+local system_mod = require('forge.system')
 local target_mod = require('forge.target')
 local template_mod = require('forge.template')
 
@@ -81,17 +82,6 @@ local function pr_state_key(num, scope)
   return root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
 end
 
-local function cmd_error(result, fallback)
-  local msg = vim.trim(result.stderr or '')
-  if msg == '' then
-    msg = vim.trim(result.stdout or '')
-  end
-  if msg == '' then
-    msg = fallback
-  end
-  return msg
-end
-
 local function push_target(branch, scope)
   if scope_mod.key(scope) ~= '' then
     return scope_mod.remote_name(scope) or scope_mod.git_url(scope) or ''
@@ -126,7 +116,7 @@ local function open_web_create(label, cmd, url)
         if result.code == 0 then
           log.info(success_msg)
         else
-          log.error(cmd_error(result, fail_msg))
+          log.error(system_mod.cmd_error(result, fail_msg))
         end
       end)
     end)
@@ -700,7 +690,7 @@ function M.create_pr(opts)
       local base = vim.trim(base_result.stdout or '')
       if base_result.code ~= 0 or base == '' then
         vim.schedule(function()
-          log.error(cmd_error(base_result, 'failed to resolve base branch'))
+          log.error(system_mod.cmd_error(base_result, 'failed to resolve base branch'))
         end)
         return
       end

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -2,24 +2,13 @@ local M = {}
 
 local ci = require('forge.ci')
 local log = require('forge.logger')
+local system_mod = require('forge.system')
 
 local function trim(text)
   if type(text) ~= 'string' then
     return ''
   end
   return vim.trim(text)
-end
-
-local function cmd_error(result, fallback)
-  local msg = result.stderr or ''
-  if vim.trim(msg) == '' then
-    msg = result.stdout or ''
-  end
-  msg = vim.trim(msg)
-  if msg == '' then
-    msg = fallback
-  end
-  return msg
 end
 
 local function run_forge_cmd(kind, id, label, cmd, success_msg, fail_msg, opts)
@@ -33,7 +22,7 @@ local function run_forge_cmd(kind, id, label, cmd, success_msg, fail_msg, opts)
           opts.on_success()
         end
       else
-        log.error(cmd_error(result, fail_msg))
+        log.error(system_mod.cmd_error(result, fail_msg))
         if opts.on_failure then
           opts.on_failure()
         end
@@ -74,7 +63,7 @@ local function load_details(cmd, fetch_err, parse_err, parse, open)
   vim.system(cmd, { text = true }, function(result)
     if result.code ~= 0 then
       vim.schedule(function()
-        log.error(cmd_error(result, fetch_err))
+        log.error(system_mod.cmd_error(result, fetch_err))
       end)
       return
     end

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local scope_mod = require('forge.scope')
+local system_mod = require('forge.system')
 local target_mod = require('forge.target')
 
 ---@param text any
@@ -24,17 +25,6 @@ local function error_result(message, code)
     code = code,
     message = message,
   }
-end
-
----@param result forge.SystemResult
----@param fallback string
----@return string
-local function cmd_error(result, fallback)
-  local msg = trim(result.stderr)
-  if not msg then
-    msg = trim(result.stdout)
-  end
-  return msg or fallback
 end
 
 ---@param opts forge.CurrentPROpts?
@@ -143,7 +133,10 @@ local function fetch_pr_json(forge, num, scope)
   local result = vim.system(forge:fetch_pr_details_cmd(num, scope), { text = true }):wait()
   if result.code ~= 0 then
     return nil,
-      cmd_error(result, ('failed to fetch %s #%s'):format(forge.labels.pr_one or 'PR', num))
+      system_mod.cmd_error(
+        result,
+        ('failed to fetch %s #%s'):format(forge.labels.pr_one or 'PR', num)
+      )
   end
   local ok, json = pcall(vim.json.decode, result.stdout or '{}')
   if not ok or type(json) ~= 'table' then
@@ -159,7 +152,8 @@ end
 local function list_pr_numbers(forge, branch, scope)
   local result = vim.system(forge:pr_for_branch_cmd(branch, scope), { text = true }):wait()
   if result.code ~= 0 then
-    return nil, cmd_error(result, ('failed to fetch %s'):format(forge.labels.pr or 'PRs'))
+    return nil,
+      system_mod.cmd_error(result, ('failed to fetch %s'):format(forge.labels.pr or 'PRs'))
   end
   local nums = {}
   local seen = {}

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local log = require('forge.logger')
+local system_mod = require('forge.system')
 
 ---@type table<string, forge.ReviewAdapter>
 local adapters = {}
@@ -33,17 +34,6 @@ local function trim(text)
     return ''
   end
   return vim.trim(text)
-end
-
-local function cmd_error(result, fallback)
-  local msg = trim(result.stderr or '')
-  if msg == '' then
-    msg = trim(result.stdout or '')
-  end
-  if msg == '' then
-    msg = fallback
-  end
-  return msg
 end
 
 local function normalize_pr_ref(pr)
@@ -166,7 +156,7 @@ local function builtins()
             if result.code == 0 then
               log.info(('checked out %s #%s'):format(kind, pr.num))
             else
-              log.error(cmd_error(result, 'checkout failed'))
+              log.error(system_mod.cmd_error(result, 'checkout failed'))
             end
           end)
         end)
@@ -189,7 +179,7 @@ local function builtins()
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
-              log.error(cmd_error(result, 'review fetch failed'))
+              log.error(system_mod.cmd_error(result, 'review fetch failed'))
               return
             end
             vim.system(
@@ -200,7 +190,7 @@ local function builtins()
                   if worktree_result.code == 0 then
                     log.info(('worktree at %s'):format(wt_path))
                   else
-                    log.error(cmd_error(worktree_result, 'worktree failed'))
+                    log.error(system_mod.cmd_error(worktree_result, 'worktree failed'))
                   end
                 end)
               end
@@ -245,7 +235,7 @@ local function builtins()
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
-              log.error(cmd_error(result, 'review fetch failed'))
+              log.error(system_mod.cmd_error(result, 'review fetch failed'))
               return
             end
             local ok, open_err = open_diffview(base .. '...' .. head)
@@ -284,7 +274,7 @@ local function builtins()
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
-              log.error(cmd_error(result, 'review fetch failed'))
+              log.error(system_mod.cmd_error(result, 'review fetch failed'))
               return
             end
             local ok, open_err = open_codediff(base .. '...' .. head)
@@ -323,7 +313,7 @@ local function builtins()
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
-              log.error(cmd_error(result, 'review fetch failed'))
+              log.error(system_mod.cmd_error(result, 'review fetch failed'))
               return
             end
             local ok, open_err = open_diffs(base .. '...' .. head)
@@ -401,7 +391,7 @@ function M.context(f, pr, opts)
     end
     local result = vim.system(f:fetch_pr_details_cmd(pr.num, pr.scope), { text = true }):wait()
     if result.code ~= 0 then
-      err = cmd_error(result, 'failed to load review details')
+      err = system_mod.cmd_error(result, 'failed to load review details')
       return nil, err
     end
     local ok, json = pcall(vim.json.decode, result.stdout or '{}')

--- a/lua/forge/system.lua
+++ b/lua/forge/system.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+---@param text any
+---@return string?
+local function trim(text)
+  if type(text) ~= 'string' then
+    return nil
+  end
+  local value = vim.trim(text)
+  if value == '' then
+    return nil
+  end
+  return value
+end
+
+---@param result forge.SystemResult
+---@param fallback string
+---@return string
+function M.cmd_error(result, fallback)
+  return trim(result.stderr) or trim(result.stdout) or fallback
+end
+
+return M

--- a/spec/system_spec.lua
+++ b/spec/system_spec.lua
@@ -1,0 +1,42 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('system helpers', function()
+  it('prefers stderr over stdout when extracting command errors', function()
+    local system_mod = require('forge.system')
+
+    assert.equals(
+      'stderr',
+      system_mod.cmd_error({
+        code = 1,
+        stderr = '  stderr  ',
+        stdout = 'stdout',
+      }, 'fallback')
+    )
+  end)
+
+  it('falls back to stdout when stderr is blank', function()
+    local system_mod = require('forge.system')
+
+    assert.equals(
+      'stdout',
+      system_mod.cmd_error({
+        code = 1,
+        stderr = '   ',
+        stdout = '  stdout  ',
+      }, 'fallback')
+    )
+  end)
+
+  it('falls back to the provided message when both streams are blank', function()
+    local system_mod = require('forge.system')
+
+    assert.equals(
+      'fallback',
+      system_mod.cmd_error({
+        code = 1,
+        stderr = '',
+        stdout = '',
+      }, 'fallback')
+    )
+  end)
+end)


### PR DESCRIPTION
## Problem

Command error extraction had drift-prone local copies across init, ops, review, and resolve. That made stderr/stdout fallback handling easier to diverge and complicated follow-up work on error reporting.

Closes #435.

## Solution

Move command error extraction into one shared forge.system helper with a single stderr-first, stdout-second, fallback-last contract. Update the existing call sites to use it and add a focused helper spec that locks in the shared behavior.