### PR TITLE
cmd: let current-open-PR mutators omit {num}

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -452,8 +452,9 @@ PR COMMANDS                                                *forge-pr-commands*
                        refs.
 
 IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
-    `:Forge pr`, `:Forge review`, and `:Forge pr ci` resolve the current PR
-    from the current branch head when `{num}` is omitted.
+    `:Forge pr`, `:Forge review`, `:Forge pr ci`, and the omitted-subject
+    `:Forge pr approve`, `merge`, `close`, `draft`, and `ready` forms resolve
+    the current PR from the current branch head when `{num}` is omitted.
 
     Default lookup policy:
     - head = current branch push context
@@ -465,30 +466,70 @@ IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
     - no matches: warn `no open PR found for this branch`
     - multiple matches: warn and ask for `repo=` or `head=`
 
+`:Forge pr close` [repo=...] [head=...]                   *:Forge-pr-close*
+`:Forge pr close` {num} [repo=...]
+    Close a PR.
+    (no `{num}`)       Resolve the current PR from the current branch and close
+                       it.
+    `{num}`            Close PR `{num}` directly.
+    `repo=`            Scope the explicit `{num}` or disambiguate implicit
+                       current-PR lookup.
+    `head=`            Override the head used for implicit current-PR lookup.
+                       Only used when `{num}` is omitted.
+
 `:Forge pr edit` {num} [repo=...]                           *:Forge-pr-edit*
     Open the PR edit compose flow for PR `{num}`.
-
-`:Forge pr close` {num} [repo=...]                         *:Forge-pr-close*
-    Close PR `{num}`.
 
 `:Forge pr reopen` {num} [repo=...]                       *:Forge-pr-reopen*
     Reopen PR `{num}`.
 
-`:Forge pr approve` {num} [repo=...]                       *:Forge-pr-approve*
-    Approve PR `{num}`.
+`:Forge pr approve` [repo=...] [head=...]                 *:Forge-pr-approve*
+`:Forge pr approve` {num} [repo=...]
+    Approve a PR.
+    (no `{num}`)       Resolve the current PR from the current branch and
+                       approve it.
+    `{num}`            Approve PR `{num}` directly.
+    `repo=`            Scope the explicit `{num}` or disambiguate implicit
+                       current-PR lookup.
+    `head=`            Override the head used for implicit current-PR lookup.
+                       Only used when `{num}` is omitted.
 
-`:Forge pr merge` {num} [repo=...] [`method=`]               *:Forge-pr-merge*
-    Merge PR `{num}`. When `method=` is omitted, the forge CLI uses its
-    default merge behavior.
+`:Forge pr merge` [repo=...] [head=...] [`method=`]         *:Forge-pr-merge*
+`:Forge pr merge` {num} [repo=...] [`method=`]
+    Merge a PR. When `method=` is omitted, the forge CLI uses its default
+    merge behavior.
+    (no `{num}`)       Resolve the current PR from the current branch and
+                       merge it.
+    `{num}`            Merge PR `{num}` directly.
+    `repo=`            Scope the explicit `{num}` or disambiguate implicit
+                       current-PR lookup.
+    `head=`            Override the head used for implicit current-PR lookup.
+                       Only used when `{num}` is omitted.
     `method=merge`     Merge commit.
     `method=squash`    Squash merge.
     `method=rebase`    Rebase merge.
 
-`:Forge pr draft` {num} [repo=...]                           *:Forge-pr-draft*
-    Mark PR `{num}` as draft when the forge supports draft toggles.
+`:Forge pr draft` [repo=...] [head=...]                     *:Forge-pr-draft*
+`:Forge pr draft` {num} [repo=...]
+    Mark a PR as draft when the forge supports draft toggles.
+    (no `{num}`)       Resolve the current PR from the current branch and mark
+                       it as draft.
+    `{num}`            Mark PR `{num}` as draft directly.
+    `repo=`            Scope the explicit `{num}` or disambiguate implicit
+                       current-PR lookup.
+    `head=`            Override the head used for implicit current-PR lookup.
+                       Only used when `{num}` is omitted.
 
