### PR TITLE
fix(format): let PR and issue rows fill picker width (#405)

### DIFF
--- a/lua/forge/format.lua
+++ b/lua/forge/format.lua
@@ -209,6 +209,7 @@ end
 local function pr_issue_rows(entries, fields, show_state, opts, icon_fn)
   local display = require('forge.config').config().display
   local icons = display.icons
+  local width = opts and opts.width or layout.picker_width()
   local numbers = {}
   local titles = {}
   local authors = {}
@@ -222,7 +223,7 @@ local function pr_issue_rows(entries, fields, show_state, opts, icon_fn)
   local title_pref, title_max = elastic_width(45, titles, 12)
   local author_pref, author_max = elastic_width(15, authors, 6)
   local plan = layout.plan({
-    width = opts and opts.width or layout.picker_width(),
+    width = width,
     columns = {
       { key = 'state', fixed = show_state and 1 or 0 },
       {
@@ -235,7 +236,7 @@ local function pr_issue_rows(entries, fields, show_state, opts, icon_fn)
         gap = ' ',
         min = 12,
         preferred = title_pref,
-        max = title_max,
+        max = math.max(title_max, width),
         shrink = 2,
         grow = 1,
         overflow = 'tail',

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -298,6 +298,32 @@ describe('format_prs', function()
     assert.equals(nil, title_text:find('...', 1, true))
     assert.truthy(title_text:find(long_title, 1, true))
   end)
+
+  it('pads PR rows to the full picker width in wide layouts', function()
+    local row = forge.format_prs({
+      { number = 1, title = 'short', state = 'OPEN', author = 'alice', created_at = '' },
+    }, fields, false, { width = 80 })[1]
+
+    assert.equals(80, require('forge.layout').display_width(flatten(row)))
+  end)
+end)
+
+describe('format_issues', function()
+  local fields = {
+    number = 'number',
+    title = 'title',
+    state = 'state',
+    author = 'author',
+    created_at = 'created_at',
+  }
+
+  it('pads issue rows to the full picker width in wide layouts', function()
+    local row = forge.format_issues({
+      { number = 10, title = 'bug report', state = 'open', author = 'alice', created_at = '' },
+    }, fields, false, { width = 80 })[1]
+
+    assert.equals(80, require('forge.layout').display_width(flatten(row)))
+  end)
 end)
 
 describe('format_issue', function()


### PR DESCRIPTION
## Problem

PR and issue picker rows stopped at their content width instead of occupying the full available picker width. Closes #405.

## Solution

Allow the shared PR/issue title column to grow to the requested picker width so wide layouts use the full row budget, and add regression coverage for full-width PR and issue rows.
