### PR TITLE
resolver: add branch-relative non-open PR lookup beside current_pr()

### DIFF
--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -251,12 +251,14 @@ end
 
 ---@param branch string
 ---@param scope forge.Scope?
+---@param state forge.PRListState?
 ---@return string[]
-function M:pr_for_branch_cmd(branch, scope)
+function M:pr_for_branch_cmd(branch, scope, state)
   return {
     'sh',
     '-c',
-    ('tea pr list --state open --output json --fields index,head --repo %s | jq -r \'.[] | select(.head=="%s" or .head.name=="%s") | .index // empty\''):format(
+    ('tea pr list --state %s --output json --fields index,head --repo %s | jq -r \'.[] | select(.head=="%s" or .head.name=="%s") | .index // empty\''):format(
+      state or 'open',
       repo_arg(scope),
       branch,
       branch

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -285,12 +285,15 @@ end
 
 ---@param branch string
 ---@param scope forge.Scope?
+---@param state forge.PRListState?
 ---@return string[]
-function M:pr_for_branch_cmd(branch, scope)
+function M:pr_for_branch_cmd(branch, scope, state)
   local cmd = {
     'gh',
     'pr',
     'list',
+    '--state',
+    state or 'open',
     '--head',
     branch,
     '--json',
@@ -605,7 +608,7 @@ function M:fetch_pr_details_cmd(num, scope)
     '-R',
     nwo(scope),
     '--json',
-    'title,body,isDraft,headRefName,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,milestone,url',
+    'title,body,isDraft,state,mergedAt,headRefName,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,milestone,url',
   }
 end
 

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -307,13 +307,23 @@ end
 
 ---@param branch string
 ---@param scope forge.Scope?
+---@param state forge.PRListState?
 ---@return string[]
-function M:pr_for_branch_cmd(branch, scope)
+function M:pr_for_branch_cmd(branch, scope, state)
+  local flag = ''
+  if state == 'closed' then
+    flag = ' --closed'
+  elseif state == 'merged' then
+    flag = ' --merged'
+  elseif state == 'all' then
+    flag = ' --all'
+  end
   return {
     'sh',
     '-c',
-    ("glab mr list --source-branch '%s' -F json -R '%s' | jq -r '.[].iid // empty'"):format(
+    ("glab mr list --source-branch '%s'%s -F json -R '%s' | jq -r '.[].iid // empty'"):format(
       branch,
+      flag,
       repo_arg(scope)
     ),
   }

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -145,23 +145,100 @@ local function fetch_pr_json(forge, num, scope)
   return json
 end
 
+---@param value any
+---@return forge.PRLookupState?
+local function pr_lookup_state_name(value)
+  local state = trim(value)
+  if not state then
+    return nil
+  end
+  state = state:lower()
+  if state == 'open' or state == 'opened' then
+    return 'open'
+  end
+  if state == 'closed' then
+    return 'closed'
+  end
+  if state == 'merged' then
+    return 'merged'
+  end
+  return nil
+end
+
+---@param json table
+---@return forge.PRLookupState?
+local function pr_lookup_state(json)
+  if json.merged == true then
+    return 'merged'
+  end
+  local pull_request = type(json.pull_request) == 'table' and json.pull_request or nil
+  if pull_request and pull_request.merged == true then
+    return 'merged'
+  end
+  if trim(json.mergedAt or json.merged_at) then
+    return 'merged'
+  end
+  return pr_lookup_state_name(json.state)
+end
+
+---@param states forge.PRLookupState[]
+---@param value forge.PRLookupState?
+---@return boolean
+local function lookup_states_include(states, value)
+  if not value then
+    return false
+  end
+  for _, state in ipairs(states) do
+    if state == value then
+      return true
+    end
+  end
+  return false
+end
+
+---@param forge forge.Forge
+---@param states forge.PRLookupState[]
+---@return forge.PRListState[]
+local function branch_lookup_states(forge, states)
+  local list_states = {}
+  local seen = {}
+  for _, value in ipairs(states) do
+    local state = pr_lookup_state_name(value)
+    if state then
+      local list_state = state
+      if state == 'merged' and forge.name == 'codeberg' then
+        list_state = 'closed'
+      end
+      if not seen[list_state] then
+        seen[list_state] = true
+        list_states[#list_states + 1] = list_state
+      end
+    end
+  end
+  return list_states
+end
+
 ---@param forge forge.Forge
 ---@param branch string
 ---@param scope forge.Scope?
+---@param states forge.PRLookupState[]
 ---@return string[]?, string?
-local function list_pr_numbers(forge, branch, scope)
-  local result = vim.system(forge:pr_for_branch_cmd(branch, scope), { text = true }):wait()
-  if result.code ~= 0 then
-    return nil,
-      system_mod.cmd_error(result, ('failed to fetch %s'):format(forge.labels.pr or 'PRs'))
-  end
+local function list_pr_numbers(forge, branch, scope, states)
   local nums = {}
   local seen = {}
-  for _, line in ipairs(vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })) do
-    local num = trim(line)
-    if num and num ~= 'null' and not seen[num] then
-      seen[num] = true
-      nums[#nums + 1] = num
+  for _, list_state in ipairs(branch_lookup_states(forge, states)) do
+    local result =
+      vim.system(forge:pr_for_branch_cmd(branch, scope, list_state), { text = true }):wait()
+    if result.code ~= 0 then
+      return nil,
+        system_mod.cmd_error(result, ('failed to fetch %s'):format(forge.labels.pr or 'PRs'))
+    end
+    for _, line in ipairs(vim.split(result.stdout or '', '\n', { plain = true, trimempty = true })) do
+      local num = trim(line)
+      if num and num ~= 'null' and not seen[num] then
+        seen[num] = true
+        nums[#nums + 1] = num
+      end
     end
   end
   return nums
@@ -270,9 +347,10 @@ end
 ---@param forge forge.Forge
 ---@param head forge.HeadRef
 ---@param scope forge.Scope
+---@param states forge.PRLookupState[]
 ---@return forge.PRRef[]?, string?
-local function matching_prs(forge, head, scope)
-  local nums, list_err = list_pr_numbers(forge, head.branch, scope)
+local function matching_prs(forge, head, scope, states)
+  local nums, list_err = list_pr_numbers(forge, head.branch, scope, states)
   if not nums then
     return nil, list_err
   end
@@ -286,7 +364,7 @@ local function matching_prs(forge, head, scope)
     if match_err then
       return nil, match_err
     end
-    if exact then
+    if exact and lookup_states_include(states, pr_lookup_state(json)) then
       matches[#matches + 1] = {
         num = num,
         scope = scope,
@@ -294,6 +372,34 @@ local function matching_prs(forge, head, scope)
     end
   end
   return matches
+end
+
+---@param policy forge.BranchPRPolicy?
+---@return forge.PRLookupPass[]
+local function branch_pr_searches(policy)
+  local searches = {}
+  if type(policy) == 'table' and type(policy.searches) == 'table' then
+    for _, pass in ipairs(policy.searches) do
+      local states = {}
+      local seen = {}
+      if type(pass) == 'table' then
+        for _, value in ipairs(pass) do
+          local state = pr_lookup_state_name(value)
+          if state and not seen[state] then
+            seen[state] = true
+            states[#states + 1] = state
+          end
+        end
+      end
+      if #states > 0 then
+        searches[#searches + 1] = states
+      end
+    end
+  end
+  if #searches == 0 then
+    return { { 'open' } }
+  end
+  return searches
 end
 
 ---@param repo forge.RepoLike?
@@ -341,8 +447,9 @@ function M.head(head, opts)
 end
 
 ---@param opts forge.CurrentPROpts?
+---@param policy forge.BranchPRPolicy?
 ---@return forge.PRRef?, forge.CmdError?
-function M.current_pr(opts)
+function M.branch_pr(opts, policy)
   opts = opts or {}
   local forge = current_forge(opts)
   if not forge then
@@ -364,25 +471,35 @@ function M.current_pr(opts)
   if not repos then
     return error_result(repo_err or 'invalid repo address', repo_code or 'invalid_repo')
   end
-  for _, scope in ipairs(repos) do
-    local matches, match_err = matching_prs(forge, head, scope)
-    if not matches then
-      return error_result(match_err or 'current PR lookup failed', 'lookup_failed')
-    end
-    if #matches == 1 then
-      return matches[1]
-    end
-    if #matches > 1 then
-      return error_result(
-        ('multiple %s match head %s; pass repo= or head='):format(
-          forge.labels.pr_full or 'PRs',
-          head_label(head)
-        ),
-        'ambiguous_pr'
-      )
+  for _, states in ipairs(branch_pr_searches(policy)) do
+    for _, scope in ipairs(repos) do
+      local matches, match_err = matching_prs(forge, head, scope, states)
+      if not matches then
+        return error_result(match_err or 'current PR lookup failed', 'lookup_failed')
+      end
+      if #matches == 1 then
+        return matches[1]
+      end
+      if #matches > 1 then
+        return error_result(
+          ('multiple %s match head %s; pass repo= or head='):format(
+            forge.labels.pr_full or 'PRs',
+            head_label(head)
+          ),
+          'ambiguous_pr'
+        )
+      end
     end
   end
   return nil
+end
+
+---@param opts forge.CurrentPROpts?
+---@return forge.PRRef?, forge.CmdError?
+function M.current_pr(opts)
+  return M.branch_pr(opts, {
+    searches = { { 'open' } },
+  })
 end
 
 return M

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -111,8 +111,14 @@
 ---@alias forge.ReleaseRefLike forge.ReleaseRef|string
 ---@alias forge.RunRefLike forge.RunRef|string
 ---@alias forge.TargetValue forge.RepoTarget|forge.RevTarget|forge.BranchTarget|forge.CommitTarget|forge.LocationTarget
+---@alias forge.PRLookupState 'open'|'closed'|'merged'
+---@alias forge.PRListState 'open'|'closed'|'merged'|'all'
+---@alias forge.PRLookupPass forge.PRLookupState[]
 ---@alias forge.RepoLike forge.Scope|forge.RepoTarget|string
 ---@alias forge.HeadLike forge.HeadInput|forge.HeadRef|forge.RevTarget|string
+
+---@class forge.BranchPRPolicy
+---@field searches forge.PRLookupPass[]
 
 ---@class forge.ScopedOpts
 ---@field scope forge.Scope?
@@ -375,7 +381,7 @@
 ---@field checkout_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field fetch_pr fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
 ---@field pr_base_cmd fun(self: forge.Forge, num: string, scope?: forge.Scope): string[]
----@field pr_for_branch_cmd fun(self: forge.Forge, branch: string, scope?: forge.Scope): string[]
+---@field pr_for_branch_cmd fun(self: forge.Forge, branch: string, scope?: forge.Scope, state?: forge.PRListState): string[]
 ---@field checks_cmd fun(self: forge.Forge, num: string): string
 ---@field check_log_cmd fun(self: forge.Forge, run_id: string, failed_only: boolean, job_id: string?, scope?: forge.Scope): string[]
 ---@field steps_cmd (fun(self: forge.Forge, run_id: string, scope?: forge.Scope): string[])?

--- a/spec/create_pr_spec.lua
+++ b/spec/create_pr_spec.lua
@@ -365,6 +365,7 @@ describe('create_pr', function()
         ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/repo.git\n'),
         ['pr-for-branch feature'] = helpers.command_result('23\n'),
         ['fetch-pr 23'] = helpers.command_result(vim.json.encode({
+          state = 'OPEN',
           title = 'Existing PR',
           body = 'Body',
           isDraft = false,
@@ -401,6 +402,7 @@ describe('create_pr', function()
       ['git remote get-url origin'] = helpers.command_result('git@github.com:owner/repo.git\n'),
       ['pr-for-branch feature'] = helpers.command_result('23\n'),
       ['fetch-pr 23'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
         title = 'Existing PR',
         body = 'Body',
         isDraft = false,

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -36,8 +36,8 @@ describe('current_pr resolver', function()
   local function fake_backend(name)
     local backend = require('forge.backends.' .. name)
     return vim.tbl_extend('force', backend, {
-      pr_for_branch_cmd = function(_, branch, scope)
-        return { 'pr-for-branch', branch, scope and scope.slug or '' }
+      pr_for_branch_cmd = function(_, branch, scope, state)
+        return { 'pr-for-branch', state or 'open', branch, scope and scope.slug or '' }
       end,
       fetch_pr_details_cmd = function(_, num, scope)
         return { 'fetch-pr', num, scope and scope.slug or '' }
@@ -91,8 +91,9 @@ describe('current_pr resolver', function()
         'git@github.com:owner/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('17\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('17\n'),
       ['fetch-pr 17 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
         headRefName = 'topic',
         headRepository = {
           name = 'fork',
@@ -123,7 +124,7 @@ describe('current_pr resolver', function()
         'git@github.com:owner/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('\n'),
     })
 
     local pr, err = require('forge.resolve').current_pr({
@@ -160,9 +161,10 @@ describe('current_pr resolver', function()
       ['git remote get-url upstream'] = helpers.command_result(
         'git@github.com:owner/upstream.git\n'
       ),
-      ['pr-for-branch feature owner/fork'] = helpers.command_result('\n'),
-      ['pr-for-branch feature owner/upstream'] = helpers.command_result('42\n'),
+      ['pr-for-branch open feature owner/fork'] = helpers.command_result('\n'),
+      ['pr-for-branch open feature owner/upstream'] = helpers.command_result('42\n'),
       ['fetch-pr 42 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
         headRefName = 'feature',
         headRepository = {
           name = 'fork',
@@ -183,11 +185,11 @@ describe('current_pr resolver', function()
       num = '42',
       scope = github_scope('upstream'),
     }, pr)
-    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch feature owner/fork'))
-    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch feature owner/upstream'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch open feature owner/fork'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch open feature owner/upstream'))
     assert.is_true(
-      vim.fn.index(captured.systems, 'pr-for-branch feature owner/fork')
-        < vim.fn.index(captured.systems, 'pr-for-branch feature owner/upstream')
+      vim.fn.index(captured.systems, 'pr-for-branch open feature owner/fork')
+        < vim.fn.index(captured.systems, 'pr-for-branch open feature owner/upstream')
     )
   end)
 
@@ -198,9 +200,10 @@ describe('current_pr resolver', function()
       ['git remote get-url upstream'] = helpers.command_result(
         'git@github.com:owner/upstream.git\n'
       ),
-      ['pr-for-branch topic owner/fork'] = helpers.command_result('\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('57\n'),
+      ['pr-for-branch open topic owner/fork'] = helpers.command_result('\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('57\n'),
       ['fetch-pr 57 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
         headRefName = 'topic',
         headRepository = {
           name = 'fork',
@@ -226,14 +229,118 @@ describe('current_pr resolver', function()
     assert.is_false(vim.tbl_contains(captured.systems, 'git branch --show-current'))
   end)
 
+  it('keeps current_pr open-only when broader branch PR states exist', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('\n'),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    })
+
+    assert.is_nil(pr)
+    assert.is_nil(err)
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch open topic owner/upstream'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'pr-for-branch closed topic owner/upstream'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'pr-for-branch merged topic owner/upstream'))
+  end)
+
+  it('resolves merged GitHub PRs through branch_pr', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch merged topic owner/upstream'] = helpers.command_result('17\n'),
+      ['fetch-pr 17 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'MERGED',
+        mergedAt = '2026-04-27T00:00:00Z',
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').branch_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    }, {
+      searches = { { 'merged' } },
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '17',
+      scope = github_scope('upstream'),
+    }, pr)
+  end)
+
+  it('supports open-first fallback policies across candidate repos', function()
+    use_system_responses({
+      ['git branch --show-current'] = helpers.command_result('feature\n'),
+      ['git config branch.feature.pushRemote'] = helpers.command_result('fork\n'),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['pr-for-branch open feature owner/fork'] = helpers.command_result('\n'),
+      ['pr-for-branch open feature owner/upstream'] = helpers.command_result('42\n'),
+      ['fetch-pr 42 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
+        headRefName = 'feature',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').branch_pr({
+      forge = github,
+    }, {
+      searches = {
+        { 'open' },
+        { 'closed', 'merged' },
+      },
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '42',
+      scope = github_scope('upstream'),
+    }, pr)
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch open feature owner/fork'))
+    assert.is_true(vim.tbl_contains(captured.systems, 'pr-for-branch open feature owner/upstream'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'pr-for-branch closed feature owner/fork'))
+    assert.is_false(
+      vim.tbl_contains(captured.systems, 'pr-for-branch merged feature owner/upstream')
+    )
+  end)
+
   it('matches GitLab merge requests by source project and branch', function()
     use_system_responses({
       ['git remote get-url upstream'] = helpers.command_result(
         'git@gitlab.com:group/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@gitlab.com:group/fork.git\n'),
-      ['pr-for-branch topic group/upstream'] = helpers.command_result('8\n'),
+      ['pr-for-branch open topic group/upstream'] = helpers.command_result('8\n'),
       ['fetch-pr 8 group/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'opened',
         source_branch = 'topic',
         source_project_id = 101,
       })),
@@ -255,14 +362,47 @@ describe('current_pr resolver', function()
     }, pr)
   end)
 
+  it('matches GitLab merged requests by source project and branch in branch_pr', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@gitlab.com:group/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@gitlab.com:group/fork.git\n'),
+      ['pr-for-branch merged topic group/upstream'] = helpers.command_result('8\n'),
+      ['fetch-pr 8 group/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'merged',
+        source_branch = 'topic',
+        source_project_id = 101,
+      })),
+      ['glab api --hostname gitlab.com projects/group%2Ffork'] = helpers.command_result(
+        vim.json.encode({ id = 101 })
+      ),
+    })
+
+    local pr, err = require('forge.resolve').branch_pr({
+      forge = gitlab,
+      repo = 'upstream',
+      head = 'fork@topic',
+    }, {
+      searches = { { 'merged' } },
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '8',
+      scope = gitlab_scope('group/upstream'),
+    }, pr)
+  end)
+
   it('matches Codeberg pull requests by head repo and branch', function()
     use_system_responses({
       ['git remote get-url upstream'] = helpers.command_result(
         'git@codeberg.org:owner/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@codeberg.org:owner/fork.git\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('13\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('13\n'),
       ['fetch-pr 13 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'open',
         head = {
           ref = 'topic',
           repo = {
@@ -285,13 +425,83 @@ describe('current_pr resolver', function()
     }, pr)
   end)
 
+  it(
+    'treats Codeberg merged PRs as merged even though branch lookup uses closed candidates',
+    function()
+      use_system_responses({
+        ['git remote get-url upstream'] = helpers.command_result(
+          'git@codeberg.org:owner/upstream.git\n'
+        ),
+        ['git remote get-url fork'] = helpers.command_result('git@codeberg.org:owner/fork.git\n'),
+        ['pr-for-branch closed topic owner/upstream'] = helpers.command_result('13\n'),
+        ['fetch-pr 13 owner/upstream'] = helpers.command_result(vim.json.encode({
+          state = 'closed',
+          merged = true,
+          merged_at = '2026-04-27T00:00:00Z',
+          head = {
+            ref = 'topic',
+            repo = {
+              full_name = 'owner/fork',
+            },
+          },
+        })),
+      })
+
+      local pr, err = require('forge.resolve').branch_pr({
+        forge = codeberg,
+        repo = 'upstream',
+        head = 'fork@topic',
+      }, {
+        searches = { { 'merged' } },
+      })
+
+      assert.is_nil(err)
+      assert.same({
+        num = '13',
+        scope = codeberg_scope('upstream'),
+      }, pr)
+    end
+  )
+
+  it('excludes merged Codeberg PRs from closed-only branch_pr policies', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@codeberg.org:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@codeberg.org:owner/fork.git\n'),
+      ['pr-for-branch closed topic owner/upstream'] = helpers.command_result('13\n'),
+      ['fetch-pr 13 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'closed',
+        merged = true,
+        merged_at = '2026-04-27T00:00:00Z',
+        head = {
+          ref = 'topic',
+          repo = {
+            full_name = 'owner/fork',
+          },
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').branch_pr({
+      forge = codeberg,
+      repo = 'upstream',
+      head = 'fork@topic',
+    }, {
+      searches = { { 'closed' } },
+    })
+
+    assert.is_nil(pr)
+    assert.is_nil(err)
+  end)
+
   it('uses existing fetch-style error phrasing for resolver failures', function()
     use_system_responses({
       ['git remote get-url upstream'] = helpers.command_result(
         'git@github.com:owner/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('', 1),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('', 1),
     })
 
     local pr, err = require('forge.resolve').current_pr({
@@ -313,8 +523,9 @@ describe('current_pr resolver', function()
         'git@github.com:owner/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('17\n18\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('17\n18\n'),
       ['fetch-pr 17 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
         headRefName = 'topic',
         headRepository = {
           name = 'fork',
@@ -325,6 +536,7 @@ describe('current_pr resolver', function()
         },
       })),
       ['fetch-pr 18 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
         headRefName = 'topic',
         headRepository = {
           name = 'fork',
@@ -347,13 +559,59 @@ describe('current_pr resolver', function()
     assert.matches('pass repo= or head=', err.message)
   end)
 
+  it('reports ambiguity when multiple non-open PRs match the same head', function()
+    use_system_responses({
+      ['git remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
+      ['pr-for-branch closed topic owner/upstream'] = helpers.command_result('17\n'),
+      ['pr-for-branch merged topic owner/upstream'] = helpers.command_result('18\n'),
+      ['fetch-pr 17 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'CLOSED',
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+      ['fetch-pr 18 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'MERGED',
+        mergedAt = '2026-04-27T00:00:00Z',
+        headRefName = 'topic',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').branch_pr({
+      forge = github,
+      repo = 'upstream',
+      head = 'fork@topic',
+    }, {
+      searches = { { 'closed', 'merged' } },
+    })
+
+    assert.is_nil(pr)
+    assert.same('ambiguous_pr', err.code)
+    assert.matches('pass repo= or head=', err.message)
+  end)
+
   it('uses existing parse-detail phrasing when PR details are malformed', function()
     use_system_responses({
       ['git remote get-url upstream'] = helpers.command_result(
         'git@github.com:owner/upstream.git\n'
       ),
       ['git remote get-url fork'] = helpers.command_result('git@github.com:owner/fork.git\n'),
-      ['pr-for-branch topic owner/upstream'] = helpers.command_result('17\n'),
+      ['pr-for-branch open topic owner/upstream'] = helpers.command_result('17\n'),
       ['fetch-pr 17 owner/upstream'] = helpers.command_result('{'),
     })
 

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -65,6 +65,17 @@ describe('github', function()
     assert.truthy(vim.tbl_contains(cmd, '--json'))
   end)
 
+  it('builds pr_for_branch_cmd with explicit state filters', function()
+    local cmd = gh:pr_for_branch_cmd('topic', { repo_arg = 'owner/repo' }, 'merged')
+    assert.same({ 'gh', 'pr', 'list' }, vim.list_slice(cmd, 1, 3))
+    assert.truthy(vim.tbl_contains(cmd, '--head'))
+    assert.truthy(vim.tbl_contains(cmd, 'topic'))
+    assert.truthy(vim.tbl_contains(cmd, '--state'))
+    assert.truthy(vim.tbl_contains(cmd, 'merged'))
+    assert.truthy(vim.tbl_contains(cmd, '-R'))
+    assert.truthy(vim.tbl_contains(cmd, 'owner/repo'))
+  end)
+
   it('respects explicit PR list limits', function()
     local cmd = gh:list_pr_json_cmd('open', 55)
     assert.truthy(vim.tbl_contains(cmd, '--limit'))
@@ -134,7 +145,7 @@ describe('github', function()
     assert.truthy(
       vim.tbl_contains(
         pr_details,
-        'title,body,isDraft,headRefName,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,milestone,url'
+        'title,body,isDraft,state,mergedAt,headRefName,headRepository,headRepositoryOwner,baseRefName,labels,assignees,reviewRequests,milestone,url'
       )
     )
 
@@ -570,6 +581,17 @@ describe('gitlab', function()
     assert.equals('mr', cmd[2])
     assert.truthy(vim.tbl_contains(gl:list_pr_json_cmd('closed'), '--closed'))
     assert.truthy(vim.tbl_contains(gl:list_pr_json_cmd('all'), '--all'))
+  end)
+
+  it('builds pr_for_branch_cmd with state variants', function()
+    local closed = gl:pr_for_branch_cmd('topic', { repo_arg = 'group/repo' }, 'closed')
+    local merged = gl:pr_for_branch_cmd('topic', { repo_arg = 'group/repo' }, 'merged')
+    local all = gl:pr_for_branch_cmd('topic', { repo_arg = 'group/repo' }, 'all')
+    assert.equals('sh', closed[1])
+    assert.truthy(closed[3]:find("--source%-branch 'topic'", 1))
+    assert.truthy(closed[3]:find('--closed', 1, true))
+    assert.truthy(merged[3]:find('--merged', 1, true))
+    assert.truthy(all[3]:find('--all', 1, true))
   end)
 
   it('respects explicit issue list limits', function()
@@ -1044,6 +1066,13 @@ describe('codeberg', function()
     local cmd = cb:list_pr_json_cmd('open')
     assert.equals('tea', cmd[1])
     assert.truthy(vim.tbl_contains(cmd, '--fields'))
+  end)
+
+  it('builds pr_for_branch_cmd with explicit states', function()
+    local cmd = cb:pr_for_branch_cmd('topic', { repo_arg = 'owner/repo' }, 'closed')
+    assert.equals('sh', cmd[1])
+    assert.truthy(cmd[3]:find('--state closed', 1, true))
+    assert.truthy(cmd[3]:find('.head=="topic"', 1, true))
   end)
 
   it('respects explicit issue list limits', function()


### PR DESCRIPTION
## Problem

`current_pr()` is intentionally open-only, but Forge did not have a second branch-relative PR resolver for workflows that need to recover a unique PR for the current branch across non-open states. That blocked follow-up features like implicit `pr reopen` and broader implicit `pr_ci()` fallback without muddying the open-only semantics used by `pr()`, `review()`, and create-PR duplicate detection.

## Solution

Add `require('forge.resolve').branch_pr()` with ordered state-search passes, and keep `current_pr()` as a thin open-only wrapper on top of it. Extend backend branch lookup commands so GitHub, GitLab, and Codeberg can enumerate branch PR candidates under broader state policies, normalize fetched PR detail state so merged PRs stay distinct from merely closed ones, and add resolver/source specs that cover open-only preservation, fallback policy ordering, ambiguity, and backend-specific matching behavior.

Closes #453.