-`:Forge pr ready` {num} [repo=...]                           *:Forge-pr-ready*
-    Mark PR `{num}` as ready when supported by the forge.
+`:Forge pr ready` [repo=...] [head=...]                     *:Forge-pr-ready*
+`:Forge pr ready` {num} [repo=...]
+    Mark a PR as ready when supported by the forge.
+    (no `{num}`)       Resolve the current PR from the current branch and mark
+                       it as ready.
+    `{num}`            Mark PR `{num}` as ready directly.
+    `repo=`            Scope the explicit `{num}` or disambiguate implicit
+                       current-PR lookup.
+    `head=`            Override the head used for implicit current-PR lookup.
+                       Only used when `{num}` is omitted.
 
 `:Forge pr browse` [{num}] [repo=...]                       *:Forge-pr-browse*
     Open PR `{num}` in the browser, or the PR list landing page when

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -66,8 +66,8 @@ local families = {
         modifiers = { 'repo', 'head' },
       },
       close = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head' },
       },
       reopen = {
         subject = { kind = 'pr', min = 1, max = 1 },
@@ -82,20 +82,20 @@ local families = {
         modifiers = { 'repo' },
       },
       approve = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head' },
       },
       merge = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo', 'method' },
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head', 'method' },
       },
       draft = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head' },
       },
       ready = {
-        subject = { kind = 'pr', min = 1, max = 1 },
-        modifiers = { 'repo' },
+        subject = { kind = 'pr', min = 0, max = 1 },
+        modifiers = { 'repo', 'head' },
       },
       refresh = {
         subject = { min = 0, max = 0 },
@@ -501,33 +501,58 @@ local function dispatch_pr(command)
     require('forge.logger').info('refreshed ' .. ((f.labels and f.labels.pr) or 'pr') .. ' list')
     return
   end
-  local scope = resolve_repo_modifier(command, f.name)
+  local function action_pr()
+    if num then
+      return { num = num, scope = resolve_repo_modifier(command, f.name) }
+    end
+    return resolve_current_pr_or_warn(command, f)
+  end
   if command.name == 'edit' then
-    ops.pr_edit({ num = num, scope = scope })
+    ops.pr_edit({ num = num, scope = resolve_repo_modifier(command, f.name) })
     return
   end
   if command.name == 'approve' then
-    ops.pr_approve(f, { num = num, scope = scope })
+    local pr = action_pr()
+    if not pr then
+      return
+    end
+    ops.pr_approve(f, pr)
     return
   end
   if command.name == 'merge' then
-    ops.pr_merge(f, { num = num, scope = scope }, command.modifiers.method)
+    local pr = action_pr()
+    if not pr then
+      return
+    end
+    ops.pr_merge(f, pr, command.modifiers.method)
     return
   end
   if command.name == 'draft' then
-    ops.pr_toggle_draft(f, { num = num, scope = scope }, false)
+    local pr = action_pr()
+    if not pr then
+      return
+    end
+    ops.pr_toggle_draft(f, pr, false)
     return
   end
   if command.name == 'ready' then
-    ops.pr_toggle_draft(f, { num = num, scope = scope }, true)
+    local pr = action_pr()
+    if not pr then
+      return
+    end
+    ops.pr_toggle_draft(f, pr, true)
     return
   end
   if command.name == 'close' then
-    ops.pr_close(f, { num = num, scope = scope })
+    local pr = action_pr()
+    if not pr then
+      return
+    end
+    ops.pr_close(f, pr)
     return
   end
   if command.name == 'reopen' then
-    ops.pr_reopen(f, { num = num, scope = scope })
+    ops.pr_reopen(f, { num = num, scope = resolve_repo_modifier(command, f.name) })
     return
   end
   warn(('unsupported pr action: %s'):format(command.name))

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -261,6 +261,37 @@ describe('command schema', function()
     assert.equals('topic', pr_ci.parsed_modifiers.head.rev)
   end)
 
+  it(
+    'attaches implicit current-open-PR mutator disambiguation modifiers to normalized commands',
+    function()
+      local close = assert(cmd.parse({ 'pr', 'close', 'repo=upstream', 'head=origin@topic' }))
+      local approve = assert(cmd.parse({ 'pr', 'approve', 'repo=upstream', 'head=origin@topic' }))
+      local merge = assert(cmd.parse({
+        'pr',
+        'merge',
+        'repo=upstream',
+        'head=origin@topic',
+        'method=squash',
+      }))
+      local draft = assert(cmd.parse({ 'pr', 'draft', 'repo=upstream', 'head=origin@topic' }))
+      local ready = assert(cmd.parse({ 'pr', 'ready', 'repo=upstream', 'head=origin@topic' }))
+
+      for _, command in ipairs({ close, approve, merge, draft, ready }) do
+        assert.same({}, command.subjects)
+        assert.equals('owner/upstream', command.parsed_modifiers.repo.slug)
+        assert.equals('topic', command.parsed_modifiers.head.rev)
+        assert.equals('owner/current', command.parsed_modifiers.head.repo.slug)
+      end
+
+      assert.equals('close', close.name)
+      assert.equals('approve', approve.name)
+      assert.equals('merge', merge.name)
+      assert.equals('squash', merge.modifiers.method)
+      assert.equals('draft', draft.name)
+      assert.equals('ready', ready.name)
+    end
+  )
+
   it('attaches default target policy for omitted direct-action addresses', function()
     local create = assert(cmd.parse({ 'pr', 'create' }))
 
@@ -282,10 +313,14 @@ describe('command schema', function()
       cmd.modifier_names('pr', 'create')
     )
     assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'ci'))
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'close'))
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'approve'))
+    assert.same({ 'repo', 'head', 'method' }, cmd.modifier_names('pr', 'merge'))
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'draft'))
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'ready'))
     assert.same({ 'repo' }, cmd.modifier_names('ci', 'open'))
     assert.same({ 'repo' }, cmd.modifier_names('ci', 'browse'))
     assert.same({ 'repo', 'web', 'blank', 'template' }, cmd.modifier_names('issue', 'create'))
