### PR TITLE
feat(status): add statusline-friendly status API

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -25,6 +25,7 @@ CONTENTS                                                 *forge.nvim-contents*
   7. Highlights ........................................... |forge-highlights|
   8. Sources ................................................. |forge-sources|
   9. Extending ............................................ |forge-extending|
+     Statusline Integration ......................... |forge-statusline|
   10. API ........................................................ |forge-api|
 
 ==============================================================================
@@ -1112,6 +1113,41 @@ Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua` power
 the built-in commands and pickers, but they are no longer documented as the
 public integration surface.
 
+STATUSLINE INTEGRATION                                  *forge-statusline*
+
+`require('forge').status()` returns cached current-branch data for the current
+working tree. It returns `nil` outside git repos, always includes `branch` when
+available, and sets `scope` and `pr` when Forge can resolve them.
+
+`status.scope` is the branch head/push scope. `status.pr.scope` is the base
+repo scope for the matching PR, so fork-aware statuslines can distinguish the
+two.
+
+Refresh happens asynchronously. When the cached value changes, forge.nvim emits
+the `User` autocmd `ForgeStatusUpdate`. A minimal core Neovim integration
+looks like: >lua
+    function _G.ForgeStatusline()
+      local status = require('forge').status()
+      if not status then
+        return ''
+      end
+      local parts = { ' ' .. status.branch }
+      if status.pr then
+        parts[#parts + 1] = '#' .. status.pr.num
+      end
+      return table.concat(parts, ' ')
+    end
+
+    vim.api.nvim_create_autocmd('User', {
+      pattern = 'ForgeStatusUpdate',
+      callback = function()
+        vim.cmd.redrawstatus()
+      end,
+    })
+
+    vim.o.statusline = '%{%v:lua.ForgeStatusline()%} ' .. vim.o.statusline
+<
+
 BUILDING A CUSTOM PICKER FROM SCRATCH                 *forge-extending-picker*
 
 Call `require('forge.picker').pick()` when you want Forge to render a custom
@@ -1156,6 +1192,7 @@ Most integrations only need one of these entrypoints:
 - `require('forge').open(route?, opts?)`
 - `require('forge').pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`, `ci(opts?)`
 - `require('forge').current_pr(opts?)`
+- `require('forge').status()`
 - `require('forge').create_pr(opts?)`, `create_issue(opts?)`
 - `require('forge.picker').pick(opts)`
 - `require('forge').register(name, source)`
@@ -1174,6 +1211,7 @@ Prefer these helpers for normal integrations:
 - `pr({ num = '42' })`, `review({ num = '42' })`, and `pr_ci({ num = '42' })`
   for explicit PR targeting
 - `current_pr(opts?)` when you need the resolved PR ref
+- `status()` when you need cached branch/current-PR UI state
 - `create_pr(opts?)` and `create_issue(opts?)` for create flows
 
 `create_pr()` is create-only: if the current branch already has an open PR, it

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -46,6 +46,12 @@ local root_cache = {}
 local repo_info_cache = cache_mod.new(30 * 60)
 local pr_state_cache = cache_mod.new(60)
 local list_cache = cache_mod.new(2 * 60)
+local status_ttl = 30
+
+---@type table<string, { value: forge.Status|false|nil, updated_at: integer?, inflight: boolean?, request_id: integer? }>
+local status_cache = {}
+
+local status_augroup
 
 ---@param cmd string
 ---@return string?
@@ -54,6 +60,20 @@ local function fn_system_text(cmd)
   if vim.v.shell_error ~= 0 and (text == '' or text:match('^fatal:') or text:match('^error:')) then
     return nil
   end
+  if text == '' then
+    return nil
+  end
+  return text
+end
+
+---@param cmd string[]
+---@return string?
+local function system_text(cmd)
+  local result = vim.system(cmd, { text = true }):wait()
+  if result.code ~= 0 then
+    return nil
+  end
+  local text = vim.trim(result.stdout or '')
   if text == '' then
     return nil
   end
@@ -176,6 +196,144 @@ local function detect_from_remote(remote)
   return nil
 end
 
+---@param root string
+---@return forge.Forge?
+local function detect_at_root(root)
+  local log = require('forge.logger')
+  if forge_cache[root] then
+    return forge_cache[root]
+  end
+  local remote = system_text({ 'git', '-C', root, 'remote', 'get-url', 'origin' })
+  if not remote then
+    log.debug('detect: no origin remote')
+    return nil
+  end
+  local name = detect_from_remote(remote)
+  if not name then
+    log.debug('detect: no forge matched remote ' .. remote)
+    return nil
+  end
+  local source = resolve_source(name)
+  if not source then
+    log.debug('detect: failed to load source module ' .. name)
+    return nil
+  end
+  if vim.fn.executable(source.cli) ~= 1 then
+    log.debug('detect: CLI ' .. source.cli .. ' not found')
+    return nil
+  end
+  forge_cache[root] = source
+  return source
+end
+
+local function emit_status_update()
+  vim.api.nvim_exec_autocmds('User', {
+    pattern = 'ForgeStatusUpdate',
+    modeline = false,
+  })
+end
+
+---@param root string?
+local function clear_status_cache(root)
+  if root then
+    status_cache[root] = nil
+    return
+  end
+  status_cache = {}
+end
+
+local function setup_status_autocmds()
+  if status_augroup then
+    return
+  end
+  status_augroup = vim.api.nvim_create_augroup('forge_status', { clear = true })
+  vim.api.nvim_create_autocmd({ 'DirChanged', 'FocusGained' }, {
+    group = status_augroup,
+    callback = function()
+      clear_status_cache()
+    end,
+  })
+end
+
+---@param root string
+---@param request_id integer
+---@param value forge.Status?
+local function set_status_value(root, request_id, value)
+  local entry = status_cache[root]
+  if not entry or entry.request_id ~= request_id then
+    return
+  end
+  entry.inflight = false
+  entry.updated_at = os.time()
+  local previous = entry.value == false and nil or entry.value
+  local next_value = value
+  entry.value = value or false
+  if not vim.deep_equal(previous, next_value) then
+    emit_status_update()
+  end
+end
+
+---@param root string
+local function refresh_status(root)
+  local entry = status_cache[root] or {}
+  if entry.inflight then
+    return
+  end
+  entry.inflight = true
+  entry.request_id = (entry.request_id or 0) + 1
+  status_cache[root] = entry
+  ---@type integer
+  local request_id = entry.request_id
+  vim.schedule(function()
+    local current = status_cache[root]
+    if not current or current.request_id ~= request_id then
+      return
+    end
+    local forge = detect_at_root(root)
+    if not forge then
+      local branch = target_mod.current_branch({ cwd = root })
+      if branch then
+        set_status_value(root, request_id, { branch = branch })
+      else
+        set_status_value(root, request_id, nil)
+      end
+      return
+    end
+    local head = resolve_mod.head(nil, {
+      forge = forge,
+      target_opts = {
+        cwd = root,
+      },
+    })
+    if not head then
+      local branch = target_mod.current_branch({ cwd = root })
+      if branch then
+        set_status_value(root, request_id, { branch = branch })
+      else
+        set_status_value(root, request_id, nil)
+      end
+      return
+    end
+    local status = {
+      branch = head.branch,
+    }
+    if head.scope then
+      status.scope = head.scope
+    end
+    resolve_mod.current_pr_async({
+      forge = forge,
+      head_branch = head.branch,
+      head_scope = head.scope,
+      target_opts = {
+        cwd = root,
+      },
+    }, function(pr)
+      status.pr = pr
+      set_status_value(root, request_id, status)
+    end)
+  end)
+end
+
 ---@return forge.Forge?
 function M.detect()
   local log = require('forge.logger')
@@ -264,6 +422,7 @@ end
 ---@param scope? forge.Scope
 function M.clear_pr_state(num, scope)
   local root = git_root()
+  clear_status_cache(root)
   if not root then
     pr_state_cache.clear()
     return
@@ -307,12 +466,15 @@ end
 ---@param key string?
 function M.clear_list(key)
   list_cache.clear(key)
+  local root = type(key) == 'string' and key:match('^(.-):') or git_root()
+  clear_status_cache(root)
 end
 
 ---@param kind string
 function M.clear_list_kind(kind)
   local root = git_root() or ''
   list_cache.clear_prefix(root .. ':' .. kind .. ':')
+  clear_status_cache(root ~= '' and root or nil)
 end
 
 function M.clear_cache()
@@ -321,6 +483,28 @@ function M.clear_cache()
   pr_state_cache.clear()
   root_cache = {}
   list_cache.clear()
+  clear_status_cache()
+end
+
+---@return forge.Status?
+function M.status()
+  setup_status_autocmds()
+  local root = git_root()
+  if not root then
+    return nil
+  end
+  local entry = status_cache[root]
+  local stale = not entry or not entry.updated_at or entry.updated_at <= (os.time() - status_ttl)
+  if stale then
+    refresh_status(root)
+    entry = status_cache[root]
+  end
+  if not entry or entry.value == false or entry.value == nil then
+    return nil
+  end
+  local value = entry.value
+  ---@cast value forge.Status
+  return value
 end
 
 ---@param range? { start_line: integer, end_line: integer }

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -27,7 +27,31 @@ local function error_result(message, code)
   }
 end
 
----@param opts forge.CurrentPROpts?
+---@param callback fun(...)
+local function schedule_callback(callback, ...)
+  local count = select('#', ...)
+  local first, second, third, fourth = ...
+  vim.schedule(function()
+    if count == 0 then
+      callback()
+      return
+    end
+    if count == 1 then
+      callback(first)
+      return
+    end
+    if count == 2 then
+      callback(first, second)
+      return
+    end
+    if count == 3 then
+      callback(first, second, third)
+      return
+    end
+    callback(first, second, third, fourth)
+  end)
+end
+
 ---@return forge.Forge?
 local function current_forge(opts)
   if type(opts) == 'table' and type(opts.forge) == 'table' then
@@ -59,7 +83,6 @@ local function scope_kind(value)
   return kind
 end
 
----@param opts forge.CurrentPROpts?
 ---@param forge forge.Forge?
 ---@return forge.ScopeKind?
 local function forge_name(opts, forge)
@@ -219,6 +242,36 @@ local function branch_lookup_states(forge, states)
 end
 
 ---@param forge forge.Forge
+---@param num string
+---@param scope forge.Scope?
+---@param callback fun(json: table?, err: string?)
+local function fetch_pr_json_async(forge, num, scope, callback)
+  vim.system(forge:fetch_pr_details_cmd(num, scope), { text = true }, function(result)
+    if result.code ~= 0 then
+      schedule_callback(
+        callback,
+        nil,
+        system_mod.cmd_error(
+          result,
+          ('failed to fetch %s #%s'):format(forge.labels.pr_one or 'PR', num)
+        )
+      )
+      return
+    end
+    local ok, json = pcall(vim.json.decode, result.stdout or '{}')
+    if not ok or type(json) ~= 'table' then
+      schedule_callback(
+        callback,
+        nil,
+        ('failed to parse %s details'):format(forge.labels.pr_one or 'PR')
+      )
+      return
+    end
+    schedule_callback(callback, json)
+  end)
+end
+
+---@param forge forge.Forge
 ---@param branch string
 ---@param scope forge.Scope?
 ---@param states forge.PRLookupState[]
@@ -242,6 +295,47 @@ local function list_pr_numbers(forge, branch, scope, states)
     end
   end
   return nums
+end
+
+---@param forge forge.Forge
+---@param branch string
+---@param scope forge.Scope?
+---@param states forge.PRLookupState[]
+---@param callback fun(nums: string[]?, err: string?)
+local function list_pr_numbers_async(forge, branch, scope, states, callback)
+  local nums = {}
+  local seen = {}
+  local list_states = branch_lookup_states(forge, states)
+  local index = 1
+  local function step()
+    local list_state = list_states[index]
+    if not list_state then
+      schedule_callback(callback, nums)
+      return
+    end
+    vim.system(forge:pr_for_branch_cmd(branch, scope, list_state), { text = true }, function(result)
+      if result.code ~= 0 then
+        schedule_callback(
+          callback,
+          nil,
+          system_mod.cmd_error(result, ('failed to fetch %s'):format(forge.labels.pr or 'PRs'))
+        )
+        return
+      end
+      for _, line in
+        ipairs(vim.split(result.stdout or '', '\n', { plain = true, trimempty = true }))
+      do
+        local num = trim(line)
+        if num and num ~= 'null' and not seen[num] then
+          seen[num] = true
+          nums[#nums + 1] = num
+        end
+      end
+      index = index + 1
+      step()
+    end)
+  end
+  step()
 end
 
 ---@param head forge.HeadRef
@@ -308,7 +402,7 @@ local function resolve_head(head, opts, kind, parse_opts)
     end
   end
   if not branch then
-    branch = target_mod.current_branch()
+    branch = target_mod.current_branch(parse_opts)
     if not branch then
       return nil, 'detached HEAD'
     end
@@ -402,8 +496,50 @@ local function branch_pr_searches(policy)
   return searches
 end
 
+---@param forge forge.Forge
+---@param head forge.HeadRef
+---@param scope forge.Scope
+---@param states forge.PRLookupState[]
+---@param callback fun(matches: forge.PRRef[]?, err: string?)
+local function matching_prs_async(forge, head, scope, states, callback)
+  list_pr_numbers_async(forge, head.branch, scope, states, function(nums, list_err)
+    if not nums then
+      callback(nil, list_err)
+      return
+    end
+    local matches = {}
+    local index = 1
+    local function step()
+      local num = nums[index]
+      if not num then
+        callback(matches)
+        return
+      end
+      fetch_pr_json_async(forge, num, scope, function(json, fetch_err)
+        if not json then
+          callback(nil, fetch_err)
+          return
+        end
+        local exact, match_err = head_matches(forge, head, pr_head(forge, json, scope))
+        if match_err then
+          callback(nil, match_err)
+          return
+        end
+        if exact and lookup_states_include(states, pr_lookup_state(json)) then
+          matches[#matches + 1] = {
+            num = num,
+            scope = scope,
+          }
+        end
+        index = index + 1
+        step()
+      end)
+    end
+    step()
+  end)
+end
+
 ---@param repo forge.RepoLike?
----@param opts forge.CurrentPROpts?
 ---@return forge.Scope?, forge.CmdError?
 function M.repo(repo, opts)
   opts = opts or {}
@@ -500,6 +636,82 @@ function M.current_pr(opts)
   return M.branch_pr(opts, {
     searches = { { 'open' } },
   })
+end
+
+---@param opts forge.CurrentPROpts?
+---@param callback fun(pr: forge.PRRef?, err: forge.CmdError?)
+function M.current_pr_async(opts, callback)
+  opts = opts or {}
+  local finish = function(pr, err)
+    schedule_callback(callback, pr, err)
+  end
+  local forge = current_forge(opts)
+  if not forge then
+    return finish(error_result('no forge detected', 'no_forge'))
+  end
+  local kind = forge_name(opts, forge)
+  if not kind then
+    return finish(error_result('no forge detected', 'no_forge'))
+  end
+  local parse_opts = target_mod.parse_opts(opts)
+  local head, head_err = resolve_head(opts.head, opts, kind, parse_opts)
+  if not head then
+    return finish(
+      error_result(
+        head_err or 'invalid head',
+        head_err == 'detached HEAD' and 'detached_head' or 'invalid_head'
+      )
+    )
+  end
+  local repos, repo_err, repo_code = candidate_scopes(opts, head, kind, parse_opts)
+  if not repos then
+    return finish(error_result(repo_err or 'invalid repo address', repo_code or 'invalid_repo'))
+  end
+  local searches = branch_pr_searches({
+    searches = { { 'open' } },
+  })
+  local search_index = 1
+  local repo_index = 1
+  local function step()
+    local states = searches[search_index]
+    if not states then
+      finish(nil, nil)
+      return
+    end
+    local scope = repos[repo_index]
+    if not scope then
+      search_index = search_index + 1
+      repo_index = 1
+      step()
+      return
+    end
+    matching_prs_async(forge, head, scope, states, function(matches, match_err)
+      if not matches then
+        finish(nil, {
+          code = 'lookup_failed',
+          message = match_err or 'current PR lookup failed',
+        })
+        return
+      end
+      if #matches == 1 then
+        finish(matches[1], nil)
+        return
+      end
+      if #matches > 1 then
+        finish(nil, {
+          code = 'ambiguous_pr',
+          message = ('multiple %s match head %s; pass repo= or head='):format(
+            forge.labels.pr_full or 'PRs',
+            head_label(head)
+          ),
+        })
+        return
+      end
+      repo_index = repo_index + 1
+      step()
+    end)
+  end
+  step()
 end
 
 return M

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -65,7 +65,12 @@ end
 ---@return boolean
 local function has_parse_opts(opts)
   return type(opts) == 'table'
-    and (opts.resolve_repo ~= nil or opts.aliases ~= nil or opts.default_repo ~= nil)
+    and (
+      opts.resolve_repo ~= nil
+      or opts.aliases ~= nil
+      or opts.default_repo ~= nil
+      or opts.cwd ~= nil
+    )
 end
 
 ---@return forge.TargetParseOpts
@@ -84,10 +89,25 @@ local function config_parse_opts()
   }
 end
 
----@param cmd string[]
+---@param opts table?
 ---@return string?
-local function shell_text(cmd)
-  local result = vim.system(cmd, { text = true }):wait()
+local function parse_cwd(opts)
+  return type(opts) == 'table' and trim(opts.cwd) or nil
+end
+
+---@param cmd string[]
+---@param cwd string?
+---@return string?
+local function shell_text(cmd, cwd)
+  local args = cmd
+  local root = trim(cwd)
+  if root and cmd[1] == 'git' then
+    args = { 'git', '-C', root }
+    for i = 2, #cmd do
+      args[#args + 1] = cmd[i]
+    end
+  end
+  local result = vim.system(args, { text = true }):wait()
   if result.code ~= 0 then
     return nil
   end
@@ -95,17 +115,19 @@ local function shell_text(cmd)
 end
 
 ---@param name string
+---@param cwd string?
 ---@return string?
-local function remote_url(name)
-  return shell_text({ 'git', 'remote', 'get-url', name })
+local function remote_url(name, cwd)
+  return shell_text({ 'git', 'remote', 'get-url', name }, cwd)
 end
 
+---@param cwd string?
 ---@return string?
-local function preferred_remote_name()
-  if remote_url('origin') then
+local function preferred_remote_name(cwd)
+  if remote_url('origin', cwd) then
     return 'origin'
   end
-  local remotes = shell_text({ 'git', 'remote' })
+  local remotes = shell_text({ 'git', 'remote' }, cwd)
   if not remotes then
     return nil
   end
@@ -113,28 +135,29 @@ local function preferred_remote_name()
 end
 
 ---@param branch string?
+---@param cwd string?
 ---@return string?
-local function push_remote_name(branch)
+local function push_remote_name(branch, cwd)
   local value = trim(branch)
   if not value then
-    return preferred_remote_name()
+    return preferred_remote_name(cwd)
   end
-  local branch_remote = shell_text({ 'git', 'config', 'branch.' .. value .. '.pushRemote' })
+  local branch_remote = shell_text({ 'git', 'config', 'branch.' .. value .. '.pushRemote' }, cwd)
   if branch_remote then
     return branch_remote
   end
-  local push_default = shell_text({ 'git', 'config', 'remote.pushDefault' })
+  local push_default = shell_text({ 'git', 'config', 'remote.pushDefault' }, cwd)
   if push_default then
     return push_default
   end
-  local upstream = shell_text({ 'git', 'rev-parse', '--abbrev-ref', value .. '@{upstream}' })
+  local upstream = shell_text({ 'git', 'rev-parse', '--abbrev-ref', value .. '@{upstream}' }, cwd)
   if upstream then
     local remote = upstream:match('^([^/]+)/')
     if remote then
       return remote
     end
   end
-  return preferred_remote_name()
+  return preferred_remote_name(cwd)
 end
 
 ---@param fragment string?
@@ -217,6 +240,7 @@ function M.resolve_repo(text, opts)
     return nil, 'empty repo address'
   end
 
+  local cwd = parse_cwd(opts)
   local aliases = alias_map(opts)
   local alias_target = aliases[value]
   if type(alias_target) == 'string' and alias_target ~= '' then
@@ -224,6 +248,7 @@ function M.resolve_repo(text, opts)
     if remote then
       local resolved, err = M.resolve_repo(remote, {
         aliases = {},
+        cwd = cwd,
       })
       if not resolved then
         return nil, err
@@ -241,7 +266,7 @@ function M.resolve_repo(text, opts)
     return resolved
   end
 
-  local remote = remote_url(value)
+  local remote = remote_url(value, cwd)
   if remote then
     local host, slug = split_url(remote)
     if not host or not slug then
@@ -340,36 +365,40 @@ function M.resolve_scope(value, forge_name, opts)
   return nil
 end
 
+---@param opts table?
 ---@return string?
-function M.current_branch()
-  return shell_text({ 'git', 'branch', '--show-current' })
+function M.current_branch(opts)
+  return shell_text({ 'git', 'branch', '--show-current' }, parse_cwd(opts))
 end
 
 ---@param opts table?
 ---@return forge.RepoTarget?
 function M.current_repo(opts)
-  local remote = preferred_remote_name()
+  local parse_opts = M.parse_opts(opts)
+  local remote = preferred_remote_name(parse_cwd(parse_opts))
   if not remote then
     return nil
   end
-  return M.resolve_repo(remote, M.parse_opts(opts))
+  return M.resolve_repo(remote, parse_opts)
 end
 
 ---@param branch string?
 ---@param opts table?
 ---@return forge.RepoTarget?
 function M.push_repo_for_branch(branch, opts)
-  local remote = push_remote_name(branch)
+  local parse_opts = M.parse_opts(opts)
+  local remote = push_remote_name(branch, parse_cwd(parse_opts))
   if not remote then
     return nil
   end
-  return M.resolve_repo(remote, M.parse_opts(opts))
+  return M.resolve_repo(remote, parse_opts)
 end
 
 ---@param opts table?
 ---@return forge.RepoTarget?
 function M.push_repo(opts)
-  return M.push_repo_for_branch(M.current_branch(), opts)
+  local parse_opts = M.parse_opts(opts)
+  return M.push_repo_for_branch(M.current_branch(parse_opts), parse_opts)
 end
 
 ---@param opts table?
@@ -428,7 +457,8 @@ end
 ---@param opts table?
 ---@return forge.RevTarget?
 function M.current_rev(opts)
-  return M.branch_rev(M.current_branch(), M.current_repo(opts))
+  local parse_opts = M.parse_opts(opts)
+  return M.branch_rev(M.current_branch(parse_opts), M.current_repo(parse_opts))
 end
 
 ---@param branch string?
@@ -449,7 +479,8 @@ end
 ---@param opts table?
 ---@return forge.RevTarget?
 function M.push_rev(opts)
-  return M.push_rev_for_branch(M.current_branch(), opts)
+  local parse_opts = M.parse_opts(opts)
+  return M.push_rev_for_branch(M.current_branch(parse_opts), parse_opts)
 end
 
 ---@param opts table?

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -88,6 +88,11 @@
 ---@field scope forge.Scope?
 ---@field project_id string?
 
+---@class forge.Status
+---@field branch string
+---@field scope forge.Scope?
+---@field pr forge.PRRef?
+
 ---@class forge.IssueRef
 ---@field num string
 ---@field scope forge.Scope?
@@ -127,6 +132,7 @@
 ---@field resolve_repo boolean?
 ---@field aliases table<string, string>?
 ---@field default_repo string?
+---@field cwd string?
 
 ---@class forge.SurfaceOpts
 ---@field forge_name string?

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -1,5 +1,7 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
 package.preload['fzf-lua.utils'] = function()
   return {
     ansi_from_hl = function(_, text)
@@ -205,6 +207,150 @@ describe('pr_state cache', function()
     forge.pr_state(fake, '42', right)
 
     assert.equals(3, calls)
+  end)
+end)
+
+describe('status', function()
+  local old_executable
+  local old_fn_system
+  local old_system
+  local real_github
+  local updates
+
+  local function github_scope(repo)
+    return assert(require('forge.scope').from_url('github', 'https://github.com/owner/' .. repo))
+  end
+
+  before_each(function()
+    old_executable = vim.fn.executable
+    old_fn_system = vim.fn.system
+    old_system = vim.system
+    real_github = require('forge.backends.github')
+    updates = 0
+    local group = vim.api.nvim_create_augroup('forge_status_spec', { clear = true })
+    vim.api.nvim_create_autocmd('User', {
+      group = group,
+      pattern = 'ForgeStatusUpdate',
+      callback = function()
+        updates = updates + 1
+      end,
+    })
+  end)
+
+  after_each(function()
+    vim.fn.executable = old_executable
+    vim.fn.system = old_fn_system
+    vim.system = old_system
+    forge.register('github', real_github)
+    forge.clear_cache()
+    pcall(vim.api.nvim_del_augroup_by_name, 'forge_status_spec')
+  end)
+
+  it('refreshes and caches branch, scope, and current PR', function()
+    local calls = {}
+    forge.register(
+      'github',
+      vim.tbl_extend('force', real_github, {
+        pr_for_branch_cmd = function(_, branch, scope, state)
+          return { 'pr-for-branch', state or 'open', branch, scope and scope.slug or '' }
+        end,
+        fetch_pr_details_cmd = function(_, num, scope)
+          return { 'fetch-pr', num, scope and scope.slug or '' }
+        end,
+      })
+    )
+    vim.fn.executable = function(bin)
+      if bin == 'gh' then
+        return 1
+      end
+      return old_executable(bin)
+    end
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      return ''
+    end
+    vim.system = helpers.system_router({
+      calls = calls,
+      responses = {
+        ['git -C /repo remote get-url origin'] = helpers.command_result(
+          'git@github.com:owner/current.git\n'
+        ),
+        ['git -C /repo branch --show-current'] = helpers.command_result('feature\n'),
+        ['git -C /repo config branch.feature.pushRemote'] = helpers.command_result('fork\n'),
+        ['git -C /repo remote get-url fork'] = helpers.command_result(
+          'git@github.com:owner/fork.git\n'
+        ),
+        ['git -C /repo remote get-url upstream'] = helpers.command_result(
+          'git@github.com:owner/upstream.git\n'
+        ),
+        ['pr-for-branch open feature owner/fork'] = helpers.command_result('\n'),
+        ['pr-for-branch open feature owner/upstream'] = helpers.command_result('42\n'),
+        ['fetch-pr 42 owner/upstream'] = helpers.command_result(vim.json.encode({
+          state = 'OPEN',
+          headRefName = 'feature',
+          headRepository = {
+            name = 'fork',
+            nameWithOwner = 'owner/fork',
+          },
+          headRepositoryOwner = {
+            login = 'owner',
+          },
+        })),
+      },
+      default = helpers.command_result('', 1),
+    })
+
+    assert.is_nil(forge.status())
+    assert.is_true(vim.wait(200, function()
+      return updates > 0 and forge.status() ~= nil
+    end))
+    assert.same({
+      branch = 'feature',
+      scope = github_scope('fork'),
+      pr = {
+        num = '42',
+        scope = github_scope('upstream'),
+      },
+    }, forge.status())
+
+    local before = #calls
+    assert.same({
+      branch = 'feature',
+      scope = github_scope('fork'),
+      pr = {
+        num = '42',
+        scope = github_scope('upstream'),
+      },
+    }, forge.status())
+    assert.equals(before, #calls)
+  end)
+
+  it('falls back to branch-only status when no forge is detected', function()
+    vim.fn.executable = function()
+      return 0
+    end
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      return ''
+    end
+    vim.system = helpers.system_router({
+      responses = {
+        ['git -C /repo remote get-url origin'] = helpers.command_result('', 1),
+        ['git -C /repo branch --show-current'] = helpers.command_result('feature\n'),
+      },
+      default = helpers.command_result('', 1),
+    })
+
+    assert.is_nil(forge.status())
+    assert.is_true(vim.wait(200, function()
+      local status = forge.status()
+      return status and status.branch == 'feature' and status.scope == nil and status.pr == nil
+    end))
+    assert.same({ branch = 'feature' }, forge.status())
   end)
 end)
 

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -332,6 +332,47 @@ describe('current_pr resolver', function()
     )
   end)
 
+  it('resolves current PR relative to an explicit cwd', function()
+    use_system_responses({
+      ['git -C /tmp/worktree branch --show-current'] = helpers.command_result('feature\n'),
+      ['git -C /tmp/worktree config branch.feature.pushRemote'] = helpers.command_result('fork\n'),
+      ['git -C /tmp/worktree remote get-url fork'] = helpers.command_result(
+        'git@github.com:owner/fork.git\n'
+      ),
+      ['git -C /tmp/worktree remote get-url upstream'] = helpers.command_result(
+        'git@github.com:owner/upstream.git\n'
+      ),
+      ['pr-for-branch open feature owner/fork'] = helpers.command_result('\n'),
+      ['pr-for-branch open feature owner/upstream'] = helpers.command_result('42\n'),
+      ['fetch-pr 42 owner/upstream'] = helpers.command_result(vim.json.encode({
+        state = 'OPEN',
+        headRefName = 'feature',
+        headRepository = {
+          name = 'fork',
+          nameWithOwner = 'owner/fork',
+        },
+        headRepositoryOwner = {
+          login = 'owner',
+        },
+      })),
+    })
+
+    local pr, err = require('forge.resolve').current_pr({
+      forge = github,
+      target_opts = {
+        cwd = '/tmp/worktree',
+      },
+    })
+
+    assert.is_nil(err)
+    assert.same({
+      num = '42',
+      scope = github_scope('upstream'),
+    }, pr)
+    assert.is_true(vim.tbl_contains(captured.systems, 'git -C /tmp/worktree branch --show-current'))
+    assert.is_false(vim.tbl_contains(captured.systems, 'git branch --show-current'))
+  end)
+
   it('matches GitLab merge requests by source project and branch', function()
     use_system_responses({
       ['git remote get-url upstream'] = helpers.command_result(

--- a/spec/target_spec.lua
+++ b/spec/target_spec.lua
@@ -198,6 +198,44 @@ describe('target parsing', function()
     assert.equals('owner/fork', rev.repo.slug)
   end)
 
+  it('resolves current push context relative to an explicit cwd', function()
+    vim.system = function(cmd)
+      local key = table.concat(cmd, ' ')
+      if key == 'git -C /tmp/worktree branch --show-current' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'feature\n' }
+          end,
+        }
+      end
+      if key == 'git -C /tmp/worktree config branch.feature.pushRemote' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'fork\n' }
+          end,
+        }
+      end
+      if key == 'git -C /tmp/worktree remote get-url fork' then
+        return {
+          wait = function()
+            return { code = 0, stdout = 'git@github.com:owner/fork.git\n' }
+          end,
+        }
+      end
+      return {
+        wait = function()
+          return { code = 1, stdout = '' }
+        end,
+      }
+    end
+
+    local target = require('forge.target')
+    local rev = assert(target.push_rev({ cwd = '/tmp/worktree' }))
+
+    assert.equals('feature', rev.rev)
+    assert.equals('owner/fork', rev.repo.slug)
+  end)
+
   it('resolves explicit branch push context without consulting the current branch', function()
     vim.system = function(cmd)
       local key = table.concat(cmd, ' ')


### PR DESCRIPTION
## Problem

forge.nvim had no statusline-oriented API for current branch and PR state, so configs had to stitch together branch context and current-PR resolution themselves.

## Solution

Add a cached `forge.status()` helper that resolves branch, head scope, and current PR per worktree root, emits `ForgeStatusUpdate` when the cached value changes, and document the core `vim.o.statusline` integration flow. Cover the new root-aware target and resolver path with focused specs.