### PR TITLE
api/cmd: let implicit pr_ci resolve closed and merged PRs

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -351,8 +351,10 @@ TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Default policy:
     - collaboration repo = `targets.default_repo`, else `upstream`, else
       `origin`
-    - `:Forge pr`, `:Forge review`, and `:Forge pr ci` default to resolving
-      the current PR from the current branch head
+    - `:Forge pr` and `:Forge review` default to resolving the current open PR
+      from the current branch head
+    - `:Forge pr ci` defaults to resolving checks for the current branch's PR,
+      preferring an open PR and falling back to a unique closed or merged PR
     - `:Forge pr create` defaults `head=` to the current branch push
       context and `base=` to the collaboration repo default branch
     - `:Forge ci` defaults to current-branch CI history
@@ -370,7 +372,7 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     name is meaningful:
     - `:Forge pr` opens the current PR
     - `:Forge review` reviews the current PR
-    - `:Forge pr ci` opens checks for the current PR
+    - `:Forge pr ci` opens checks for the current branch's PR
     - `:Forge ci` opens current-branch CI history
     - `:Forge browse` opens the current file/line context
 
@@ -421,8 +423,9 @@ PR COMMANDS                                                *forge-pr-commands*
 `:Forge pr ci` [repo=...] [head=...]                           *:Forge-pr-ci*
 `:Forge pr ci` {num} [repo=...]
     Open PR checks.
-    (no `{num}`)       Resolve the current PR from the current branch and open
-                       its checks.
+    (no `{num}`)       Resolve the current branch's PR and open its checks.
+                       Forge prefers a unique open PR; if none match, it falls
+                       back to a unique closed or merged PR.
     `{num}`            Open checks for PR `{num}` directly.
     `repo=`            Scope the explicit `{num}` or disambiguate implicit
                        current-PR lookup.
@@ -452,7 +455,7 @@ PR COMMANDS                                                *forge-pr-commands*
                        refs.
 
 IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
-    `:Forge pr`, `:Forge review`, `:Forge pr ci`, and the omitted-subject
+    `:Forge pr`, `:Forge review`, and the omitted-subject
     `:Forge pr approve`, `merge`, `close`, `draft`, and `ready` forms resolve
     the current PR from the current branch head when `{num}` is omitted.
 
@@ -465,6 +468,20 @@ IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
     - exactly one match: run the action
     - no matches: warn `no open PR found for this branch`
     - multiple matches: warn and ask for `repo=` or `head=`
+
+IMPLICIT BRANCH-RELATIVE PR CI RESOLUTION ~             *forge-pr-ci-resolution*
+    `:Forge pr ci` uses the same branch-context + `repo=` / `head=`
+    disambiguation model, but with a broader state policy when `{num}` is
+    omitted.
+
+    Lookup policy:
+    - first search open PRs for the current branch
+    - if no open PR matches, search closed and merged PRs
+
+    Outcomes:
+    - exactly one match in a pass: open its checks
+    - no matches in any pass: warn `no PR found for this branch`
+    - multiple matches in a pass: warn and ask for `repo=` or `head=`
 
 `:Forge pr close` [repo=...] [head=...]                   *:Forge-pr-close*
 `:Forge pr close` {num} [repo=...]

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -439,6 +439,19 @@ local function resolve_current_pr_or_warn(command, f)
   return nil
 end
 
+local function resolve_branch_pr_or_warn(command, f, policy, no_match)
+  local pr, err = require('forge.resolve').branch_pr(current_pr_resolution_opts(command, f), policy)
+  if err then
+    warn(err.message)
+    return nil
+  end
+  if pr then
+    return pr
+  end
+  warn(no_match)
+  return nil
+end
+
 local function dispatch_pr(command)
   if not require_git_or_warn() then
     return
@@ -480,7 +493,12 @@ local function dispatch_pr(command)
   end
   if command.name == 'ci' then
     local pr = num and { num = num, scope = resolve_repo_modifier(command, f.name) }
-      or resolve_current_pr_or_warn(command, f)
+      or resolve_branch_pr_or_warn(command, f, {
+        searches = {
+          { 'open' },
+          { 'closed', 'merged' },
+        },
+      }, ('no %s found for this branch'):format((f.labels and f.labels.pr_one) or 'PR'))
     if not pr then
       return
     end

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -535,6 +535,7 @@ local function review_action_opts(opts)
 end
 
 local resolve_action_pr