-    assert.same({ 'repo', 'method' }, cmd.modifier_names('pr', 'merge'))
     assert.same({ 'repo', 'head', 'adapter' }, cmd.modifier_names('review'))
   end)
 

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -686,12 +686,120 @@ describe(':Forge command', function()
     }, captured.ops_calls[3])
   end)
 
+  it('dispatches implicit current-open-PR mutators through forge.current_pr', function()
+    captured.current_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+
+    vim.cmd('Forge pr approve')
+    vim.cmd('Forge pr merge')
+    vim.cmd('Forge pr close')
+    vim.cmd('Forge pr draft')
+    vim.cmd('Forge pr ready')
+
+    assert.equals(5, #captured.current_pr_calls)
+    for _, call in ipairs(captured.current_pr_calls) do
+      assert.equals('github', call.forge.name)
+      assert.is_nil(call.repo)
+      assert.is_nil(call.head)
+    end
+
+    assert.same({
+      name = 'pr_approve',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_merge',
+      pr = { num = '42', scope = repo_scope('upstream') },
+      method = nil,
+    }, captured.ops_calls[2])
+    assert.same({
+      name = 'pr_close',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[3])
+    assert.same({
+      name = 'pr_toggle_draft',
+      pr = { num = '42', scope = repo_scope('upstream') },
+      is_draft = false,
+    }, captured.ops_calls[4])
+    assert.same({
+      name = 'pr_toggle_draft',
+      pr = { num = '42', scope = repo_scope('upstream') },
+      is_draft = true,
+    }, captured.ops_calls[5])
+    assert.same({}, captured.warnings)
+  end)
+
+  it('passes repo= and head= disambiguation through implicit current-open-PR mutators', function()
+    captured.current_pr_result = {
+      num = '57',
+      scope = repo_scope('upstream'),
+    }
+
+    vim.cmd('Forge pr approve repo=upstream head=origin@topic')
+    vim.cmd('Forge pr merge repo=upstream head=origin@topic method=squash')
+    vim.cmd('Forge pr close repo=upstream head=origin@topic')
+    vim.cmd('Forge pr draft repo=upstream head=origin@topic')
+    vim.cmd('Forge pr ready repo=upstream head=origin@topic')
+
+    for _, call in ipairs(captured.current_pr_calls) do
+      assert.equals('github', call.forge.name)
+      assert.equals('repo', call.repo.kind)
+      assert.equals('owner/upstream', call.repo.slug)
+      assert.equals('rev', call.head.kind)
+      assert.equals('topic', call.head.rev)
+      assert.equals('owner/current', call.head.repo.slug)
+    end
+
+    assert.same({
+      name = 'pr_approve',
+      pr = { num = '57', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({
+      name = 'pr_merge',
+      pr = { num = '57', scope = repo_scope('upstream') },
+      method = 'squash',
+    }, captured.ops_calls[2])
+    assert.same({
+      name = 'pr_close',
+      pr = { num = '57', scope = repo_scope('upstream') },
+    }, captured.ops_calls[3])
+    assert.same({
+      name = 'pr_toggle_draft',
+      pr = { num = '57', scope = repo_scope('upstream') },
+      is_draft = false,
+    }, captured.ops_calls[4])
+    assert.same({
+      name = 'pr_toggle_draft',
+      pr = { num = '57', scope = repo_scope('upstream') },
+      is_draft = true,
+    }, captured.ops_calls[5])
+  end)
+
   it('warns cleanly when implicit current-PR commands find no matching PR', function()
     vim.cmd('Forge pr')
     vim.cmd('Forge review')
     vim.cmd('Forge pr ci')
 
     assert.same({
+      'no open PR found for this branch',
+      'no open PR found for this branch',
+      'no open PR found for this branch',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('warns cleanly when implicit current-open-PR mutators find no matching PR', function()
+    vim.cmd('Forge pr approve')
+    vim.cmd('Forge pr merge')
+    vim.cmd('Forge pr close')
+    vim.cmd('Forge pr draft')
+    vim.cmd('Forge pr ready')
+
+    assert.same({
+      'no open PR found for this branch',
+      'no open PR found for this branch',
       'no open PR found for this branch',
       'no open PR found for this branch',
       'no open PR found for this branch',
@@ -706,6 +814,20 @@ describe(':Forge command', function()
     }
 
     vim.cmd('Forge pr')
+
+    assert.same({
+      'multiple PRs match head owner/current@main; pass repo= or head=',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('surfaces resolver errors from implicit current-open-PR mutators', function()
+    captured.current_pr_error = {
+      code = 'ambiguous_pr',
+      message = 'multiple PRs match head owner/current@main; pass repo= or head=',
+    }
+
+    vim.cmd('Forge pr merge')
 
     assert.same({
       'multiple PRs match head owner/current@main; pass repo= or head=',
@@ -1477,14 +1599,19 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(pr, 'repo='))
     assert.is_true(vim.tbl_contains(pr, 'head='))
     assert.is_true(vim.tbl_contains(close, 'repo='))
+    assert.is_true(vim.tbl_contains(close, 'head='))
     assert.is_true(vim.tbl_contains(edit, 'repo='))
     assert.is_true(vim.tbl_contains(approve, 'repo='))
+    assert.is_true(vim.tbl_contains(approve, 'head='))
     assert.is_true(vim.tbl_contains(merge, 'repo='))
+    assert.is_true(vim.tbl_contains(merge, 'head='))
     assert.is_true(vim.tbl_contains(merge, 'method='))
     assert.is_true(vim.tbl_contains(pr_ci, 'repo='))
     assert.is_true(vim.tbl_contains(pr_ci, 'head='))
     assert.is_true(vim.tbl_contains(draft, 'repo='))
+    assert.is_true(vim.tbl_contains(draft, 'head='))
     assert.is_true(vim.tbl_contains(ready, 'repo='))
+    assert.is_true(vim.tbl_contains(ready, 'head='))
     assert.is_true(vim.tbl_contains(review, 'open'))
     assert.is_true(vim.tbl_contains(review, 'repo='))
     assert.is_true(vim.tbl_contains(review, 'head='))
@@ -1529,6 +1656,7 @@ describe(':Forge command', function()
     local merge = require('forge.cmd').complete('', 'Forge pr merge repo=upstream ', 0)
 
     assert.is_false(vim.tbl_contains(merge, 'repo='))
+    assert.is_true(vim.tbl_contains(merge, 'head='))
     assert.is_true(vim.tbl_contains(merge, 'method='))
     assert.is_false(vim.tbl_contains(merge, '302'))
     assert.is_false(vim.tbl_contains(merge, '301'))


### PR DESCRIPTION
## Problem

`:Forge pr close`, `approve`, `merge`, `draft`, and `ready` required an explicit PR number even when the current branch already mapped to exactly one open PR. That made those mutators inconsistent with the existing implicit current-PR flows in `:Forge pr`, `:Forge review`, and `:Forge pr ci`.

Closes #452.

## Solution

Allow those mutators to omit `{num}` and route the omitted-subject form through the existing current-open-PR resolver, with `repo=` and `head=` available for disambiguation. Update the help text and command specs so parsing, completion, dispatch, and warning behavior all match the new command surface.