### PR TITLE
fix(codeberg): apply reviewers after PR create (#367)

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -302,6 +302,77 @@ end
 
 ---@param f forge.Forge
 ---@param branch string
+---@param metadata forge.CommentMetadata?
+---@return forge.CommentMetadata?, forge.CommentMetadata?
+local function created_pr_reviewer_follow_up(f, branch, metadata)
+  if branch == '' or type(f.update_pr_cmd) ~= 'function' then
+    return nil, nil
+  end
+  if submission.supports(f, 'pr', 'create', 'reviewers') then
+    return nil, nil
+  end
+  if not submission.supports(f, 'pr', 'update', 'reviewers') then
+    return nil, nil
+  end
+  local created = submission.filter(f, 'pr', 'create', metadata)
+  local desired = submission.filter(f, 'pr', 'update', metadata)
+  local add_reviewers, remove_reviewers = submission.diff(created.reviewers, desired.reviewers)
+  if #add_reviewers == 0 and #remove_reviewers == 0 then
+    return nil, nil
+  end
+  return desired, created
+end
+
+---@param f forge.Forge
+---@param branch string
+---@param ref forge.Scope?
+---@param head_scope forge.Scope?
+---@param title string
+---@param body string
+---@param metadata forge.CommentMetadata?
+---@param cb fun(err: string?)
+local function apply_created_pr_reviewers(f, branch, ref, head_scope, title, body, metadata, cb)
+  local desired, created = created_pr_reviewer_follow_up(f, branch, metadata)
+  if not desired or not created then
+    cb(nil)
+    return
+  end
+  local resolved, err = require('forge.resolve').current_pr({
+    forge = f,
+    scope = ref,
+    head_branch = branch,
+    head_scope = head_scope or ref,
+  })
+  if err then
+    cb(err.message)
+    return
+  end
+  if not resolved then
+    cb(('failed to resolve created %s reviewers'):format(f.labels.pr_one))
+    return
+  end
+  vim.system(
+    f:update_pr_cmd(resolved.num, title, body, ref, desired, created),
+    { text = true },
+    function(result)
+      vim.schedule(function()
+        if result.code ~= 0 then
+          cb(
+            require('forge.system').cmd_error(
+              result,
+              ('failed to update created %s'):format(f.labels.pr_one)
+            )
+          )
+          return
+        end
+        cb(nil)
+      end)
+    end
+  )
+end
+
+---@param f forge.Forge
+---@param branch string
 ---@param title string
 ---@param body string
 ---@param pr_base string
@@ -309,6 +380,8 @@ end
 ---@param buf integer?
 ---@param ref? forge.Scope
 ---@param push_target string?
+---@param metadata forge.CommentMetadata?
+---@param head_scope forge.Scope?
 local function push_and_create(
   f,
   branch,
@@ -319,7 +392,8 @@ local function push_and_create(
   buf,
   ref,
   push_target,
-  metadata
+  metadata,
+  head_scope
 )
   local log = require('forge.logger')
   log.info('pushing and creating ' .. f.labels.pr_one .. '...')
@@ -344,15 +418,29 @@ local function push_and_create(
           vim.schedule(function()
             if create_result.code == 0 then
               local url = vim.trim(create_result.stdout or '')
-              if url ~= '' then
-                set_clipboard(url)
-              end
-              log.info(('created %s -> %s'):format(f.labels.pr_one, url))
-              require('forge').clear_list()
-              if buf and vim.api.nvim_buf_is_valid(buf) then
-                vim.bo[buf].modified = false
-                close_compose_buf(buf)
-              end
+              apply_created_pr_reviewers(
+                f,
+                branch,
+                ref,
+                head_scope,
+                title,
+                body,
+                metadata,
+                function(err)
+                  if url ~= '' then
+                    set_clipboard(url)
+                  end
+                  log.info(('created %s -> %s'):format(f.labels.pr_one, url))
+                  if err then
+                    log.error(err)
+                  end
+                  require('forge').clear_list()
+                  if buf and vim.api.nvim_buf_is_valid(buf) then
+                    vim.bo[buf].modified = false
+                    close_compose_buf(buf)
+                  end
+                end
+              )
             else
               local msg = vim.trim(create_result.stderr or '')
               if msg == '' then
@@ -591,7 +679,8 @@ end
 ---@param push_target string?
 ---@param base_ref string?
 ---@param head_ref string?
-function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, head_ref)
+---@param head_scope forge.Scope?
+function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, head_ref, head_scope)
   local bufpath = resolve_bufpath(ref, f.name)
   if not bufpath then
     require('forge.logger').warn('cannot open compose buffer: no repo scope available')
@@ -711,7 +800,8 @@ function M.open_pr(f, branch, base, draft, tmpl, ref, push_target, base_ref, hea
         buf,
         ref,
         push_target,
-        submission_data.metadata
+        submission_data.metadata,
+        head_scope
       )
     end,
   })

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -778,7 +778,9 @@ function M.create_pr(opts)
           opts.draft or false,
           nil,
           base_scope,
-          push_to
+          push_to,
+          nil,
+          head_scope
         )
       else
         local root = git_root() or ''
@@ -797,7 +799,8 @@ function M.create_pr(opts)
           base_scope,
           push_to,
           target_ref,
-          head_ref
+          head_ref,
+          head_scope
         )
       end
     end)

