### PR TITLE
fix(logger): demote routine progress chatter (#437)

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -110,7 +110,7 @@ local function open_web_create(label, cmd, url)
   local success_msg = ('opened %s creation in browser'):format(label)
   local fail_msg = ('failed to open %s creation in browser'):format(label)
   if cmd then
-    log.info(('opening %s creation in browser...'):format(label))
+    log.debug(('opening %s creation in browser...'):format(label))
     vim.system(cmd, { text = true }, function(result)
       vim.schedule(function()
         if result.code == 0 then
@@ -685,7 +685,7 @@ function M.create_pr(opts)
       cb(opts.base_branch)
       return
     end
-    log.info('resolving base branch...')
+    log.debug('resolving base branch...')
     vim.system(f:default_branch_cmd(base_scope), { text = true }, function(base_result)
       local base = vim.trim(base_result.stdout or '')
       if base_result.code ~= 0 or base == '' then
@@ -716,7 +716,7 @@ function M.create_pr(opts)
     cb(base, target_ref)
   end
 
-  log.info('checking for existing ' .. f.labels.pr_one .. '...')
+  log.debug('checking for existing ' .. f.labels.pr_one .. '...')
   local existing, err = resolve_mod.current_pr({
     forge = f,
     scope = base_scope,
@@ -740,7 +740,7 @@ function M.create_pr(opts)
   if opts.web then
     with_base(function(base)
       ensure_creatable(base, function()
-        log.info('pushing...')
+        log.debug('pushing...')
         vim.system(
           { 'git', 'push', '-u', push_to ~= '' and push_to or 'origin', branch },
           { text = true },

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -208,7 +208,7 @@ function M.pr_edit(pr, f)
   local ref = pr.scope or forge.current_scope(f.name)
   local current_branch = trim(vim.fn.system('git branch --show-current'))
 
-  log.info(('fetching %s #%s...'):format(f.labels.pr_one, pr.num))
+  log.debug(('fetching %s #%s...'):format(f.labels.pr_one, pr.num))
   load_details(
     f:fetch_pr_details_cmd(pr.num, ref),
     'failed to fetch ' .. f.labels.pr_one .. ' #' .. pr.num,
@@ -359,7 +359,7 @@ function M.issue_edit(issue, f)
   local forge = require('forge')
   local ref = issue.scope or forge.current_scope(f.name)
 
-  log.info(('fetching issue #%s...'):format(issue.num))
+  log.debug(('fetching issue #%s...'):format(issue.num))
   load_details(
     f:fetch_issue_details_cmd(issue.num, ref),
     'failed to fetch issue #' .. issue.num,
@@ -513,7 +513,7 @@ local function ci_log(f, run)
     })
     return
   end
-  log.info('fetching CI/CD logs...')
+  log.debug('fetching CI/CD logs...')
   require('forge.log').open(
     f:run_log_cmd(run.id, status == 'failure' or status == 'failed', run_ref),
     {

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -437,7 +437,7 @@ function M.checks(f, num, filter, cached_checks, opts)
       require('forge.term').open(f:live_tail_cmd(run_id, job_id, check_ref), { url = c.link })
       return
     end
-    log.info('fetching check logs...')
+    log.debug('fetching check logs...')
     local cmd = f:check_log_cmd(run_id, bucket == 'fail', job_id, check_ref)
     local steps_cmd = f.steps_cmd and f:steps_cmd(run_id, check_ref) or nil
     local status_cmd = f.run_status_cmd and f:run_status_cmd(run_id, check_ref) or nil
@@ -521,7 +521,7 @@ function M.checks(f, num, filter, cached_checks, opts)
       label = 'refresh',
       reload = false,
       fn = function()
-        log.info(('refreshing checks for %s #%s...'):format(f.labels.pr_one, num))
+        log.debug(('refreshing checks for %s #%s...'):format(f.labels.pr_one, num))
         M.checks(f, num, filter, nil, { back = opts.back, scope = ref })
       end,
     },
@@ -562,7 +562,7 @@ function M.checks(f, num, filter, cached_checks, opts)
         return f:checks_json_cmd(num, ref)
       end,
       on_fetch = function()
-        log.info(('fetching checks for %s #%s...'):format(f.labels.pr_one, num))
+        log.debug(('fetching checks for %s #%s...'):format(f.labels.pr_one, num))
       end,
       on_success = function(checks)
         current_checks = checks
@@ -710,7 +710,7 @@ function M.ci(f, branch, filter, opts)
       emit_cached(emit)
       return
     end
-    log.info('fetching ' .. ci_inline_label(f) .. '...')
+    log.debug('fetching ' .. ci_inline_label(f) .. '...')
     picker_session.request_json(
       request_key,
       f:list_runs_json_cmd(branch, ref, current_limit + 1),
@@ -907,7 +907,7 @@ function M.ci(f, branch, filter, opts)
       label = 'refresh',
       reload = false,
       fn = function()
-        log.info('refreshing ' .. ci_inline_label(f) .. '...')
+        log.debug('refreshing ' .. ci_inline_label(f) .. '...')
         runs_stale = true
         if refresh_picker(picker_handle) then
           return
@@ -1028,7 +1028,7 @@ function M.pr(state, f, opts)
       emit_cached_prs(emit)
       return
     end
-    log.info(('fetching %s list (%s)...'):format(f.labels.pr, state))
+    log.debug(('fetching %s list (%s)...'):format(f.labels.pr, state))
     picker_session.request_json(
       cache_key,
       f:list_pr_json_cmd(state, current_limit + 1, ref),
@@ -1601,7 +1601,7 @@ function M.issue(state, f, opts)
       emit_cached_issues(emit)
       return
     end
-    log.info('fetching issue list (' .. state .. ')...')
+    log.debug('fetching issue list (' .. state .. ')...')
     picker_session.request_json(
       cache_key,
       f:list_issue_json_cmd(state, current_limit + 1, ref),
@@ -2033,7 +2033,7 @@ function M.release(state, f, opts)
       emit_cached_releases(emit)
       return
     end
-    log.info('fetching releases...')
+    log.debug('fetching releases...')
     local requested = current_limit + 1
     picker_session.request_json(
       cache_key,

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -150,7 +150,7 @@ local function builtins()
         local f = ctx.forge
         local pr = ctx.pr
         local kind = f.labels.pr_one
-        log.info(('checking out %s #%s...'):format(kind, pr.num))
+        log.debug(('checking out %s #%s...'):format(kind, pr.num))
         vim.system(f:checkout_cmd(pr.num, pr.scope), { text = true }, function(result)
           vim.schedule(function()
             if result.code == 0 then
@@ -175,7 +175,7 @@ local function builtins()
         end
         local root = trim(vim.fn.system('git rev-parse --show-toplevel'))
         local wt_path = vim.fs.normalize(root .. '/../' .. branch)
-        log.info(('fetching %s #%s into worktree...'):format(kind, pr.num))
+        log.debug(('fetching %s #%s into worktree...'):format(kind, pr.num))
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
@@ -231,7 +231,7 @@ local function builtins()
           return
         end
         local kind = ctx.forge.labels.pr_one
-        log.info(('opening %s #%s in diffview...'):format(kind, ctx.pr.num))
+        log.debug(('opening %s #%s in diffview...'):format(kind, ctx.pr.num))
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
@@ -270,7 +270,7 @@ local function builtins()
           return
         end
         local kind = ctx.forge.labels.pr_one
-        log.info(('opening %s #%s in codediff...'):format(kind, ctx.pr.num))
+        log.debug(('opening %s #%s in codediff...'):format(kind, ctx.pr.num))
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then
@@ -309,7 +309,7 @@ local function builtins()
           return
         end
         local kind = ctx.forge.labels.pr_one
-        log.info(('opening %s #%s in diffs...'):format(kind, ctx.pr.num))
+        log.debug(('opening %s #%s in diffs...'):format(kind, ctx.pr.num))
         vim.system(fetch_cmd, { text = true }, function(result)
           vim.schedule(function()
             if result.code ~= 0 then

--- a/spec/create_issue_spec.lua
+++ b/spec/create_issue_spec.lua
@@ -297,6 +297,7 @@ describe('create_issue', function()
       return vim.tbl_contains(captured.infos, 'opened issue creation in browser')
     end)
 
+    assert.same({ 'opened issue creation in browser' }, captured.infos)
     assert.is_true(vim.tbl_contains(captured.systems, 'create-issue-web'))
   end)
 

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -542,7 +542,7 @@ describe('create_pr', function()
 
     assert.is_true(vim.tbl_contains(captured.systems, 'git push -u origin feature'))
     assert.is_true(vim.tbl_contains(captured.systems, 'create-pr-web'))
-    assert.is_true(vim.tbl_contains(captured.infos, 'opened PR creation in browser'))
+    assert.same({ 'opened PR creation in browser' }, captured.infos)
     assert.equals('feature', captured.web_create.head_branch)
     assert.equals('main', captured.web_create.base_branch)
   end)

--- a/spec/edit_issue_spec.lua
+++ b/spec/edit_issue_spec.lua
@@ -9,6 +9,7 @@ describe('edit_issue', function()
 
   before_each(function()
     captured = {
+      debugs = {},
       errors = {},
       infos = {},
       systems = {},
@@ -149,7 +150,9 @@ describe('edit_issue', function()
 
     package.preload['forge.logger'] = function()
       return {
-        debug = function() end,
+        debug = function(msg)
+          table.insert(captured.debugs, msg)
+        end,
         info = function(msg)
           table.insert(captured.infos, msg)
         end,
@@ -228,6 +231,7 @@ describe('edit_issue', function()
       },
       scope = nil,
     }, captured.opened)
-    assert.is_true(vim.tbl_contains(captured.infos, 'fetching issue #23...'))
+    assert.same({}, captured.infos)
+    assert.is_true(vim.tbl_contains(captured.debugs, 'fetching issue #23...'))
   end)
 end)

--- a/spec/edit_pr_spec.lua
+++ b/spec/edit_pr_spec.lua
@@ -9,6 +9,7 @@ describe('forge.pr explicit PR targeting', function()
 
   before_each(function()
     captured = {
+      debugs = {},
       errors = {},
       infos = {},
       systems = {},
@@ -168,7 +169,9 @@ describe('forge.pr explicit PR targeting', function()
 
     package.preload['forge.logger'] = function()
       return {
-        debug = function() end,
+        debug = function(msg)
+          table.insert(captured.debugs, msg)
+        end,
         info = function(msg)
           table.insert(captured.infos, msg)
         end,
@@ -252,7 +255,8 @@ describe('forge.pr explicit PR targeting', function()
       current_branch = 'other-local-branch',
       scope = nil,
     }, captured.opened)
-    assert.is_true(vim.tbl_contains(captured.infos, 'fetching PR #23...'))
+    assert.same({}, captured.infos)
+    assert.is_true(vim.tbl_contains(captured.debugs, 'fetching PR #23...'))
     assert.is_false(vim.tbl_contains(captured.systems, 'pr-base 23'))
   end)
 

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -2896,7 +2896,8 @@ describe('pickers', function()
 
     assert.equals('error', streamed[1].placeholder_kind)
     assert.equals('boom', streamed[1].display[1][1])
-    assert.same({ 'fetching checks for PR #42...' }, logger_messages.info)
+    assert.same({}, logger_messages.info)
+    assert.same({ 'fetching checks for PR #42...' }, logger_messages.debug)
     assert.same({ 'boom' }, logger_messages.error)
   end)
 

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -15,6 +15,7 @@ describe('review adapters', function()
     captured = {
       calls = {},
       cmds = {},
+      debugs = {},
       infos = {},
       errors = {},
     }
@@ -74,7 +75,9 @@ describe('review adapters', function()
           table.insert(captured.errors, msg)
         end,
         warn = function() end,
-        debug = function() end,
+        debug = function(msg)
+          table.insert(captured.debugs, msg)
+        end,
       }
     end
 
@@ -153,7 +156,8 @@ describe('review adapters', function()
         opts = {},
       },
     }, captured.cmds)
-    assert.same({ 'opening PR #42 in diffview...' }, captured.infos)
+    assert.same({ 'opening PR #42 in diffview...' }, captured.debugs)
+    assert.same({}, captured.infos)
     assert.same({}, captured.errors)
   end)
 
@@ -224,7 +228,8 @@ describe('review adapters', function()
         opts = {},
       },
     }, captured.cmds)
-    assert.same({ 'opening PR #42 in codediff...' }, captured.infos)
+    assert.same({ 'opening PR #42 in codediff...' }, captured.debugs)
+    assert.same({}, captured.infos)
     assert.same({}, captured.errors)
   end)
 
@@ -295,7 +300,8 @@ describe('review adapters', function()
         opts = {},
       },
     }, captured.cmds)
-    assert.same({ 'opening PR #42 in diffs...' }, captured.infos)
+    assert.same({ 'opening PR #42 in diffs...' }, captured.debugs)
+    assert.same({}, captured.infos)
     assert.same({}, captured.errors)
   end)
 
@@ -329,10 +335,8 @@ describe('review adapters', function()
       'git fetch origin pull/42/head:pr-42',
       'git worktree add /pr-42 pr-42',
     }, captured.calls)
-    assert.same({
-      'fetching PR #42 into worktree...',
-      'worktree at /pr-42',
-    }, captured.infos)
+    assert.same({ 'worktree at /pr-42' }, captured.infos)
+    assert.same({ 'fetching PR #42 into worktree...' }, captured.debugs)
     assert.same({}, captured.errors)
   end)
 
@@ -362,7 +366,8 @@ describe('review adapters', function()
     }, { num = '42', scope = scope }, { adapter = 'worktree' })
 
     assert.same({ 'git fetch origin pull/42/head:pr-42' }, captured.calls)
-    assert.same({ 'fetching PR #42 into worktree...' }, captured.infos)
+    assert.same({}, captured.infos)
+    assert.same({ 'fetching PR #42 into worktree...' }, captured.debugs)
     assert.same({ 'fetch failed' }, captured.errors)
   end)
 


### PR DESCRIPTION
## Problem

Routine progress notifications still surfaced as user-facing `info` messages in normal Forge flows. Closes #437. Closes #170.

## Solution

Demote fetch, refresh, open, and other preflight chatter in create, edit, review, CI, and picker paths to `debug`, while keeping success and failure notifications user-facing. Update the affected specs to assert the new logging contract.
