### PR TITLE
fix(cmd): keep interactive CI flows out of :Forge (#449)

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -344,8 +344,8 @@ COMMANDS                                                              *:Forge*
     surface.
     Direct commands cover explicit forge actions with stable targets such as
     PR/issue/release numbers, tags, and CI run ids, plus current-ref actions
-    rooted in the current branch such as bare `:Forge pr`, `:Forge review`,
-    `:Forge pr ci`, and `:Forge ci`.
+    rooted in the current branch such as bare `:Forge pr` and
+    `:Forge review`.
 
 TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Supported verbs accept explicit target modifiers such as `repo=...`,
@@ -357,11 +357,8 @@ TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
       `origin`
     - `:Forge pr` and `:Forge review` default to resolving the current open PR
       from the current branch head
-    - `:Forge pr ci` defaults to resolving checks for the current branch's PR,
-      preferring an open PR and falling back to a unique closed or merged PR
     - `:Forge pr create` defaults `head=` to the current branch push
       context and `base=` to the collaboration repo default branch
-    - `:Forge ci` defaults to current-branch CI history
     - `:Forge browse` defaults to the current file/line selection on the
       current branch, and falls back to the current repo root in non-file
       buffers
@@ -376,8 +373,6 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     name is meaningful:
     - `:Forge pr` opens the current PR
     - `:Forge review` reviews the current PR
-    - `:Forge pr ci` opens checks for the current branch's PR
-    - `:Forge ci` opens current-branch CI history
     - `:Forge browse` opens the current file/line context
 
     When the detected forge is GitLab, the Ex command surface also accepts
@@ -410,16 +405,11 @@ The user-facing surface is organized into three layers:
    - `require('forge.picker').pick(opts)`
    - Root sections, list routes, filters, load-more, nested picker actions
 
-Today, most Ex commands and top-level Lua helpers stay on the deterministic
-side of that boundary. The remaining CI helpers still bridge into the
-interactive layer:
-- `:Forge pr ci`
-- `:Forge ci`
+Today, `:Forge` commands stay on the deterministic side of that boundary.
+The remaining current-ref helpers that still bridge into the interactive
+layer are Lua-only:
 - `require('forge').pr_ci(opts?)`
 - `require('forge').ci(opts?)`
-
-Those entrypoints are still classified as interactive route/picker workflows
-for now even though they use current-ref targeting.
 
 PR COMMANDS                                                *forge-pr-commands*
 
@@ -453,17 +443,10 @@ PR COMMANDS                                                *forge-pr-commands*
                        resolved `head=` / `base=` pair.
     `draft fill`       Create draft instantly.
 
-`:Forge pr ci` [repo=...] [head=...]                           *:Forge-pr-ci*
-`:Forge pr ci` {num} [repo=...]
-    Open PR checks.
-    (no `{num}`)       Resolve the current branch's PR and open its checks.
-                       Forge prefers a unique open PR; if none match, it falls
-                       back to a unique closed or merged PR.
-    `{num}`            Open checks for PR `{num}` directly.
-    `repo=`            Scope the explicit `{num}` or disambiguate implicit
-                       current-PR lookup.
-    `head=`            Override the head used for implicit current-PR lookup.
-                       Only used when `{num}` is omitted.
+`:Forge pr ci`                                                  *:Forge-pr-ci*
+    PR checks are interactive-only and are not available from
+    `:Forge`. Use `require('forge').pr_ci()` for the interactive
+    checks flow.
 
 `:Forge review` [repo=...] [head=...] [adapter=...]              *:Forge-review*
 `:Forge review` {num} [repo=...] [adapter=...]
@@ -501,20 +484,6 @@ IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
     - exactly one match: run the action
     - no matches: warn `no open PR found for this branch`
     - multiple matches: warn and ask for `repo=` or `head=`
-
-IMPLICIT BRANCH-RELATIVE PR CI RESOLUTION ~             *forge-pr-ci-resolution*
-    `:Forge pr ci` uses the same branch-context + `repo=` / `head=`
-    disambiguation model, but with a broader state policy when `{num}` is
-    omitted.
-
-    Lookup policy:
-    - first search open PRs for the current branch
-    - if no open PR matches, search closed and merged PRs
-
-    Outcomes:
-    - exactly one match in a pass: open its checks
-    - no matches in any pass: warn `no PR found for this branch`
-    - multiple matches in a pass: warn and ask for `repo=` or `head=`
 
 IMPLICIT BRANCH-RELATIVE PR REOPEN RESOLUTION ~     *forge-pr-reopen-resolution*
     `:Forge pr reopen` uses the same branch-context + `repo=` / `head=`
@@ -646,13 +615,10 @@ ISSUE COMMANDS                                          *forge-issue-commands*
 
 CI COMMANDS                                                *forge-ci-commands*
 
-`:Forge ci` [repo=...]                                              *:Forge-ci*
-    Open current-branch CI history. This is branch CI; use `:Forge pr ci`
-    for checks attached to a PR.
-    (no modifiers)     Show runs/checks for the current branch in its push
-                       scope.
-    `repo=`            Override the repo scope while keeping the current
-                       branch.
+`:Forge ci`                                                        *:Forge-ci*
+    Current-branch CI history is interactive-only and is not
+    available from `:Forge`. Use `require('forge').ci()` for the
+    interactive current-branch flow.
 
 `:Forge ci open` {run-id} [repo=...]                          *:Forge-ci-open*
     Open the primary local run view for CI run `{run-id}`. Active runs
@@ -666,9 +632,9 @@ CI COMMANDS                                                *forge-ci-commands*
     when `{run-id}` is omitted.
 
 `:Forge ci refresh` [repo=...]                             *:Forge-ci-refresh*
-    Invalidate the cached CI run list so the next picker or
-    list-consuming command fetches fresh data from the forge. Mirrors
-    the CI picker's refresh action.
+    Invalidate the cached CI run list so the next interactive CI flow
+    or explicit list-consuming command fetches fresh data from the
+    forge. Mirrors the CI picker's refresh action.
 
     Cancel/rerun remains a picker action via `keys.ci.toggle`; there are
     no direct `:Forge ci cancel`, `rerun`, or `toggle` verbs.
@@ -1164,9 +1130,8 @@ mirror the Ex surface and reuse the shared resolver layer. >lua
 <
 
 `pr_ci()` and `ci()` still currently enter the interactive CI/checks layer
-even though they use current-ref resolution. They remain top-level helpers
-because they mirror the command surface, but they are not part of the
-deterministic contract yet.
+even though they use current-ref resolution. They remain top-level Lua
+helpers, but they are not part of the deterministic Ex contract.
 
 Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua`
 power the built-in commands and pickers, but they are not the public
@@ -1280,9 +1245,11 @@ warns instead of redirecting into edit.
 MIGRATION NOTES ~                                         *forge-migration*
 
 For the implicit-ref rollout:
-- `:Forge pr`, `:Forge review`, and `:Forge pr ci` are now the canonical
-  current-PR commands when `{num}` is omitted.
-- `:Forge ci` is current-branch CI history; PR checks live under `:Forge pr ci`.
+- `:Forge pr` and `:Forge review` are the canonical current-PR commands when
+  `{num}` is omitted.
+- `:Forge pr ci` and bare `:Forge ci` are not available from Ex; use
+  `require('forge').pr_ci()` and `require('forge').ci()` for the
+  interactive current-ref CI flows.
 - `:Forge pr create` and `require('forge').create_pr()` are create-only.
 - `edit_pr()` is removed; use `pr({ num = '42' })` instead.
 - Prefer `require('forge').pr()`, `review()`, `pr_ci()`, `ci()`, and

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -41,7 +41,6 @@ local families = {
     verb_order = {
       'open',
       'browse',
-      'ci',
       'close',
       'reopen',
       'create',
@@ -307,6 +306,18 @@ local function warn(msg)
   require('forge.logger').warn(msg)
 end
 
+local function unavailable_pr_checks_message(f)
+  local pr_one = (f and f.labels and f.labels.pr_one) or 'PR'
+  return ("%s checks are not available from :Forge; use require('forge').pr_ci()"):format(pr_one)
+end
+
+local function unavailable_ci_history_message(f)
+  local ci_inline = (f and f.labels and f.labels.ci_inline) or 'CI runs'
+  return ("current-branch %s are not available from :Forge; use require('forge').ci()"):format(
+    ci_inline
+  )
+end
+
 local function error_result(msg, opts)
   opts = opts or {}
   return nil, {
@@ -493,17 +504,7 @@ local function dispatch_pr(command)
     return
   end
   if command.name == 'ci' then
-    local pr = num and { num = num, scope = resolve_repo_modifier(command, f.name) }
-      or resolve_branch_pr_or_warn(command, f, {
-        searches = {
-          { 'open' },
-          { 'closed', 'merged' },
-        },
-      }, ('no %s found for this branch'):format((f.labels and f.labels.pr_one) or 'PR'))
-    if not pr then
-      return
-    end
-    ops.pr_ci(f, pr)
+    warn(unavailable_pr_checks_message(f))
     return
   end
   if command.name == 'browse' then
@@ -664,9 +665,11 @@ local function dispatch_ci(command)
     return
   end
   if command.name == 'open' and command.subjects[1] == nil then
-    require('forge').ci(command.parsed_modifiers.repo ~= nil and {
-      repo = command.parsed_modifiers.repo,
-    } or nil)
+    local f = require_forge_or_warn()
+    if not f then
+      return
+    end
+    warn(unavailable_ci_history_message(f))
     return
   end
   local f = require_forge_or_warn()

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -61,6 +61,15 @@ local function declares_modifier(command, flag_name)
 end
 
 function M.family_slot(command)
+  if command and command.family == 'ci' and command.name == 'open' and command.implicit then
+    return {
+      slot_class = 'family',
+      include_verbs = true,
+      include_modifiers = false,
+      include_subjects = false,
+      static_before_dynamic = true,
+    }
+  end
   if command and command.family == 'browse' and command.name == 'open' then
     return {
       slot_class = 'family',
@@ -93,6 +102,14 @@ local function release_delete_subject_slot(state)
 end
 
 function M.argument_slot(command, state)
+  if command and command.family == 'pr' and command.name == 'ci' then
+    return {
+      slot_class = 'argument',
+      include_modifiers = false,
+      include_subjects = false,
+      static_before_dynamic = true,
+    }
+  end
   if command and command.family == 'release' and command.name == 'delete' then
     return {
       slot_class = 'argument',
@@ -180,6 +197,12 @@ function M.subject(command)
 end
 
 function M.modifier_value(command, flag_name, spec)
+  if command.family == 'pr' and command.name == 'ci' then
+    return nil
+  end
+  if command.family == 'ci' and command.name == 'open' and command.implicit then
+    return nil
+  end
   if not declares_modifier(command, flag_name) then
     return nil
   end

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -342,7 +342,6 @@ describe('command schema', function()
     assert.same({
       'open',
       'browse',
-      'ci',
       'close',
       'reopen',
       'create',

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -576,25 +576,15 @@ describe(':Forge command', function()
     assert.is_nil(captured.ops_calls[1])
   end)
 
-  it('dispatches implicit current-branch CI commands through forge.ci', function()
+  it('warns when bare :Forge ci would enter interactive current-branch history', function()
     vim.cmd('Forge ci')
     vim.cmd('Forge ci repo=upstream')
 
     assert.same({
-      {},
-      {
-        repo = {
-          kind = 'repo',
-          form = 'hosted',
-          text = 'upstream',
-          host = 'github.com',
-          remote = 'upstream',
-          via = 'remote',
-          slug = 'owner/upstream',
-        },
-      },
-    }, captured.ci_calls)
-    assert.same({}, captured.warnings)
+      "current-branch CI runs are not available from :Forge; use require('forge').ci()",
+      "current-branch CI runs are not available from :Forge; use require('forge').ci()",
+    }, captured.warnings)
+    assert.same({}, captured.ci_calls)
     assert.same({}, captured.ops_calls)
   end)
 
@@ -625,7 +615,7 @@ describe(':Forge command', function()
     assert.same({}, captured.warnings)
   end)
 
-  it('dispatches implicit pr ci through forge.resolve.branch_pr', function()
+  it('warns when :Forge pr ci would enter interactive PR checks', function()
     captured.branch_pr_result = {
       num = '42',
       scope = repo_scope('upstream'),
@@ -634,20 +624,10 @@ describe(':Forge command', function()
     vim.cmd('Forge pr ci')
 
     assert.same({
-      name = 'pr_ci',
-      pr = { num = '42', scope = repo_scope('upstream') },
-    }, captured.ops_calls[1])
-    assert.equals(1, #captured.branch_pr_calls)
-    assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
-    assert.is_nil(captured.branch_pr_calls[1].opts.repo)
-    assert.is_nil(captured.branch_pr_calls[1].opts.head)
-    assert.same({
-      searches = {
-        { 'open' },
-        { 'closed', 'merged' },
-      },
-    }, captured.branch_pr_calls[1].policy)
-    assert.same({}, captured.warnings)
+      "PR checks are not available from :Forge; use require('forge').pr_ci()",
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+    assert.same({}, captured.branch_pr_calls)
   end)
 
   it('passes repo= and head= disambiguation through implicit current-PR commands', function()
@@ -680,7 +660,7 @@ describe(':Forge command', function()
     }, captured.ops_calls[2])
   end)
 
-  it('passes repo= and head= disambiguation through implicit pr ci branch lookup', function()
+  it('warns for :Forge pr ci even when repo= and head= are provided', function()
     captured.branch_pr_result = {
       num = '57',
       scope = repo_scope('upstream'),
@@ -688,17 +668,11 @@ describe(':Forge command', function()
 
     vim.cmd('Forge pr ci repo=upstream head=origin@topic')
 
-    assert.equals(1, #captured.branch_pr_calls)
-    assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
-    assert.equals('repo', captured.branch_pr_calls[1].opts.repo.kind)
-    assert.equals('owner/upstream', captured.branch_pr_calls[1].opts.repo.slug)
-    assert.equals('rev', captured.branch_pr_calls[1].opts.head.kind)
-    assert.equals('topic', captured.branch_pr_calls[1].opts.head.rev)
-    assert.equals('owner/current', captured.branch_pr_calls[1].opts.head.repo.slug)
     assert.same({
-      name = 'pr_ci',
-      pr = { num = '57', scope = repo_scope('upstream') },
-    }, captured.ops_calls[1])
+      "PR checks are not available from :Forge; use require('forge').pr_ci()",
+    }, captured.warnings)
+    assert.same({}, captured.ops_calls)
+    assert.same({}, captured.branch_pr_calls)
   end)
 
   it('dispatches implicit pr reopen through closed-only branch lookup', function()
@@ -852,9 +826,10 @@ describe(':Forge command', function()
     vim.cmd('Forge pr ci')
 
     assert.same({
-      'no PR found for this branch',
+      "PR checks are not available from :Forge; use require('forge').pr_ci()",
     }, captured.warnings)
     assert.same({}, captured.ops_calls)
+    assert.same({}, captured.branch_pr_calls)
   end)
 
   it('warns cleanly when implicit pr reopen finds no matching branch PR', function()
@@ -897,7 +872,7 @@ describe(':Forge command', function()
     assert.same({}, captured.ops_calls)
   end)
 
-  it('surfaces resolver errors from implicit pr ci branch lookup', function()
+  it('does not consult the resolver for unsupported implicit pr ci flows', function()
     captured.branch_pr_error = {
       code = 'ambiguous_pr',
       message = 'multiple PRs match head owner/current@main; pass repo= or head=',
@@ -906,9 +881,10 @@ describe(':Forge command', function()
     vim.cmd('Forge pr ci')
 
     assert.same({
-      'multiple PRs match head owner/current@main; pass repo= or head=',
+      "PR checks are not available from :Forge; use require('forge').pr_ci()",
     }, captured.warnings)
     assert.same({}, captured.ops_calls)
+    assert.same({}, captured.branch_pr_calls)
   end)
 
   it('surfaces resolver errors from implicit pr reopen branch lookup', function()
@@ -1076,7 +1052,7 @@ describe(':Forge command', function()
     }, captured.ops_calls[2])
   end)
 
-  it('dispatches explicit PR open and PR checks through forge.ops', function()
+  it('keeps explicit PR open direct while rejecting explicit PR checks from Ex', function()
     vim.cmd('Forge pr open 42')
     vim.cmd('Forge pr ci 42 repo=upstream')
 
@@ -1085,9 +1061,8 @@ describe(':Forge command', function()
       pr = { num = '42', scope = nil },
     }, captured.ops_calls[1])
     assert.same({
-      name = 'pr_ci',
-      pr = { num = '42', scope = repo_scope('upstream') },
-    }, captured.ops_calls[2])
+      "PR checks are not available from :Forge; use require('forge').pr_ci()",
+    }, captured.warnings)
   end)
 
   it('keeps explicit PR reopen routed directly through forge.ops', function()
@@ -1384,7 +1359,6 @@ describe(':Forge command', function()
         expected = {
           'open',
           'browse',
-          'ci',
           'create',
           'edit',
           'refresh',
@@ -1398,7 +1372,7 @@ describe(':Forge command', function()
       },
       {
         cmdline = 'Forge ci ',
-        expected = { 'open', 'browse', 'refresh', 'repo=' },
+        expected = { 'open', 'browse', 'refresh' },
       },
       {
         cmdline = 'Forge release ',
@@ -1418,7 +1392,7 @@ describe(':Forge command', function()
       },
       {
         cmdline = 'Forge pr ci ',
-        expected = { 'repo=', 'head=' },
+        expected = {},
       },
       {
         cmdline = 'Forge pr reopen ',
@@ -1468,7 +1442,7 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(families, 'worktrees'))
 
     assert.is_true(vim.tbl_contains(pr, 'open'))
-    assert.is_true(vim.tbl_contains(pr, 'ci'))
+    assert.is_false(vim.tbl_contains(pr, 'ci'))
     assert.is_true(vim.tbl_contains(pr, 'create'))
     assert.is_false(vim.tbl_contains(pr, 'approve'))
     assert.is_false(vim.tbl_contains(pr, 'merge'))
@@ -1489,10 +1463,10 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(ci, 'open'))
     assert.is_true(vim.tbl_contains(ci, 'browse'))
     assert.is_true(vim.tbl_contains(ci, 'refresh'))
-    assert.is_true(vim.tbl_contains(ci, 'repo='))
+    assert.is_false(vim.tbl_contains(ci, 'repo='))
     assert.is_false(vim.tbl_contains(ci, 'log'))
     assert.is_false(vim.tbl_contains(ci, 'watch'))
-    assert.same({ 'repo=', 'head=' }, pr_ci)
+    assert.same({}, pr_ci)
     assert.is_true(vim.tbl_contains(issue, 'edit'))
     assert.is_true(vim.tbl_contains(issue, 'refresh'))
     assert.is_true(vim.tbl_contains(release, 'browse'))
@@ -1622,14 +1596,13 @@ describe(':Forge command', function()
     assert.same({
       'open',
       'browse',
-      'ci',
       'create',
       'edit',
       'refresh',
       'repo=',
       'head=',
     }, mr)
-    assert.same({ 'open', 'browse', 'refresh', 'repo=' }, pipeline)
+    assert.same({ 'open', 'browse', 'refresh' }, pipeline)
   end)
 
   it(
@@ -1676,7 +1649,6 @@ describe(':Forge command', function()
         { values = bases, prefix = 'base=' },
         { values = current_pr_heads, prefix = 'head=' },
         { values = review_heads, prefix = 'head=' },
-        { values = pr_ci_heads, prefix = 'head=' },
       }) do
         local values = case.values
         local prefix = case.prefix
@@ -1685,6 +1657,8 @@ describe(':Forge command', function()
         assert.is_true(vim.tbl_contains(values, prefix .. '@main'))
         assert.is_true(vim.tbl_contains(values, prefix .. '@deadbee'))
       end
+
+      assert.same({}, pr_ci_heads)
 
       assert.is_true(vim.tbl_contains(templates, 'template=bug'))
       assert.is_true(vim.tbl_contains(templates, 'template=feature'))
@@ -1813,8 +1787,7 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(merge, 'repo='))
     assert.is_true(vim.tbl_contains(merge, 'head='))
     assert.is_true(vim.tbl_contains(merge, 'method='))
-    assert.is_true(vim.tbl_contains(pr_ci, 'repo='))
-    assert.is_true(vim.tbl_contains(pr_ci, 'head='))
+    assert.same({}, pr_ci)
     assert.is_true(vim.tbl_contains(draft, 'repo='))
     assert.is_true(vim.tbl_contains(draft, 'head='))
     assert.is_true(vim.tbl_contains(ready, 'repo='))


### PR DESCRIPTION
## Problem

`:Forge pr ci` and bare `:Forge ci` still entered picker-backed interactive flows even though the Ex surface is supposed to stay deterministic. Completion and help also continued to advertise those paths.

## Solution

Warn for those interactive-only Ex forms instead of dispatching them, stop advertising them in completion, and update help text to document `require('forge').pr_ci()` and `require('forge').ci()` as the Lua-only interactive entrypoints.