### PR TITLE
feat(cmd): align PR completion with branch state (#455)

### DIFF
--- a/lua/forge/availability.lua
+++ b/lua/forge/availability.lua
@@ -15,9 +15,11 @@ local function pr_state(f, entry)
   if not value then
     return nil
   end
-  if value.is_draft ~= nil then
+  if value.review_decision ~= nil or value.is_draft ~= nil or value.mergeable ~= nil then
     return {
-      review_decision = '',
+      state = value.state or '',
+      mergeable = value.mergeable or '',
+      review_decision = value.review_decision or '',
       is_draft = value.is_draft == true,
     }
   end
@@ -41,19 +43,24 @@ function M.pr_can_approve(f, entry)
   return state == nil or (state.review_decision or ''):upper() ~= 'APPROVED'
 end
 
-function M.pr_can_merge(f, entry)
+function M.pr_merge_methods(f, entry)
   if not pr_open(entry) then
-    return false
+    return {}
   end
   local state = pr_state(f, entry)
   if state and state.is_draft then
-    return false
+    return {}
   end
   local value = entry_value(entry)
   local info = require('forge').repo_info(f, value and value.scope or nil)
-  return merge_permission(info)
-    and type((info or {}).merge_methods) == 'table'
-    and #info.merge_methods > 0
+  if not merge_permission(info) or type((info or {}).merge_methods) ~= 'table' then
+    return {}
+  end
+  return info.merge_methods
+end
+
+function M.pr_can_merge(f, entry)
+  return #M.pr_merge_methods(f, entry) > 0
 end
 
 function M.pr_can_toggle_draft(f, entry)

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1089,6 +1089,9 @@ function M.run(opts)
   return M.dispatch(command)
 end
 
+---@param command forge.Command
+---@param args string[]
+---@return forge.CommandCompletionState
 local function completion_state(command, args)
   local state = {
     subjects = {},
@@ -1402,6 +1405,192 @@ local function completion_entry(value)
   return { value = value }
 end
 
+---@param value string?
+---@param forge_name forge.ScopeKind
+---@return forge.Scope?
+local function completion_repo_scope(value, forge_name)
+  if type(value) ~= 'string' or value == '' then
+    return nil
+  end
+  return require('forge.target').resolve_scope(value, forge_name, target_parse_opts())
+end
+
+---@param value forge.RepoLike?
+---@return forge.Scope?
+local function completion_repo_like_scope(value)
+  if type(value) ~= 'table' or value.kind == 'repo' then
+    return nil
+  end
+  ---@cast value forge.Scope
+  return value
+end
+
+---@param value string?
+---@return forge.RevTarget?
+local function completion_head(value)
+  if type(value) ~= 'string' or value == '' then
+    return nil
+  end
+  return require('forge.target').parse_rev(value, target_parse_opts())
+end
+
+---@param state forge.CommandCompletionState
+---@param f forge.Forge
+---@param include_head boolean?
+---@return forge.CurrentPROpts?
+local function completion_current_pr_opts(state, f, include_head)
+  local opts = {
+    forge = f,
+  }
+  if state.modifiers.repo ~= nil then
+    local scope = completion_repo_scope(state.modifiers.repo, f.name)
+    if not scope then
+      return nil
+    end
+    opts.repo = scope
+  end
+  if include_head ~= false and state.modifiers.head ~= nil then
+    local head = completion_head(state.modifiers.head)
+    if not head then
+      return nil
+    end
+    opts.head = head
+  end
+  return opts
+end
+
+---@param pr forge.PRRef
+---@param state string
+---@param pr_state forge.PRState?
+---@return forge.PickerEntry
+local function pr_completion_entry(pr, state, pr_state)
+  ---@type forge.PRCompletionValue
+  local value = {
+    num = pr.num,
+    scope = pr.scope,
+    state = state,
+  }
+  if type(pr_state) == 'table' then
+    value.is_draft = pr_state.is_draft
+    value.review_decision = pr_state.review_decision
+    value.mergeable = pr_state.mergeable
+  end
+  return completion_entry(value)
+end
+
+---@param state forge.CommandCompletionState
+---@return forge.PRCompletionTarget?
+local function implicit_pr_completion_target(state)
+  local forge_mod = require('forge')
+  local f = forge_mod.detect()
+  if not f then
+    return nil
+  end
+  local opts = completion_current_pr_opts(state, f)
+  if not opts then
+    return nil
+  end
+  local pr, err = forge_mod.current_pr(opts)
+  if err then
+    return nil
+  end
+  if pr then
+    local pr_state = forge_mod.pr_state(f, pr.num, pr.scope)
+    local state_name = type(pr_state) == 'table' and pr_state.state or nil
+    return {
+      forge = f,
+      entry = pr_completion_entry(pr, state_name or 'OPEN', pr_state),
+    }
+  end
+  pr, err = require('forge.resolve').branch_pr(opts, {
+    searches = { { 'closed' } },
+  })
+  if err then
+    return nil
+  end
+  if pr then
+    return {
+      forge = f,
+      entry = pr_completion_entry(pr, 'CLOSED'),
+    }
+  end
+  pr, err = require('forge.resolve').branch_pr(opts, {
+    searches = { { 'merged' } },
+  })
+  if err then
+    return nil
+  end
+  if pr then
+    return {
+      forge = f,
+      entry = pr_completion_entry(pr, 'MERGED'),
+    }
+  end
+  return nil
+end
+
+---@param command forge.Command
+---@param state forge.CommandCompletionState
+---@return forge.PRCompletionTarget?
+local function merge_method_completion_target(command, state)
+  if command.family ~= 'pr' or command.name ~= 'merge' then
+    return nil
+  end
+  local forge_mod = require('forge')
+  local f = forge_mod.detect()
+  if not f then
+    return nil
+  end
+  local opts = completion_current_pr_opts(state, f, false)
+  if not opts then
+    return nil
+  end
+  local num = state.subjects[1]
+  if num then
+    local scope = completion_repo_like_scope(opts.repo)
+    local pr_state = forge_mod.pr_state(f, num, scope)
+    local state_name = type(pr_state) == 'table' and pr_state.state or nil
+    return {
+      forge = f,
+      entry = pr_completion_entry({ num = num, scope = scope }, state_name or 'OPEN', pr_state),
+    }
+  end
+  local pr, err = forge_mod.current_pr(opts)
+  if err or not pr then
+    return nil
+  end
+  local pr_state = forge_mod.pr_state(f, pr.num, pr.scope)
+  local state_name = type(pr_state) == 'table' and pr_state.state or nil
+  return {
+    forge = f,
+    entry = pr_completion_entry(pr, state_name or 'OPEN', pr_state),
+  }
+end
+
+---@param command forge.Command?
+---@param state forge.CommandCompletionState
+---@param values string[]
+---@return string[]
+local function filter_family_verb_completion_items(command, state, values)
+  if not command then
+    return values
+  end
+  local items = {}
+  local target = nil
+  if command.family == 'pr' and command.name == 'open' then
+    target = implicit_pr_completion_target(state)
+  end
+  local policy = require('forge.completion_policy')
+  for _, value in ipairs(values) do
+    local forge = target and target.forge or nil
+    local entry = target and target.entry or nil
+    if policy.verb(command, value, forge, entry) then
+      items[#items + 1] = value
+    end
+  end
+  return items
+end
+
 local function complete_pr_subjects(command, state, prefix, policy)
   local f, forge_mod, scope = completion_forge(state)
   if not f or not forge_mod then
@@ -1482,12 +1671,9 @@ local function complete_release_subjects(state, prefix, policy)
   return filter(items, prefix)
 end
 
----@param opts? forge.SurfaceOpts
-local function completion_values(family_name, verb_name, flag_name, prefix, opts)
-  local command = M.resolve(family_name, verb_name, opts)
-  if not command then
-    return nil
-  end
+---@param command forge.Command
+---@param state forge.CommandCompletionState
+local function completion_values(command, state, flag_name, prefix)
   local spec = modifiers[flag_name]
   local policy = require('forge.completion_policy').modifier_value(command, flag_name, spec)
   if not policy then
@@ -1510,6 +1696,16 @@ local function completion_values(family_name, verb_name, flag_name, prefix, opts
   end
   if policy.source == 'adapter' then
     return filter(require('forge').review_adapter_names(), prefix or '')
+  end
+  if policy.source == 'available_merge_methods' then
+    local target = merge_method_completion_target(command, state)
+    if not target then
+      return filter(spec.values, prefix or '')
+    end
+    return filter(
+      require('forge.availability').pr_merge_methods(target.forge, target.entry),
+      prefix or ''
+    )
   end
   if policy.source == 'command_values' then
     return filter(command.modifier_values[flag_name], prefix or '')
@@ -1576,11 +1772,21 @@ function M.complete(arglead, cmdline, _)
 
   local flag, value_prefix = arglead:match('^([%w%-_]+)=(.*)$')
   if flag then
-    local values = completion_values(family_name, explicit_verb, flag, value_prefix, surface_opts)
-    if values then
-      return vim.tbl_map(function(v)
-        return flag .. '=' .. v
-      end, values)
+    local command = M.resolve(family_name, explicit_verb, surface_opts)
+    if command then
+      command.declared_modifiers = command.modifiers or {}
+      local rest_index = explicit_verb and 4 or 3
+      local consumed = {}
+      for i = rest_index, #words - 1 do
+        consumed[#consumed + 1] = words[i]
+      end
+      local state = completion_state(command, consumed)
+      local values = completion_values(command, state, flag, value_prefix)
+      if values then
+        return vim.tbl_map(function(v)
+          return flag .. '=' .. v
+        end, values)
+      end
     end
   end
   if arg_idx == 1 then
@@ -1601,7 +1807,15 @@ function M.complete(arglead, cmdline, _)
     local slot_policy = require('forge.completion_policy').family_slot(command)
     local candidates = {}
     if slot_policy.include_verbs then
-      for _, verb in ipairs(M.verb_names(family_name, surface_opts)) do
+      for _, verb in
+        ipairs(
+          filter_family_verb_completion_items(
+            command,
+            state,
+            M.verb_names(family_name, surface_opts)
+          )
+        )
+      do
         candidates[#candidates + 1] = verb
       end
     end

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -3,6 +3,15 @@ local M = {}
 local availability = require('forge.availability')
 local picker = require('forge.picker')
 
+local implicit_pr_completion_verbs = {
+  approve = true,
+  merge = true,
+  close = true,
+  draft = true,
+  ready = true,
+  reopen = true,
+}
+
 local function pr_completion_available(verb, f, entry)
   if verb == 'approve' then
     return availability.pr_can_approve(f, entry)
@@ -98,6 +107,18 @@ function M.argument_slot(command, state)
     include_subjects = command ~= nil,
     static_before_dynamic = true,
   }
+end
+
+function M.verb(command, verb, f, entry)
+  if
+    type(command) == 'table'
+    and command.family == 'pr'
+    and command.name == 'open'
+    and implicit_pr_completion_verbs[verb]
+  then
+    return entry ~= nil and pr_completion_available(verb, f, entry)
+  end
+  return true
 end
 
 function M.subject(command)
@@ -208,6 +229,14 @@ function M.modifier_value(command, flag_name, spec)
       cmdline_usefulness = 'local_only',
       allow_empty_prefix = true,
       source = 'adapter',
+    }
+  end
+  if command.family == 'pr' and command.name == 'merge' and flag_name == 'method' then
+    return {
+      slot_class = 'modifier_value',
+      cmdline_usefulness = 'dynamic_allowed',
+      allow_empty_prefix = true,
+      source = 'available_merge_methods',
     }
   end
   if command.modifier_values and command.modifier_values[flag_name] then

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -207,6 +207,22 @@
 ---@field default_targets table
 ---@field range { start_line: integer, end_line: integer }?
 
+---@class forge.CommandCompletionState
+---@field subjects string[]
+---@field modifiers table<string, string>
+
+---@class forge.PRCompletionValue
+---@field num string
+---@field scope forge.Scope?
+---@field state string
+---@field is_draft boolean?
+---@field review_decision string?
+---@field mergeable string?
+
+---@class forge.PRCompletionTarget
+---@field forge forge.Forge
+---@field entry forge.PickerEntry
+
 ---@class forge.Context
 ---@field id string
 ---@field root string

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -148,6 +148,12 @@ describe(':Forge command', function()
       return {
         branch_pr = function(opts, policy)
           table.insert(captured.branch_pr_calls, { opts = opts, policy = policy })
+          if type(captured.branch_pr_result) == 'function' then
+            return captured.branch_pr_result(opts, policy)
+          end
+          if type(captured.branch_pr_error) == 'function' then
+            return nil, captured.branch_pr_error(opts, policy)
+          end
           return captured.branch_pr_result, captured.branch_pr_error
         end,
       }
@@ -1449,14 +1455,8 @@ describe(':Forge command', function()
           'open',
           'browse',
           'ci',
-          'close',
-          'reopen',
           'create',
           'edit',
-          'approve',
-          'merge',
-          'draft',
-          'ready',
           'refresh',
           'repo=',
           'head=',
@@ -1540,10 +1540,12 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(pr, 'open'))
     assert.is_true(vim.tbl_contains(pr, 'ci'))
     assert.is_true(vim.tbl_contains(pr, 'create'))
-    assert.is_true(vim.tbl_contains(pr, 'approve'))
-    assert.is_true(vim.tbl_contains(pr, 'merge'))
-    assert.is_true(vim.tbl_contains(pr, 'draft'))
-    assert.is_true(vim.tbl_contains(pr, 'ready'))
+    assert.is_false(vim.tbl_contains(pr, 'approve'))
+    assert.is_false(vim.tbl_contains(pr, 'merge'))
+    assert.is_false(vim.tbl_contains(pr, 'draft'))
+    assert.is_false(vim.tbl_contains(pr, 'ready'))
+    assert.is_false(vim.tbl_contains(pr, 'close'))
+    assert.is_false(vim.tbl_contains(pr, 'reopen'))
     assert.is_true(vim.tbl_contains(pr, 'refresh'))
     assert.is_true(vim.tbl_contains(pr, 'repo='))
     assert.is_true(vim.tbl_contains(pr, 'head='))
@@ -1583,6 +1585,99 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(issue_create, 'head='))
   end)
 
+  it('filters bare pr verb completion for an open non-draft branch PR', function()
+    captured.current_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+    captured.pr_states['owner/upstream#42'] = {
+      state = 'OPEN',
+      review_decision = '',
+      is_draft = false,
+    }
+    captured.repo_infos['owner/upstream'] = {
+      permission = 'WRITE',
+      merge_methods = { 'merge', 'squash' },
+    }
+
+    local pr = completion('Forge pr ')
+
+    assert.is_true(vim.tbl_contains(pr, 'approve'))
+    assert.is_true(vim.tbl_contains(pr, 'merge'))
+    assert.is_true(vim.tbl_contains(pr, 'close'))
+    assert.is_true(vim.tbl_contains(pr, 'draft'))
+    assert.is_false(vim.tbl_contains(pr, 'ready'))
+    assert.is_false(vim.tbl_contains(pr, 'reopen'))
+    assert.equals(1, #captured.current_pr_calls)
+    assert.same({}, captured.branch_pr_calls)
+  end)
+
+  it('filters bare pr verb completion for an open draft branch PR', function()
+    captured.current_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+    captured.pr_states['owner/upstream#42'] = {
+      state = 'OPEN',
+      review_decision = '',
+      is_draft = true,
+    }
+    captured.repo_infos['owner/upstream'] = {
+      permission = 'WRITE',
+      merge_methods = { 'merge', 'squash' },
+    }
+
+    local pr = completion('Forge pr ')
+
+    assert.is_true(vim.tbl_contains(pr, 'approve'))
+    assert.is_true(vim.tbl_contains(pr, 'close'))
+    assert.is_true(vim.tbl_contains(pr, 'ready'))
+    assert.is_false(vim.tbl_contains(pr, 'merge'))
+    assert.is_false(vim.tbl_contains(pr, 'draft'))
+    assert.is_false(vim.tbl_contains(pr, 'reopen'))
+  end)
+
+  it('filters bare pr verb completion for a closed branch PR', function()
+    captured.branch_pr_result = function(_, policy)
+      local state = policy and policy.searches and policy.searches[1] and policy.searches[1][1]
+        or nil
+      if state == 'closed' then
+        return {
+          num = '42',
+          scope = repo_scope('upstream'),
+        }
+      end
+      return nil
+    end
+
+    local pr = completion('Forge pr ')
+
+    assert.is_true(vim.tbl_contains(pr, 'reopen'))
+    assert.is_false(vim.tbl_contains(pr, 'approve'))
+    assert.is_false(vim.tbl_contains(pr, 'merge'))
+    assert.is_false(vim.tbl_contains(pr, 'close'))
+    assert.is_false(vim.tbl_contains(pr, 'draft'))
+    assert.is_false(vim.tbl_contains(pr, 'ready'))
+    assert.equals(1, #captured.current_pr_calls)
+    assert.equals(1, #captured.branch_pr_calls)
+    assert.same({ { 'closed' } }, captured.branch_pr_calls[1].policy.searches)
+  end)
+
+  it('suppresses implicit current-pr action verbs when branch completion is ambiguous', function()
+    captured.current_pr_error = {
+      code = 'ambiguous_pr',
+      message = 'multiple PRs match head owner/current@main; pass repo= or head=',
+    }
+
+    local pr = completion('Forge pr ')
+
+    for _, verb in ipairs({ 'approve', 'merge', 'close', 'draft', 'ready', 'reopen' }) do
+      assert.is_false(vim.tbl_contains(pr, verb))
+    end
+    assert.is_true(vim.tbl_contains(pr, 'repo='))
+    assert.is_true(vim.tbl_contains(pr, 'head='))
+  end)
+
   it('completes GitLab family aliases contextually', function()
     detected_forge_name = 'gitlab'
 
@@ -1598,14 +1693,8 @@ describe(':Forge command', function()
       'open',
       'browse',
       'ci',
-      'close',
-      'reopen',
       'create',
       'edit',
-      'approve',
-      'merge',
-      'draft',
-      'ready',
       'refresh',
       'repo=',
       'head=',
@@ -1689,6 +1778,40 @@ describe(':Forge command', function()
       )
     end
   )
+
+  it('filters implicit merge method completion through repo-supported merge methods', function()
+    captured.current_pr_result = {
+      num = '42',
+      scope = repo_scope('upstream'),
+    }
+    captured.pr_states['owner/upstream#42'] = {
+      state = 'OPEN',
+      review_decision = '',
+      is_draft = false,
+    }
+    captured.repo_infos['owner/upstream'] = {
+      permission = 'WRITE',
+      merge_methods = { 'squash' },
+    }
+
+    assert.same({ 'method=squash' }, completion('Forge pr merge method='))
+    assert.equals(1, #captured.current_pr_calls)
+  end)
+
+  it('filters explicit merge method completion through the targeted repo info', function()
+    captured.pr_states['owner/upstream#42'] = {
+      state = 'OPEN',
+      review_decision = '',
+      is_draft = false,
+    }
+    captured.repo_infos['owner/upstream'] = {
+      permission = 'WRITE',
+      merge_methods = { 'rebase' },
+    }
+
+    assert.same({ 'method=rebase' }, completion('Forge pr merge 42 repo=upstream method='))
+    assert.same({}, captured.current_pr_calls)
+  end)
 
   it('completes registered review adapters for adapter=', function()
     extra_review_adapters = { 'custom-test-review' }

--- a/spec/completion_policy_spec.lua
+++ b/spec/completion_policy_spec.lua
@@ -118,6 +118,18 @@ describe('forge.completion_policy', function()
     ))
   end)
 
+  it('filters implicit PR family verbs through picker-aligned availability helpers', function()
+    local command = { family = 'pr', name = 'open' }
+
+    assert.is_true(policy.verb(command, 'browse', {}, nil))
+    assert.is_false(policy.verb(command, 'merge', {}, nil))
+    assert.is_true(policy.verb(command, 'merge', {}, { value = { merge = true } }))
+    assert.is_false(policy.verb(command, 'merge', {}, { value = { merge = false } }))
+    assert.is_true(policy.verb(command, 'close', {}, { value = { pr_toggle = 'close' } }))
+    assert.is_true(policy.verb(command, 'reopen', {}, { value = { pr_toggle = 'reopen' } }))
+    assert.is_false(policy.verb(command, 'reopen', {}, { value = { pr_toggle = 'close' } }))
+  end)
+
   it('classifies numeric subject suppression and release cache preferences', function()
     local merge = policy.subject({ name = 'merge', subject = { kind = 'pr' } })
     local reopen = policy.subject({ name = 'reopen', subject = { kind = 'pr' } })
@@ -232,6 +244,20 @@ describe('forge.completion_policy', function()
       allow_empty_prefix = true,
       source = 'command_values',
     }, policy.modifier_value(command, 'state'))
+
+    assert.same(
+      {
+        slot_class = 'modifier_value',
+        cmdline_usefulness = 'dynamic_allowed',
+        allow_empty_prefix = true,
+        source = 'available_merge_methods',
+      },
+      policy.modifier_value(
+        { family = 'pr', name = 'merge', modifiers = { 'method' } },
+        'method',
+        { values = { 'merge', 'squash', 'rebase' } }
+      )
+    )
 
     assert.same({
       slot_class = 'modifier_value',


### PR DESCRIPTION
## Problem

Implicit `:Forge pr`/`:Forge mr` completion and `method=` suggestions were static, so they could offer verbs or merge methods that do not match the current branch PR state or targeted repo.

## Solution

Resolve completion targets through the shared current/branch PR helpers, filter stateful verbs through shared availability rules, and restrict `method=` values to the targeted repo's supported merge methods with specs covering open, draft, closed, and ambiguous cases.
