### PR TITLE
test(logger): cover debug and file logging

### DIFF
--- a/spec/logger_spec.lua
+++ b/spec/logger_spec.lua
@@ -5,8 +5,19 @@ describe('logger', function()
   local old_schedule
   local old_in_fast_event
   local old_cmd
+  local old_forge
   local notified
   local scheduled
+
+  local function read_file(path)
+    local fd = io.open(path, 'r')
+    if not fd then
+      return nil
+    end
+    local content = fd:read('*a')
+    fd:close()
+    return content
+  end
 
   before_each(function()
     notified = {}
@@ -15,6 +26,7 @@ describe('logger', function()
     old_schedule = vim.schedule
     old_in_fast_event = vim.in_fast_event
     old_cmd = vim.cmd
+    old_forge = vim.g.forge
     vim.notify = function(msg, level)
       notified[#notified + 1] = { msg = msg, level = level }
     end
@@ -38,6 +50,7 @@ describe('logger', function()
     vim.schedule = old_schedule
     vim.in_fast_event = old_in_fast_event
     vim.cmd = old_cmd
+    vim.g.forge = old_forge
     package.loaded['forge.logger'] = nil
   end)
 
@@ -71,5 +84,67 @@ describe('logger', function()
       { redraw = true },
       { msg = '[forge]: slow', level = vim.log.levels.WARN },
     }, notified)
+  end)
+
+  it('notifies debug logs when forge.debug is true', function()
+    vim.g.forge = { debug = true }
+    vim.in_fast_event = function()
+      return false
+    end
+
+    require('forge.logger').debug('trace')
+
+    assert.equals(0, #scheduled)
+    assert.same({
+      { redraw = true },
+      { msg = '[forge]: trace', level = vim.log.levels.DEBUG },
+    }, notified)
+  end)
+
+  it('writes debug logs to a file without notifying when forge.debug is a path', function()
+    local path = vim.fn.tempname()
+    vim.g.forge = { debug = path }
+    vim.in_fast_event = function()
+      return false
+    end
+
+    require('forge.logger').debug('trace')
+
+    assert.same({}, notified)
+    local content = read_file(path)
+    os.remove(path)
+
+    assert.is_not_nil(content)
+    assert.is_not_nil(content:match('%[DEBUG%] trace\n?$'))
+  end)
+
+  it('writes info, warn, and error logs to a file while still notifying', function()
+    local path = vim.fn.tempname()
+    vim.g.forge = { debug = path }
+    vim.in_fast_event = function()
+      return false
+    end
+
+    local logger = require('forge.logger')
+    logger.info('info')
+    logger.warn('warn')
+    logger.error('error')
+
+    assert.same({
+      { redraw = true },
+      { msg = '[forge]: info', level = vim.log.levels.INFO },
+      { redraw = true },
+      { msg = '[forge]: warn', level = vim.log.levels.WARN },
+      { redraw = true },
+      { msg = '[forge]: error', level = vim.log.levels.ERROR },
+    }, notified)
+
+    local content = read_file(path)
+    os.remove(path)
+
+    assert.is_not_nil(content)
+    assert.is_not_nil(content:match('%[INFO%] info\n'))
+    assert.is_not_nil(content:match('%[WARN%] warn\n'))
+    assert.is_not_nil(content:match('%[ERROR%] error\n'))
   end)
 end)


### PR DESCRIPTION
## Problem

The logger specs only covered fast-event scheduling and immediate notify behavior. The remaining logger contract around debug notifications and file logging was still untested, which left issue #436 only partially covered.

Closes #436.

## Solution

Add focused logger specs for debug notify behavior, debug file logging without notify, and info/warn/error file logging while still notifying. The picker failure-path coverage from #438 is already on main, so this PR fills in the remaining logger-spec half of the issue.