### PR TITLE
refactor(surface): separate direct and interactive entrypoints (#463)

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -336,9 +336,12 @@ Top-level keys: ~
 COMMANDS                                                              *:Forge*
 
 `:Forge`                                                      *:Forge-no-args*
-    The `:Forge` command surface is action-oriented. It does not open picker
-    UIs. `:Forge` with no arguments warns with `missing command`.
-    Use `require('forge').open()` for the interactive picker surface.
+    The `:Forge` command surface is the direct-action side of the plugin.
+    Most commands resolve into deterministic actions or deterministic UI
+    entrypoints rather than list navigation or picker control flow. `:Forge`
+    with no arguments warns with `missing command`.
+    Use `require('forge').open()` for the interactive route and picker
+    surface.
     Direct commands cover explicit forge actions with stable targets such as
     PR/issue/release numbers, tags, and CI run ids, plus current-ref actions
     rooted in the current branch such as bare `:Forge pr`, `:Forge review`,
@@ -388,6 +391,35 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     through `:Forge`; use the interactive picker surface instead.
     This includes list navigation, list-scoped filters/refresh, CI
     cancel/rerun toggles, nested per-PR checks, and copy helpers.
+
+SURFACE TAXONOMY                                          *forge-surface-model*
+
+The user-facing surface is organized into three layers:
+
+1. Deterministic core
+   - Direct command and helper entrypoints
+   - Explicit targets or current-ref resolution
+   - No list navigation or picker-specific control flow
+
+2. Deterministic UI
+   - Buffers, browser opens, review adapters, CI log/summary views
+   - Still entered through a direct action rather than picker navigation
+
+3. Interactive route/picker
+   - `require('forge').open(route?, opts?)`
+   - `require('forge.picker').pick(opts)`
+   - Root sections, list routes, filters, load-more, nested picker actions
+
+Today, most Ex commands and top-level Lua helpers stay on the deterministic
+side of that boundary. The remaining CI helpers still bridge into the
+interactive layer:
+- `:Forge pr ci`
+- `:Forge ci`
+- `require('forge').pr_ci(opts?)`
+- `require('forge').ci(opts?)`
+
+Those entrypoints are still classified as interactive route/picker workflows
+for now even though they use current-ref targeting.
 
 PR COMMANDS                                                *forge-pr-commands*
 
@@ -1091,18 +1123,19 @@ Lua surfaces exist at several layers:
 
 MENTAL MODEL                                           *forge-extending-model*
 
-The canonical order is:
-1. `require('forge').open(route)` for built-in route and picker flows.
-2. `require('forge').pr()`, `review()`, `pr_ci()`, and `ci()` for common
-   current-ref actions.
-3. `require('forge').current_pr(opts?)` when you need the resolved PR ref
-   without running an action.
-4. `require('forge.picker').pick()` for custom picker UIs.
+Choose the surface by workflow type instead of by call depth:
+1. Deterministic core and deterministic UI:
+   `require('forge').pr()`, `review()`, `create_pr()`, `create_issue()`,
+   `edit_issue()`, `current_pr(opts?)`, and `status()`
+2. Interactive built-in workflows:
+   `require('forge').open(route?, opts?)`
+3. Custom interactive UIs:
+   `require('forge.picker').pick()`
 
-Routes are still the highest-level and most stable surface. The top-level
-current-ref helpers mirror the Ex command semantics, including explicit
-`num=` targeting for PR actions. `forge.picker.pick()` is the low-level UI
-primitive wired to `fzf-lua`.
+The top-level current-ref helpers mirror the Ex command semantics, including
+explicit `num=` targeting for PR actions. `require('forge').open()` is the
+entrypoint for built-in route and picker flows. `forge.picker.pick()` is the
+low-level UI primitive wired to `fzf-lua`.
 On GitLab, route arguments also accept provider-native aliases such as `mrs`,
 `mrs.open`, `pipelines`, and `pipelines.current_branch`.
 
@@ -1118,8 +1151,8 @@ built-in forge route and its action set.
 
 CALLING THE TOP-LEVEL API                             *forge-extending-verbs*
 
-For common current-ref workflows, call `require('forge')` directly. These
-helpers mirror the Ex surface and reuse the shared resolver layer. >lua
+For common direct workflows, call `require('forge')` directly. These helpers
+mirror the Ex surface and reuse the shared resolver layer. >lua
     local forge = require('forge')
     forge.pr()
     forge.pr({ num = '42' })
@@ -1130,9 +1163,14 @@ helpers mirror the Ex surface and reuse the shared resolver layer. >lua
     forge.ci({ repo = 'upstream' })
 <
 
-Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua` power
-the built-in commands and pickers, but they are no longer documented as the
-public integration surface.
+`pr_ci()` and `ci()` still currently enter the interactive CI/checks layer
+even though they use current-ref resolution. They remain top-level helpers
+because they mirror the command surface, but they are not part of the
+deterministic contract yet.
+
+Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua`
+power the built-in commands and pickers, but they are not the public
+integration surface.
 
 STATUSLINE INTEGRATION                                  *forge-statusline*
 
@@ -1202,21 +1240,23 @@ The help file does not mirror every exported helper. Canonical signatures and
 contracts live in the source:
 
   Surface                    Canonical file                  Use case ~
-  `require('forge')`         `lua/forge/init.lua`            routes, high-level
-                                                            current-ref helpers,
+  `require('forge')`         `lua/forge/init.lua`            deterministic helpers,
+                                                            built-in routes,
                                                             and extension hooks
   `require('forge.picker')`  `lua/forge/picker/init.lua`     custom picker UI
   `forge.Forge` / shared     `lua/forge/types.lua`           backend and shared
                                                             contracts
 
 Most integrations only need one of these entrypoints:
-- `require('forge').open(route?, opts?)`
-- `require('forge').pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`, `ci(opts?)`
-- `require('forge').current_pr(opts?)`
-- `require('forge').status()`
-- `require('forge').create_pr(opts?)`, `create_issue(opts?)`
-- `require('forge.picker').pick(opts)`
-- `require('forge').register(name, source)`
+- Deterministic helpers:
+  `require('forge').pr(opts?)`, `review(opts?)`, `edit_issue(num, scope?)`,
+  `current_pr(opts?)`, `status()`, `create_pr(opts?)`, `create_issue(opts?)`
+- Interactive built-in routes:
+  `require('forge').open(route?, opts?)`
+- Interactive picker primitive:
+  `require('forge.picker').pick(opts)`
+- Extension registration:
+  `require('forge').register(name, source)`
 
 Advanced registration helpers such as `register_context_provider()`,
 `register_action()`, and `register_review_adapter()` live in
@@ -1226,14 +1266,13 @@ TOP-LEVEL API: `require('forge')` ~                     *forge-top-level-api*
 
 The canonical user-facing Lua surface lives in `lua/forge/init.lua`.
 Prefer these helpers for normal integrations:
-- `open(route?, opts?)` for built-in routes
-- `pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`, and `ci(opts?)` for current-ref
-  workflows
+- `pr(opts?)`, `review(opts?)`, `edit_issue(num, scope?)`,
+  `current_pr(opts?)`, `status()`, `create_pr(opts?)`, and
+  `create_issue(opts?)` for deterministic integrations
+- `open(route?, opts?)` for built-in interactive routes
+- `pr_ci(opts?)` and `ci(opts?)` for the current interactive CI/checks helpers
 - `pr({ num = '42' })`, `review({ num = '42' })`, and `pr_ci({ num = '42' })`
   for explicit PR targeting
-- `current_pr(opts?)` when you need the resolved PR ref
-- `status()` when you need cached branch/current-PR UI state
-- `create_pr(opts?)` and `create_issue(opts?)` for create flows
 
 `create_pr()` is create-only: if the current branch already has an open PR, it
 warns instead of redirecting into edit.
@@ -1247,7 +1286,7 @@ For the implicit-ref rollout:
 - `:Forge pr create` and `require('forge').create_pr()` are create-only.
 - `edit_pr()` is removed; use `pr({ num = '42' })` instead.
 - Prefer `require('forge').pr()`, `review()`, `pr_ci()`, `ci()`, and
-  `current_pr()` over internal verb modules for common workflows.
+  `current_pr()` over internal modules for common workflows.
 
 PUBLIC API: `require('forge.picker')` ~                     *forge-picker-api*
 

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -463,11 +463,12 @@ local function dispatch_pr(command)
   local num = command.subjects[1]
   if command.name == 'create' then
     local target = require('forge.target')
+    local forge_mod = require('forge')
     local parse_opts = target_parse_opts()
     local head = command.parsed_modifiers.head or command.default_targets.head
     local base = command.parsed_modifiers.base or command.default_targets.base
     local scope = resolve_repo_modifier(command, f.name)
-    ops.pr_create({
+    forge_mod.create_pr({
       draft = command.modifiers.draft == true,
       instant = command.modifiers.fill == true,
       web = command.modifiers.web == true,
@@ -622,7 +623,7 @@ local function dispatch_issue(command)
   local scope = resolve_repo_modifier(command, f.name)
   if command.name == 'create' then
     local template = command.modifiers.template
-    ops.issue_create({
+    require('forge').create_issue({
       web = command.modifiers.web == true,
       blank = command.modifiers.blank == true,
       template = template ~= true and template or nil,
@@ -733,6 +734,7 @@ local function dispatch_browse(command)
   end
   local scope = resolve_scope_modifier(command, f.name)
   local subject = command.subjects[1]
+  local forge_mod = require('forge')
   if subject then
     ops.browse_subject(f, { num = subject, scope = scope })
     return
@@ -744,19 +746,19 @@ local function dispatch_browse(command)
   end
   local commit = command.parsed_modifiers.commit
   if commit and commit.commit then
-    ops.browse_commit({ commit = commit.commit, scope = scope })
+    forge_mod.open('browse.commit', { commit = commit.commit, scope = scope })
     return
   end
   local branch = command.parsed_modifiers.branch
-  local file_loc = require('forge').file_loc(command.range)
+  local file_loc = forge_mod.file_loc(command.range)
   if branch and branch.branch then
     if ops.browse_file(f, file_loc, branch.branch, scope) then
       return
     end
-    ops.browse_branch(branch.branch, { scope = scope })
+    forge_mod.open('browse.branch', { branch = branch.branch, scope = scope })
     return
   end
-  local ctx = require('forge').current_context()
+  local ctx = forge_mod.current_context()
   local ctx_branch = type(ctx) == 'table' and ctx.branch or nil
   if ops.browse_file(f, file_loc, ctx_branch, scope) then
     return

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -864,7 +864,8 @@ function M.ci(opts)
   if not head then
     return
   end
-  require('forge.ops').ci_list(head.branch, {
+  M.open('ci.current_branch', {
+    branch = head.branch,
     scope = head.scope,
   })
 end

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -185,17 +185,6 @@ local function location_arg(location)
   return ('%s:%d-%d'):format(location.path, range.start_line, range.end_line)
 end
 
----@param state? 'open'|'closed'|'all'
----@param opts? forge.PickerBackOpts
-function M.pr_list(state, opts)
-  require('forge').open(state and ('prs.' .. state) or 'prs', opts)
-end
-
----@param opts? forge.CreatePROpts
-function M.pr_create(opts)
-  require('forge').create_pr(opts)
-end
-
 ---@param pr forge.PRRefLike
 ---@param f forge.Forge?
 function M.pr_edit(pr, f)
@@ -337,17 +326,6 @@ function M.pr_browse(f, pr)
   f:view_web(f.kinds.pr, pr.num, pr.scope)
 end
 
----@param state? 'open'|'closed'|'all'
----@param opts? forge.PickerBackOpts
-function M.issue_list(state, opts)
-  require('forge').open(state and ('issues.' .. state) or 'issues', opts)
-end
-
----@param opts? forge.CreateIssueOpts
-function M.issue_create(opts)
-  require('forge').create_issue(opts)
-end
-
 ---@param issue forge.IssueRefLike
 ---@param f forge.Forge?
 function M.issue_edit(issue, f)
@@ -410,13 +388,6 @@ function M.issue_reopen(f, issue, opts)
     'reopen failed',
     opts
   )
-end
-
----@param branch string?
----@param opts? forge.PickerBackOpts
-function M.ci_list(branch, opts)
-  opts = vim.tbl_extend('force', opts or {}, { branch = branch })
-  require('forge').open(branch == nil and 'ci.all' or 'ci.current_branch', opts)
 end
 
 ---@param f forge.Forge
@@ -661,12 +632,6 @@ function M.ci_toggle(f, run, opts)
   end
 end
 
----@param state? 'all'|'draft'|'prerelease'
----@param opts? forge.PickerBackOpts
-function M.release_list(state, opts)
-  require('forge').open(state and ('releases.' .. state) or 'releases', opts)
-end
-
 ---@param f forge.Forge
 ---@param release forge.ReleaseRefLike
 function M.release_browse(f, release)
@@ -717,11 +682,6 @@ function M.browse_subject(f, ref)
   f:browse_subject(ref.num, ref.scope)
 end
 
----@param opts? { commit?: string, scope?: forge.Scope }
-function M.browse_commit(opts)
-  require('forge').open('browse.commit', opts)
-end
-
 ---@param opts? forge.ScopedOpts
 ---@return boolean
 function M.browse_repo(opts)
@@ -732,17 +692,6 @@ function M.browse_repo(opts)
   end
   vim.ui.open(url)
   return true
-end
-
----@param branch string?
----@param opts? forge.RouteOpts
-function M.browse_branch(branch, opts)
-  require('forge').open('browse.branch', vim.tbl_extend('force', opts or {}, { branch = branch }))
-end
-
----@param opts? forge.RouteOpts
-function M.browse_contextual(opts)
-  require('forge').open('browse.contextual', opts)
 end
 
 ---@param f forge.Forge

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -1410,7 +1410,7 @@ function M.pr(state, f, opts)
       label = 'create',
       available = pr_create_visible,
       fn = function()
-        ops.pr_create({ back = opts.back, scope = ref })
+        forge_mod.create_pr({ back = opts.back, scope = ref })
       end,
     },
     {
@@ -1830,7 +1830,7 @@ function M.issue(state, f, opts)
       name = 'create',
       label = 'create',
       fn = function()
-        ops.issue_create({ back = opts.back, scope = ref })
+        forge_mod.create_issue({ back = opts.back, scope = ref })
       end,
     },
     {

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -53,6 +53,7 @@ describe('high-level implicit-ref API', function()
       head_error = nil,
       head_result = nil,
       infos = {},
+      opens = {},
       ops_calls = {},
       repo_calls = {},
       repo_error = nil,
@@ -162,9 +163,6 @@ describe('high-level implicit-ref API', function()
 
     package.preload['forge.ops'] = function()
       return {
-        ci_list = function(branch, opts)
-          table.insert(captured.ops_calls, { name = 'ci_list', branch = branch, opts = opts or {} })
-        end,
         pr_ci = function(f, pr, opts)
           table.insert(captured.ops_calls, { name = 'pr_ci', f = f, pr = pr, opts = opts })
         end,
@@ -215,7 +213,9 @@ describe('high-level implicit-ref API', function()
         current_context = function()
           return nil
         end,
-        open = function() end,
+        open = function(route, opts)
+          table.insert(captured.opens, { route = route, opts = opts })
+        end,
       }
     end
 
@@ -411,15 +411,13 @@ describe('high-level implicit-ref API', function()
     assert.is_nil(captured.head_calls[1].head)
     assert.equals('upstream@release', captured.head_calls[2].head)
     assert.same({
-      name = 'ci_list',
-      branch = 'feature',
-      opts = { scope = repo_scope('current') },
-    }, captured.ops_calls[1])
+      route = 'ci.current_branch',
+      opts = { branch = 'feature', scope = repo_scope('current') },
+    }, captured.opens[1])
     assert.same({
-      name = 'ci_list',
-      branch = 'release',
-      opts = { scope = repo_scope('upstream') },
-    }, captured.ops_calls[2])
+      route = 'ci.current_branch',
+      opts = { branch = 'release', scope = repo_scope('upstream') },
+    }, captured.opens[2])
     assert.same({}, captured.repo_calls)
   end)
 
@@ -436,10 +434,9 @@ describe('high-level implicit-ref API', function()
     assert.is_nil(captured.repo_calls[1].repo)
     assert.equals('upstream', captured.repo_calls[1].opts.repo)
     assert.same({
-      name = 'ci_list',
-      branch = 'feature',
-      opts = { scope = repo_scope('upstream') },
-    }, captured.ops_calls[1])
+      route = 'ci.current_branch',
+      opts = { branch = 'feature', scope = repo_scope('upstream') },
+    }, captured.opens[1])
   end)
 
   it('warns cleanly when no current PR matches the high-level current-ref entrypoints', function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -393,14 +393,6 @@ describe(':Forge command', function()
 
     package.preload['forge.ops'] = function()
       return {
-        pr_list = function(state, opts)
-          table.insert(captured.ops_calls, { name = 'pr_list', state = state, opts = opts })
-          require('forge').open(state and ('prs.' .. state) or 'prs', opts)
-        end,
-        pr_create = function(opts)
-          table.insert(captured.ops_calls, { name = 'pr_create', opts = opts })
-          require('forge').create_pr(opts)
-        end,
         pr_edit = function(pr)
           table.insert(captured.ops_calls, { name = 'pr_edit', pr = pr })
         end,
@@ -438,14 +430,6 @@ describe(':Forge command', function()
             f:browse_subject(ref.num, ref.scope)
           end
         end,
-        issue_list = function(state, opts)
-          table.insert(captured.ops_calls, { name = 'issue_list', state = state, opts = opts })
-          require('forge').open(state and ('issues.' .. state) or 'issues', opts)
-        end,
-        issue_create = function(opts)
-          table.insert(captured.ops_calls, { name = 'issue_create', opts = opts })
-          require('forge').create_issue(opts)
-        end,
         issue_edit = function(issue)
           table.insert(captured.ops_calls, { name = 'issue_edit', issue = issue })
         end,
@@ -459,13 +443,6 @@ describe(':Forge command', function()
         issue_reopen = function(_, issue)
           table.insert(captured.ops_calls, { name = 'issue_reopen', issue = issue })
         end,
-        ci_list = function(branch, opts)
-          table.insert(captured.ops_calls, { name = 'ci_list', branch = branch, opts = opts })
-          require('forge').open(
-            branch == nil and 'ci.all' or 'ci.current_branch',
-            vim.tbl_extend('force', opts or {}, { branch = branch })
-          )
-        end,
         ci_log = function(_, run)
           table.insert(captured.ops_calls, { name = 'ci_log', run = run })
         end,
@@ -477,10 +454,6 @@ describe(':Forge command', function()
         end,
         ci_browse = function(_, run)
           table.insert(captured.ops_calls, { name = 'ci_browse', run = run })
-        end,
-        release_list = function(state, opts)
-          table.insert(captured.ops_calls, { name = 'release_list', state = state, opts = opts })
-          require('forge').open(state and ('releases.' .. state) or 'releases', opts)
         end,
         release_browse = function(f, release)
           table.insert(captured.ops_calls, { name = 'release_browse', release = release })
@@ -494,21 +467,6 @@ describe(':Forge command', function()
         end,
         list_browse = function(_, kind, opts)
           table.insert(captured.ops_calls, { name = 'list_browse', kind = kind, opts = opts })
-        end,
-        browse_commit = function(opts)
-          table.insert(captured.ops_calls, { name = 'browse_commit', opts = opts })
-          require('forge').open('browse.commit', opts)
-        end,
-        browse_branch = function(branch, opts)
-          table.insert(captured.ops_calls, { name = 'browse_branch', branch = branch, opts = opts })
-          require('forge').open(
-            'browse.branch',
-            vim.tbl_extend('force', opts or {}, { branch = branch })
-          )
-        end,
-        browse_contextual = function(opts)
-          table.insert(captured.ops_calls, { name = 'browse_contextual', opts = opts })
-          require('forge').open('browse.contextual', opts)
         end,
         browse_repo = function(opts)
           table.insert(captured.ops_calls, { name = 'browse_repo', opts = opts })
@@ -1029,45 +987,17 @@ describe(':Forge command', function()
 
     vim.cmd('Forge browse branch=main')
 
-    assert.same({
-      name = 'browse_branch',
-      branch = 'main',
-      opts = {
-        scope = {
-          kind = 'github',
-          host = 'github.com',
-          owner = 'owner',
-          repo = 'current',
-          slug = 'owner/current',
-          repo_arg = 'owner/current',
-          web_url = 'https://github.com/owner/current',
-        },
-      },
-    }, captured.ops_calls[1])
     assert.equals('browse.branch', captured.opens[1].route)
     assert.equals('main', captured.opens[1].opts.branch)
+    assert.same(repo_scope('current'), captured.opens[1].opts.scope)
   end)
 
-  it('dispatches explicit commit browsing through ops.browse_commit', function()
+  it('dispatches explicit commit browsing through forge.open', function()
     vim.cmd('Forge browse commit=abc1234')
 
-    assert.same({
-      name = 'browse_commit',
-      opts = {
-        commit = 'abc1234',
-        scope = {
-          kind = 'github',
-          host = 'github.com',
-          owner = 'owner',
-          repo = 'current',
-          slug = 'owner/current',
-          repo_arg = 'owner/current',
-          web_url = 'https://github.com/owner/current',
-        },
-      },
-    }, captured.ops_calls[1])
     assert.equals('browse.commit', captured.opens[1].route)
     assert.equals('abc1234', captured.opens[1].opts.commit)
+    assert.same(repo_scope('current'), captured.opens[1].opts.scope)
   end)
 
   it('dispatches explicit location browsing through ops.browse_location', function()

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -349,9 +349,6 @@ describe('pickers', function()
         pr_edit = function(pr)
           table.insert(op_calls, { name = 'pr_edit', pr = pr })
         end,
-        pr_create = function(opts)
-          require('forge').create_pr(opts)
-        end,
         pr_close = function(_, pr, opts)
           table.insert(op_calls, { name = 'pr_close', pr = pr })
           if opts and opts.on_success then
@@ -405,9 +402,6 @@ describe('pickers', function()
         end,
         issue_edit = function(issue)
           table.insert(op_calls, { name = 'issue_edit', issue = issue })
-        end,
-        issue_create = function(opts)
-          require('forge').create_issue(opts)
         end,
         issue_close = function(_, issue, opts)
           table.insert(op_calls, { name = 'issue_close', issue = issue, opts = opts })


### PR DESCRIPTION
## Problem

forge.nvim's public surface still blurred deterministic entrypoints with interactive route and picker workflows, especially through thin `ops.lua` wrappers and flattened API docs.

## Solution

Document the taxonomy in `doc/forge.nvim.txt`, route create and browse/CI entrypoints through the top-level `forge` API, and remove the redundant `ops.lua` wrapper layer so the operations surface only contains actual operations.