--- a/spec/submission_integration_spec.lua
+++ b/spec/submission_integration_spec.lua
@@ -5,6 +5,7 @@ describe('submission integration', function()
   local old_fn_system
   local old_system
   local old_feedkeys
+  local old_schedule
   local old_preload
 
   before_each(function()
@@ -19,9 +20,11 @@ describe('submission integration', function()
     old_fn_system = vim.fn.system
     old_system = vim.system
     old_feedkeys = vim.api.nvim_feedkeys
+    old_schedule = vim.schedule
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.resolve'] = package.preload['forge.resolve'],
       ['forge.template'] = package.preload['forge.template'],
     }
 
@@ -33,6 +36,9 @@ describe('submission integration', function()
     end
 
     vim.api.nvim_feedkeys = function() end
+    vim.schedule = function(fn)
+      fn()
+    end
 
     vim.system = function(cmd, _, cb)
       table.insert(captured.calls, cmd)
@@ -90,6 +96,15 @@ describe('submission integration', function()
       }
     end
 
+    package.preload['forge.resolve'] = function()
+      return {
+        current_pr = function(opts)
+          captured.current_pr_opts = opts
+          return { num = '24' }
+        end,
+      }
+    end
+
     package.preload['forge.template'] = function()
       return {
         normalize_body = function(s)
@@ -107,6 +122,7 @@ describe('submission integration', function()
     package.loaded['forge.backends.github'] = nil
     package.loaded['forge.backends.gitlab'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.resolve'] = nil
     package.loaded['forge.submission'] = nil
     package.loaded['forge.template'] = nil
   end)
@@ -115,9 +131,11 @@ describe('submission integration', function()
     vim.fn.system = old_fn_system
     vim.system = old_system
     vim.api.nvim_feedkeys = old_feedkeys
+    vim.schedule = old_schedule
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.resolve'] = old_preload['forge.resolve']
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
@@ -126,6 +144,7 @@ describe('submission integration', function()
     package.loaded['forge.backends.github'] = nil
     package.loaded['forge.backends.gitlab'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.resolve'] = nil
     package.loaded['forge.submission'] = nil
     package.loaded['forge.template'] = nil
 
@@ -283,5 +302,112 @@ describe('submission integration', function()
     assert.truthy(vim.tbl_contains(cmd, 'carol'))
     assert.truthy(vim.tbl_contains(cmd, '--milestone'))
     assert.falsy(vim.tbl_contains(cmd, '--add-assignees'))
+  end)
+
+  it('applies Codeberg PR reviewers after create when tea create cannot set them', function()
+    local compose = require('forge.compose')
+    local cb = require('forge.backends.codeberg')
+    local ref = {
+      kind = 'codeberg',
+      host = 'codeberg.org',
+      slug = 'forgejo/tea-test',
+      repo_arg = 'forgejo/tea-test',
+      web_url = 'https://codeberg.org/forgejo/tea-test',
+    }
+
+    vim.system = function(cmd, _, cb_fn)
+      table.insert(captured.calls, cmd)
+      local key = table.concat(cmd, ' ')
+      local result = {
+        code = 0,
+        stdout = '',
+        stderr = '',
+      }
+      if
+        key
+        == 'tea pr create --title created pr --description created body --base main --repo forgejo/tea-test --labels docs --assignees alice --milestone v1'
+      then
+        result.stdout = 'https://codeberg.org/forgejo/tea-test/pulls/24'
+      end
+      if cb_fn then
+        cb_fn(result)
+      end
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    compose.open_pr(
+      cb,
+      'topic',
+      'main',
+      false,
+      { body = 'body' },
+      ref,
+      'origin',
+      'origin/main',
+      'HEAD',
+      ref
+    )
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, {
+      '# created pr',
+      '',
+      'created body',
+      '',
+      '<!--',
+      '  Reviewers: carol',
+      '  Labels: docs',
+      '  Assignees: alice',
+      '  Milestone: v1',
+      '-->',
+    })
+    vim.cmd('write')
+
+    vim.wait(100, function()
+      return #captured.calls >= 3
+    end)
+
+    assert.same({ 'git', 'push', '-u', 'origin', 'topic' }, captured.calls[1])
+    assert.same({
+      'tea',
+      'pr',
+      'create',
+      '--title',
+      'created pr',
+      '--description',
+      'created body',
+      '--base',
+      'main',
+      '--repo',
+      'forgejo/tea-test',
+      '--labels',
+      'docs',
+      '--assignees',
+      'alice',
+      '--milestone',
+      'v1',
+    }, captured.calls[2])
+    assert.same({
+      forge = cb,
+      scope = ref,
+      head_branch = 'topic',
+      head_scope = ref,
+    }, captured.current_pr_opts)
+    assert.same({ 'tea', 'pr', 'edit', '24' }, vim.list_slice(captured.calls[3], 1, 4))
+    assert.truthy(vim.tbl_contains(captured.calls[3], '--add-reviewers'))
+    assert.truthy(vim.tbl_contains(captured.calls[3], 'carol'))
+    assert.falsy(vim.tbl_contains(captured.calls[3], '--add-labels'))
+    assert.falsy(vim.tbl_contains(captured.calls[3], '--add-assignees'))
+    assert.is_true(
+      vim.tbl_contains(
+        captured.infos,
+        'created PR -> https://codeberg.org/forgejo/tea-test/pulls/24'
+      )
+    )
+    assert.same({}, captured.errors)
   end)
 end)


### PR DESCRIPTION
## Problem

Codeberg PR creation can carry labels, assignees, and milestones, but `tea pr create` cannot set reviewers. That caused requested reviewers from Forge compose buffers to be dropped on create instead of being preserved.

## Solution

After a successful PR create, resolve the created PR from the explicit head branch and head scope, then apply reviewer diffs with the backend update command when the backend supports reviewer updates but not reviewer creation.

Part of #367.