+local resolve_pr_ci_target
 
 ---@param opts forge.PRActionOpts?
 ---@param require_forge boolean?
@@ -578,6 +579,33 @@ resolve_action_pr = function(opts)
     return forge, pr
   end
   log.warn(('no open %s found for this branch'):format(forge.labels.pr_one or 'PR'))
+  return nil
+end
+
+resolve_pr_ci_target = function(opts)
+  local _, explicit = explicit_pr_num(opts)
+  if explicit then
+    return resolve_pr_action_target(opts, true)
+  end
+  local log = require('forge.logger')
+  local forge = detect_or_warn()
+  if not forge then
+    return nil
+  end
+  local pr, err = resolve_mod.branch_pr(implicit_ref_opts(opts, forge), {
+    searches = {
+      { 'open' },
+      { 'closed', 'merged' },
+    },
+  })
+  if err then
+    log.warn(err.message or 'PR lookup failed')
+    return nil
+  end
+  if pr then
+    return forge, pr
+  end
+  log.warn(('no %s found for this branch'):format(forge.labels.pr_one or 'PR'))
   return nil
 end
 
@@ -639,7 +667,7 @@ end
 
 ---@param opts forge.PRActionOpts?
 function M.pr_ci(opts)
-  local forge, pr = resolve_pr_action_target(opts, true)
+  local forge, pr = resolve_pr_ci_target(opts)
   if not forge or not pr then
     return
   end

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -42,6 +42,9 @@ describe('high-level implicit-ref API', function()
 
   before_each(function()
     captured = {
+      branch_pr_calls = {},
+      branch_pr_error = nil,
+      branch_pr_result = nil,
       current_pr_calls = {},
       current_pr_error = nil,
       current_pr_result = nil,
@@ -179,6 +182,10 @@ describe('high-level implicit-ref API', function()
 
     package.preload['forge.resolve'] = function()
       return {
+        branch_pr = function(opts, policy)
+          table.insert(captured.branch_pr_calls, { opts = opts, policy = policy })
+          return captured.branch_pr_result, captured.branch_pr_error
+        end,
         current_pr = function(opts)
           table.insert(captured.current_pr_calls, opts)
           return captured.current_pr_result, captured.current_pr_error
@@ -344,31 +351,46 @@ describe('high-level implicit-ref API', function()
     end
   )
 
-  it('routes review() and pr_ci() through current_pr() with explicit address opts', function()
-    captured.current_pr_result = {
-      num = '57',
-      scope = repo_scope('upstream'),
-    }
+  it(
+    'routes review() through current_pr() and pr_ci() through branch_pr() with explicit address opts',
+    function()
+      captured.current_pr_result = {
+        num = '57',
+        scope = repo_scope('upstream'),
+      }
+      captured.branch_pr_result = {
+        num = '57',
+        scope = repo_scope('upstream'),
+      }
 
-    local forge = require('forge')
-    forge.review({ repo = 'upstream', head = 'origin@topic', adapter = 'worktree' })
-    forge.pr_ci({ repo = 'upstream', head = 'origin@topic' })
+      local forge = require('forge')
+      forge.review({ repo = 'upstream', head = 'origin@topic', adapter = 'worktree' })
+      forge.pr_ci({ repo = 'upstream', head = 'origin@topic' })
 
-    assert.equals(2, #captured.current_pr_calls)
-    for _, call in ipairs(captured.current_pr_calls) do
-      assert.equals('github', call.forge.name)
-      assert.equals('upstream', call.repo)
-      assert.equals('origin@topic', call.head)
+      assert.equals(1, #captured.current_pr_calls)
+      assert.equals('github', captured.current_pr_calls[1].forge.name)
+      assert.equals('upstream', captured.current_pr_calls[1].repo)
+      assert.equals('origin@topic', captured.current_pr_calls[1].head)
+      assert.equals(1, #captured.branch_pr_calls)
+      assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
+      assert.equals('upstream', captured.branch_pr_calls[1].opts.repo)
+      assert.equals('origin@topic', captured.branch_pr_calls[1].opts.head)
+      assert.same({
+        searches = {
+          { 'open' },
+          { 'closed', 'merged' },
+        },
+      }, captured.branch_pr_calls[1].policy)
+      assert.equals('pr_review', captured.ops_calls[1].name)
+      assert.equals('github', captured.ops_calls[1].f.name)
+      assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[1].pr)
+      assert.same({ adapter = 'worktree' }, captured.ops_calls[1].opts)
+      assert.equals('pr_ci', captured.ops_calls[2].name)
+      assert.equals('github', captured.ops_calls[2].f.name)
+      assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[2].pr)
+      assert.is_nil(captured.ops_calls[2].opts)
     end
-    assert.equals('pr_review', captured.ops_calls[1].name)
-    assert.equals('github', captured.ops_calls[1].f.name)
-    assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[1].pr)
-    assert.same({ adapter = 'worktree' }, captured.ops_calls[1].opts)
-    assert.equals('pr_ci', captured.ops_calls[2].name)
-    assert.equals('github', captured.ops_calls[2].f.name)
-    assert.same({ num = '57', scope = repo_scope('upstream') }, captured.ops_calls[2].pr)
-    assert.is_nil(captured.ops_calls[2].opts)
-  end)
+  )
 
   it('opens current-branch CI through ci() and supports explicit head targeting', function()
     local forge = require('forge')
@@ -430,7 +452,21 @@ describe('high-level implicit-ref API', function()
     assert.same({
       'no open PR found for this branch',
       'no open PR found for this branch',
-      'no open PR found for this branch',
+      'no PR found for this branch',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('surfaces branch-relative PR lookup warnings from pr_ci()', function()
+    captured.branch_pr_error = {
+      code = 'ambiguous_pr',
+      message = 'multiple PRs match head owner/current@main; pass repo= or head=',
+    }
+
+    require('forge').pr_ci()
+
+    assert.same({
+      'multiple PRs match head owner/current@main; pass repo= or head=',
     }, captured.warnings)
     assert.same({}, captured.ops_calls)
   end)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -7,6 +7,7 @@ local preload_modules = {
   'forge.logger',
   'forge.ops',
   'forge.pickers',
+  'forge.resolve',
 }
 
 local loaded_modules = {
@@ -15,6 +16,7 @@ local loaded_modules = {
   'forge.logger',
   'forge.ops',
   'forge.pickers',
+  'forge.resolve',
 }
 
 local function repo_scope(repo)
@@ -83,6 +85,9 @@ describe(':Forge command', function()
       opens = {},
       ops_calls = {},
       ci_calls = {},
+      branch_pr_calls = {},
+      branch_pr_result = nil,
+      branch_pr_error = nil,
       current_pr_calls = {},
       current_pr_result = nil,
       current_pr_error = nil,
@@ -136,6 +141,15 @@ describe(':Forge command', function()
         info = function() end,
         debug = function() end,
         error = function() end,
+      }
+    end
+
+    package.preload['forge.resolve'] = function()
+      return {
+        branch_pr = function(opts, policy)
+          table.insert(captured.branch_pr_calls, { opts = opts, policy = policy })
+          return captured.branch_pr_result, captured.branch_pr_error
+        end,
       }
     end
 
@@ -628,14 +642,12 @@ describe(':Forge command', function()
 
     vim.cmd('Forge pr')
     vim.cmd('Forge review adapter=worktree')
-    vim.cmd('Forge pr ci')
 
-    assert.equals(3, #captured.current_pr_calls)
+    assert.equals(2, #captured.current_pr_calls)
     assert.equals('github', captured.current_pr_calls[1].forge.name)
     assert.is_nil(captured.current_pr_calls[1].repo)
     assert.is_nil(captured.current_pr_calls[1].head)
     assert.equals('github', captured.current_pr_calls[2].forge.name)
-    assert.equals('github', captured.current_pr_calls[3].forge.name)
     assert.same({
       name = 'pr_edit',
       pr = { num = '42', scope = repo_scope('upstream') },
@@ -645,10 +657,32 @@ describe(':Forge command', function()
       pr = { num = '42', scope = repo_scope('upstream') },
       opts = { adapter = 'worktree' },
     }, captured.ops_calls[2])
+    assert.same({}, captured.branch_pr_calls)
+    assert.same({}, captured.warnings)
+  end)
+
+  it('dispatches implicit pr ci through forge.resolve.branch_pr', function()
+    captured.branch_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+
+    vim.cmd('Forge pr ci')
+
     assert.same({
       name = 'pr_ci',
       pr = { num = '42', scope = repo_scope('upstream') },
-    }, captured.ops_calls[3])
+    }, captured.ops_calls[1])
+    assert.equals(1, #captured.branch_pr_calls)
+    assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
+    assert.is_nil(captured.branch_pr_calls[1].opts.repo)
+    assert.is_nil(captured.branch_pr_calls[1].opts.head)
+    assert.same({
+      searches = {
+        { 'open' },
+        { 'closed', 'merged' },
+      },
+    }, captured.branch_pr_calls[1].policy)
     assert.same({}, captured.warnings)
   end)
 
@@ -660,8 +694,8 @@ describe(':Forge command', function()
 
     vim.cmd('Forge pr repo=upstream head=origin@topic')
     vim.cmd('Forge review repo=upstream head=origin@topic adapter=worktree')
-    vim.cmd('Forge pr ci repo=upstream head=origin@topic')
 
+    assert.equals(2, #captured.current_pr_calls)
     for _, call in ipairs(captured.current_pr_calls) do
       assert.equals('github', call.forge.name)
       assert.equals('repo', call.repo.kind)
@@ -680,10 +714,27 @@ describe(':Forge command', function()
       pr = { num = '57', scope = repo_scope('upstream') },
       opts = { adapter = 'worktree' },
     }, captured.ops_calls[2])
+  end)
+
+  it('passes repo= and head= disambiguation through implicit pr ci branch lookup', function()
+    captured.branch_pr_result = {
+      num = '57',
+      scope = repo_scope('upstream'),
+    }
+
+    vim.cmd('Forge pr ci repo=upstream head=origin@topic')
+
+    assert.equals(1, #captured.branch_pr_calls)
+    assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
+    assert.equals('repo', captured.branch_pr_calls[1].opts.repo.kind)
+    assert.equals('owner/upstream', captured.branch_pr_calls[1].opts.repo.slug)
+    assert.equals('rev', captured.branch_pr_calls[1].opts.head.kind)
+    assert.equals('topic', captured.branch_pr_calls[1].opts.head.rev)
+    assert.equals('owner/current', captured.branch_pr_calls[1].opts.head.repo.slug)
     assert.same({
       name = 'pr_ci',
       pr = { num = '57', scope = repo_scope('upstream') },
-    }, captured.ops_calls[3])
+    }, captured.ops_calls[1])
   end)
 
   it('dispatches implicit current-open-PR mutators through forge.current_pr', function()
@@ -780,12 +831,19 @@ describe(':Forge command', function()
   it('warns cleanly when implicit current-PR commands find no matching PR', function()
     vim.cmd('Forge pr')
     vim.cmd('Forge review')
-    vim.cmd('Forge pr ci')
 
     assert.same({
       'no open PR found for this branch',
       'no open PR found for this branch',
-      'no open PR found for this branch',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('warns cleanly when implicit pr ci finds no matching branch PR', function()
+    vim.cmd('Forge pr ci')
+
+    assert.same({
+      'no PR found for this branch',
     }, captured.warnings)
     assert.same({}, captured.ops_calls)
   end)
@@ -814,6 +872,20 @@ describe(':Forge command', function()
     }
 
     vim.cmd('Forge pr')
+
+    assert.same({
+      'multiple PRs match head owner/current@main; pass repo= or head=',
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('surfaces resolver errors from implicit pr ci branch lookup', function()
+    captured.branch_pr_error = {
+      code = 'ambiguous_pr',
+      message = 'multiple PRs match head owner/current@main; pass repo= or head=',
+    }
+
+    vim.cmd('Forge pr ci')
 
     assert.same({
       'multiple PRs match head owner/current@main; pass repo= or head=',


### PR DESCRIPTION
## Problem

Implicit `pr_ci()` and `:Forge pr ci` were still open-PR-only even after the shared branch-relative resolver work landed. That made post-close and post-merge CI inspection awkward: if the current branch no longer had an open PR, users had to remember and pass an explicit PR number just to reopen its checks.

## Solution

Broaden only the implicit `pr_ci()` / `:Forge pr ci` path so it first looks for a unique open PR for the branch, then falls back to a unique closed or merged PR when no open match exists. Keep `pr()` and `review()` open-only, preserve explicit `{num}` / `num=` behavior, and update the API/command specs plus vimdoc so the CI-specific branch-relative policy and warnings are documented.

Closes #450.