### PR TITLE
feat(ci): add a buffer-native PR checks view (#464)

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -344,8 +344,8 @@ COMMANDS                                                              *:Forge*
     surface.
     Direct commands cover explicit forge actions with stable targets such as
     PR/issue/release numbers, tags, and CI run ids, plus current-ref actions
-    rooted in the current branch such as bare `:Forge pr` and
-    `:Forge review`.
+    rooted in the current branch such as bare `:Forge pr`, `:Forge review`,
+    and `:Forge pr ci`.
 
 TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Supported verbs accept explicit target modifiers such as `repo=...`,
@@ -357,6 +357,8 @@ TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
       `origin`
     - `:Forge pr` and `:Forge review` default to resolving the current open PR
       from the current branch head
+    - `:Forge pr ci` defaults to resolving checks for the current branch's PR,
+      preferring an open PR and falling back to a unique closed or merged PR
     - `:Forge pr create` defaults `head=` to the current branch push
       context and `base=` to the collaboration repo default branch
     - `:Forge browse` defaults to the current file/line selection on the
@@ -385,7 +387,7 @@ CANONICAL SYNTAX AND COMPATIBILITY               *forge-command-compatibility*
     Commands that need interactive selection are intentionally not exposed
     through `:Forge`; use the interactive picker surface instead.
     This includes list navigation, list-scoped filters/refresh, CI
-    cancel/rerun toggles, nested per-PR checks, and copy helpers.
+    cancel/rerun toggles, and copy helpers.
 
 SURFACE TAXONOMY                                          *forge-surface-model*
 
@@ -405,10 +407,10 @@ The user-facing surface is organized into three layers:
    - `require('forge.picker').pick(opts)`
    - Root sections, list routes, filters, load-more, nested picker actions
 
-Today, `:Forge` commands stay on the deterministic side of that boundary.
-The remaining current-ref helpers that still bridge into the interactive
-layer are Lua-only:
-- `require('forge').pr_ci(opts?)`
+Today, `:Forge` commands and `require('forge').pr_ci()` stay on the
+deterministic side of that boundary.
+The remaining current-ref helper that still bridges into the interactive
+layer is Lua-only:
 - `require('forge').ci(opts?)`
 
 PR COMMANDS                                                *forge-pr-commands*
@@ -443,10 +445,18 @@ PR COMMANDS                                                *forge-pr-commands*
                        resolved `head=` / `base=` pair.
     `draft fill`       Create draft instantly.
 
-`:Forge pr ci`                                                  *:Forge-pr-ci*
-    PR checks are interactive-only and are not available from
-    `:Forge`. Use `require('forge').pr_ci()` for the interactive
-    checks flow.
+`:Forge pr ci` [repo=...] [head=...]                           *:Forge-pr-ci*
+`:Forge pr ci` {num} [repo=...]
+    Open PR checks in the buffer-native checks view.
+    (no `{num}`)       Resolve the current branch's PR and open its checks.
+                       Forge prefers a unique open PR; if none match, it falls
+                       back to a unique closed or merged PR.
+    `{num}`            Open checks for PR `{num}` directly.
+    `repo=`            Scope the explicit `{num}` or disambiguate implicit
+                       branch-relative PR lookup.
+    `head=`            Override the head used for implicit branch-relative
+                       lookup. Only used when `{num}` is omitted.
+    Use `<cr>` to inspect the highlighted check and `gx` to open its URL.
 
 `:Forge review` [repo=...] [head=...] [adapter=...]              *:Forge-review*
 `:Forge review` {num} [repo=...] [adapter=...]
@@ -484,6 +494,20 @@ IMPLICIT CURRENT-PR RESOLUTION ~                   *forge-current-pr-resolution*
     - exactly one match: run the action
     - no matches: warn `no open PR found for this branch`
     - multiple matches: warn and ask for `repo=` or `head=`
+
+IMPLICIT BRANCH-RELATIVE PR CI RESOLUTION ~             *forge-pr-ci-resolution*
+    `:Forge pr ci` uses the same branch-context + `repo=` / `head=`
+    disambiguation model, but with a broader state policy when `{num}` is
+    omitted.
+
+    Lookup policy:
+    - first search open PRs for the current branch
+    - if no open PR matches, search closed and merged PRs
+
+    Outcomes:
+    - exactly one match in a pass: open its checks buffer
+    - no matches in any pass: warn `no PR found for this branch`
+    - multiple matches in a pass: warn and ask for `repo=` or `head=`
 
 IMPLICIT BRANCH-RELATIVE PR REOPEN RESOLUTION ~     *forge-pr-reopen-resolution*
     `:Forge pr reopen` uses the same branch-context + `repo=` / `head=`
@@ -1129,9 +1153,9 @@ mirror the Ex surface and reuse the shared resolver layer. >lua
     forge.ci({ repo = 'upstream' })
 <
 
-`pr_ci()` and `ci()` still currently enter the interactive CI/checks layer
-even though they use current-ref resolution. They remain top-level Lua
-helpers, but they are not part of the deterministic Ex contract.
+`pr_ci()` now opens the deterministic PR checks buffer. `ci()` still currently
+enters the interactive current-branch CI history layer, so only `ci()` remains
+outside the deterministic Ex contract.
 
 Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua`
 power the built-in commands and pickers, but they are not the public
@@ -1214,8 +1238,9 @@ contracts live in the source:
 
 Most integrations only need one of these entrypoints:
 - Deterministic helpers:
-  `require('forge').pr(opts?)`, `review(opts?)`, `edit_issue(num, scope?)`,
-  `current_pr(opts?)`, `status()`, `create_pr(opts?)`, `create_issue(opts?)`
+  `require('forge').pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`,
+  `edit_issue(num, scope?)`, `current_pr(opts?)`, `status()`,
+  `create_pr(opts?)`, `create_issue(opts?)`
 - Interactive built-in routes:
   `require('forge').open(route?, opts?)`
 - Interactive picker primitive:
@@ -1232,10 +1257,10 @@ TOP-LEVEL API: `require('forge')` ~                     *forge-top-level-api*
 The canonical user-facing Lua surface lives in `lua/forge/init.lua`.
 Prefer these helpers for normal integrations:
 - `pr(opts?)`, `review(opts?)`, `edit_issue(num, scope?)`,
-  `current_pr(opts?)`, `status()`, `create_pr(opts?)`, and
-  `create_issue(opts?)` for deterministic integrations
+  `current_pr(opts?)`, `status()`, `create_pr(opts?)`,
+  `create_issue(opts?)`, and `pr_ci(opts?)` for deterministic integrations
 - `open(route?, opts?)` for built-in interactive routes
-- `pr_ci(opts?)` and `ci(opts?)` for the current interactive CI/checks helpers
+- `ci(opts?)` for the current interactive CI history helper
 - `pr({ num = '42' })`, `review({ num = '42' })`, and `pr_ci({ num = '42' })`
   for explicit PR targeting
 
@@ -1247,9 +1272,10 @@ MIGRATION NOTES ~                                         *forge-migration*
 For the implicit-ref rollout:
 - `:Forge pr` and `:Forge review` are the canonical current-PR commands when
   `{num}` is omitted.
-- `:Forge pr ci` and bare `:Forge ci` are not available from Ex; use
-  `require('forge').pr_ci()` and `require('forge').ci()` for the
-  interactive current-ref CI flows.
+- `:Forge pr ci` and `require('forge').pr_ci()` now open deterministic PR
+  checks buffers.
+- bare `:Forge ci` is still not available from Ex; use `require('forge').ci()`
+  for the current interactive CI history flow.
 - `:Forge pr create` and `require('forge').create_pr()` are create-only.
 - `edit_pr()` is removed; use `pr({ num = '42' })` instead.
 - Prefer `require('forge').pr()`, `review()`, `pr_ci()`, `ci()`, and

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -41,6 +41,7 @@ local families = {
     verb_order = {
       'open',
       'browse',
+      'ci',
       'close',
       'reopen',
       'create',
@@ -306,11 +307,6 @@ local function warn(msg)
   require('forge.logger').warn(msg)
 end
 
-local function unavailable_pr_checks_message(f)
-  local pr_one = (f and f.labels and f.labels.pr_one) or 'PR'
-  return ("%s checks are not available from :Forge; use require('forge').pr_ci()"):format(pr_one)
-end
-
 local function unavailable_ci_history_message(f)
   local ci_inline = (f and f.labels and f.labels.ci_inline) or 'CI runs'
   return ("current-branch %s are not available from :Forge; use require('forge').ci()"):format(
@@ -504,7 +500,17 @@ local function dispatch_pr(command)
     return
   end
   if command.name == 'ci' then
-    warn(unavailable_pr_checks_message(f))
+    local pr = num and { num = num, scope = resolve_repo_modifier(command, f.name) }
+      or resolve_branch_pr_or_warn(command, f, {
+        searches = {
+          { 'open' },
+          { 'closed', 'merged' },
+        },
+      }, ('no %s found for this branch'):format((f.labels and f.labels.pr_one) or 'PR'))
+    if not pr then
+      return
+    end
+    ops.pr_ci(f, pr)
     return
   end
   if command.name == 'browse' then

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -102,14 +102,6 @@ local function release_delete_subject_slot(state)
 end
 
 function M.argument_slot(command, state)
-  if command and command.family == 'pr' and command.name == 'ci' then
-    return {
-      slot_class = 'argument',
-      include_modifiers = false,
-      include_subjects = false,
-      static_before_dynamic = true,
-    }
-  end
   if command and command.family == 'release' and command.name == 'delete' then
     return {
       slot_class = 'argument',
@@ -197,9 +189,6 @@ function M.subject(command)
 end
 
 function M.modifier_value(command, flag_name, spec)
-  if command.family == 'pr' and command.name == 'ci' then
-    return nil
-  end
   if command.family == 'ci' and command.name == 'open' and command.implicit then
     return nil
   end

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -224,10 +224,8 @@ end
 ---@param opts? forge.PickerLimitOpts
 function M.pr_ci(f, pr, opts)
   pr = normalize_pr_ref(pr)
-  opts = vim.tbl_extend('force', opts or {}, { scope = pr.scope })
-  local pickers = require('forge.pickers')
   if f.capabilities.per_pr_checks then
-    pickers.checks(f, pr.num, nil, nil, opts)
+    require('forge.pr_checks').open(f, pr, opts)
     return
   end
   log.warn(('%s does not support %s checks'):format(f.name, f.labels.pr_one))

--- a/lua/forge/pr_checks.lua
+++ b/lua/forge/pr_checks.lua
@@ -7,8 +7,21 @@ local system_mod = require('forge.system')
 
 local ns = vim.api.nvim_create_namespace('forge_pr_checks')
 
+---@class forge.PRChecksHighlight
+---@field col integer
+---@field end_col integer
+---@field group string
+
+---@class forge.PRChecksLine
+---@field text string
+---@field highlights forge.PRChecksHighlight[]
+---@field check forge.Check?
+
+---@type table<integer, { proc?: table, request_id?: integer, lines?: forge.PRChecksLine[] }>
 local buf_data = {}
 
+---@param pr forge.PRRef
+---@return string?
 local function bufname(pr)
   local prefix = scope_mod.bufpath(pr.scope)
   if not prefix or not pr.num or pr.num == '' then
@@ -91,6 +104,8 @@ local function jump(buf, dir)
   vim.api.nvim_win_set_cursor(0, { positions[#positions], 0 })
 end
 
+---@param buf integer
+---@return forge.Check?
 local function current_check(buf)
   local line = vim.api.nvim_win_get_cursor(0)[1]
   local lines = data_for(buf).lines or {}
@@ -98,14 +113,20 @@ local function current_check(buf)
   return entry and entry.check or nil
 end
 
+---@param check forge.Check
+---@return string?
 local function check_run_id(check)
   return check.run_id or (check.link or ''):match('/actions/runs/(%d+)')
 end
 
+---@param check forge.Check
+---@return string?
 local function check_job_id(check)
   return check.job_id or (check.link or ''):match('/job/(%d+)')
 end
 
+---@param checks forge.Check[]
+---@return forge.PRChecksLine[]
 local function render_rows(checks)
   local forge = require('forge')
   local rows = forge.format_checks(checks, { width = layout.picker_width() })
@@ -116,16 +137,15 @@ local function render_rows(checks)
     local col = 0
     for _, seg in ipairs(row) do
       local part = seg[1] or ''
-      local width = vim.fn.strdisplaywidth(part)
       text[#text + 1] = part
       if seg[2] then
         highlights[#highlights + 1] = {
           col = col,
-          end_col = col + width,
+          end_col = col + #part,
           group = seg[2],
         }
       end
-      col = col + width
+      col = col + #part
     end
     lines[#lines + 1] = {
       text = table.concat(text),
@@ -136,6 +156,9 @@ local function render_rows(checks)
   return lines
 end
 
+---@param text string
+---@param group string?
+---@return forge.PRChecksLine[]
 local function render_placeholder(text, group)
   return {
     {
@@ -143,7 +166,7 @@ local function render_placeholder(text, group)
       highlights = group and {
         {
           col = 0,
-          end_col = vim.fn.strdisplaywidth(text),
+          end_col = #text,
           group = group,
         },
       } or {},
@@ -152,6 +175,8 @@ local function render_placeholder(text, group)
   }
 end
 
+---@param buf integer
+---@param lines forge.PRChecksLine[]
 local function render(buf, lines)
   vim.bo[buf].modifiable = true
   vim.api.nvim_buf_set_lines(
@@ -176,6 +201,8 @@ local function render(buf, lines)
   set_data(buf, { lines = lines })
 end
 
+---@param check forge.Check?
+---@return boolean
 local function openable_check(check)
   if type(check) ~= 'table' then
     return false
@@ -186,11 +213,17 @@ local function openable_check(check)
   return check_run_id(check) ~= nil
 end
 
+---@param f forge.Forge
+---@param check forge.Check
+---@param scope forge.Scope?
 local function inspect_check(f, check, scope)
   if not openable_check(check) then
     return
   end
   local run_id = check_run_id(check)
+  if not run_id then
+    return
+  end
   local job_id = check_job_id(check)
   local bucket = (check.bucket or ''):lower()
   local ref = check.scope or scope
@@ -212,6 +245,10 @@ local function inspect_check(f, check, scope)
   })
 end
 
+---@param buf integer
+---@param f forge.Forge
+---@param pr forge.PRRef
+---@param opts table?
 local function setup_keymaps(buf, f, pr, opts)
   local cfg = require('forge').config()
   local keys = type(cfg.keys) == 'table' and cfg.keys.log or {}
@@ -246,6 +283,9 @@ local function setup_keymaps(buf, f, pr, opts)
   end, 'Previous check')
 end
 
+---@param pr forge.PRRef
+---@param reuse_buf integer?
+---@return integer, boolean
 local function prepare_buf(pr, reuse_buf)
   local name = bufname(pr)
   local buf
@@ -294,6 +334,9 @@ local function prepare_buf(pr, reuse_buf)
   return buf, reusing
 end
 
+---@param checks forge.Check[]
+---@param scope forge.Scope?
+---@return forge.Check[]
 local function normalize_checks(checks, scope)
   local forge = require('forge')
   local normalized = vim.deepcopy(checks)
@@ -303,6 +346,10 @@ local function normalize_checks(checks, scope)
   return forge.filter_checks(normalized, 'all')
 end
 
+---@param f forge.Forge
+---@param pr forge.PRRef
+---@param opts table?
+---@param reuse_buf integer?
 function M.open(f, pr, opts, reuse_buf)
   opts = opts or {}
   local buf, reusing = prepare_buf(pr, reuse_buf)

--- a/lua/forge/pr_checks.lua
+++ b/lua/forge/pr_checks.lua
@@ -1,0 +1,348 @@
+local M = {}
+
+local layout = require('forge.layout')
+local log = require('forge.logger')
+local scope_mod = require('forge.scope')
+local system_mod = require('forge.system')
+
+local ns = vim.api.nvim_create_namespace('forge_pr_checks')
+
+local buf_data = {}
+
+local function bufname(pr)
+  local prefix = scope_mod.bufpath(pr.scope)
+  if not prefix or not pr.num or pr.num == '' then
+    return nil
+  end
+  return ('forge://%s/pr/%s/checks'):format(prefix, pr.num)
+end
+
+local function data_for(buf)
+  local data = buf_data[buf]
+  if not data then
+    data = {}
+    buf_data[buf] = data
+  end
+  return data
+end
+
+local function set_data(buf, fields)
+  local data = data_for(buf)
+  for key, value in pairs(fields) do
+    data[key] = value
+  end
+  return data
+end
+
+local function stop_proc(buf)
+  local proc = data_for(buf).proc
+  if proc and type(proc.kill) == 'function' then
+    pcall(function()
+      proc:kill()
+    end)
+  end
+  data_for(buf).proc = nil
+end
+
+local function begin_request(buf)
+  local data = data_for(buf)
+  data.request_id = (data.request_id or 0) + 1
+  stop_proc(buf)
+  return data.request_id
+end
+
+local function request_current(buf, request_id)
+  return data_for(buf).request_id == request_id
+end
+
+local function line_positions(buf)
+  local lines = data_for(buf).lines or {}
+  local positions = {}
+  for lnum, line in ipairs(lines) do
+    if line.check ~= nil then
+      positions[#positions + 1] = lnum
+    end
+  end
+  return positions
+end
+
+local function jump(buf, dir)
+  local positions = line_positions(buf)
+  if #positions == 0 then
+    return
+  end
+  local current = vim.api.nvim_win_get_cursor(0)[1]
+  if dir > 0 then
+    for _, lnum in ipairs(positions) do
+      if lnum > current then
+        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+        return
+      end
+    end
+    vim.api.nvim_win_set_cursor(0, { positions[1], 0 })
+    return
+  end
+  for i = #positions, 1, -1 do
+    if positions[i] < current then
+      vim.api.nvim_win_set_cursor(0, { positions[i], 0 })
+      return
+    end
+  end
+  vim.api.nvim_win_set_cursor(0, { positions[#positions], 0 })
+end
+
+local function current_check(buf)
+  local line = vim.api.nvim_win_get_cursor(0)[1]
+  local lines = data_for(buf).lines or {}
+  local entry = lines[line]
+  return entry and entry.check or nil
+end
+
+local function check_run_id(check)
+  return check.run_id or (check.link or ''):match('/actions/runs/(%d+)')
+end
+
+local function check_job_id(check)
+  return check.job_id or (check.link or ''):match('/job/(%d+)')
+end
+
+local function render_rows(checks)
+  local forge = require('forge')
+  local rows = forge.format_checks(checks, { width = layout.picker_width() })
+  local lines = {}
+  for index, row in ipairs(rows) do
+    local text = {}
+    local highlights = {}
+    local col = 0
+    for _, seg in ipairs(row) do
+      local part = seg[1] or ''
+      local width = vim.fn.strdisplaywidth(part)
+      text[#text + 1] = part
+      if seg[2] then
+        highlights[#highlights + 1] = {
+          col = col,
+          end_col = col + width,
+          group = seg[2],
+        }
+      end
+      col = col + width
+    end
+    lines[#lines + 1] = {
+      text = table.concat(text),
+      highlights = highlights,
+      check = checks[index],
+    }
+  end
+  return lines
+end
+
+local function render_placeholder(text, group)
+  return {
+    {
+      text = text,
+      highlights = group and {
+        {
+          col = 0,
+          end_col = vim.fn.strdisplaywidth(text),
+          group = group,
+        },
+      } or {},
+      check = nil,
+    },
+  }
+end
+
+local function render(buf, lines)
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(
+    buf,
+    0,
+    -1,
+    false,
+    vim.tbl_map(function(line)
+      return line.text
+    end, lines)
+  )
+  vim.bo[buf].modifiable = false
+  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+  for lnum, line in ipairs(lines) do
+    for _, hl in ipairs(line.highlights or {}) do
+      vim.api.nvim_buf_set_extmark(buf, ns, lnum - 1, hl.col, {
+        end_col = hl.end_col,
+        hl_group = hl.group,
+      })
+    end
+  end
+  set_data(buf, { lines = lines })
+end
+
+local function openable_check(check)
+  if type(check) ~= 'table' then
+    return false
+  end
+  if (check.bucket or ''):lower() == 'skipping' then
+    return false
+  end
+  return check_run_id(check) ~= nil
+end
+
+local function inspect_check(f, check, scope)
+  if not openable_check(check) then
+    return
+  end
+  local run_id = check_run_id(check)
+  local job_id = check_job_id(check)
+  local bucket = (check.bucket or ''):lower()
+  local ref = check.scope or scope
+  local in_progress = bucket == 'pending'
+  if in_progress and f.live_tail_cmd then
+    require('forge.term').open(f:live_tail_cmd(run_id, job_id, ref), { url = check.link })
+    return
+  end
+  require('forge.log').open(f:check_log_cmd(run_id, bucket == 'fail', job_id, ref), {
+    forge_name = f.name,
+    scope = ref,
+    run_id = run_id,
+    url = check.link,
+    steps_cmd = f.steps_cmd and f:steps_cmd(run_id, ref) or nil,
+    job_id = job_id,
+    in_progress = in_progress,
+    status_cmd = f.run_status_cmd and f:run_status_cmd(run_id, ref) or nil,
+    replace_win = vim.api.nvim_get_current_win(),
+  })
+end
+
+local function setup_keymaps(buf, f, pr, opts)
+  local cfg = require('forge').config()
+  local keys = type(cfg.keys) == 'table' and cfg.keys.log or {}
+  local function map(key, fn, desc)
+    if key and key ~= false then
+      vim.keymap.set('n', key, fn, { buffer = buf, desc = desc })
+    end
+  end
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end, { buffer = buf, desc = 'Close' })
+  vim.keymap.set('n', 'gx', function()
+    local check = current_check(buf)
+    if check and check.link and check.link ~= '' then
+      vim.ui.open(check.link)
+    end
+  end, { buffer = buf, desc = 'Browse' })
+  vim.keymap.set('n', '<cr>', function()
+    local check = current_check(buf)
+    if check then
+      inspect_check(f, check, pr.scope)
+    end
+  end, { buffer = buf, desc = 'Open' })
+  map(keys.refresh, function()
+    M.open(f, pr, opts, buf)
+  end, 'Refresh')
+  map(keys.next_step, function()
+    jump(buf, 1)
+  end, 'Next check')
+  map(keys.prev_step, function()
+    jump(buf, -1)
+  end, 'Previous check')
+end
+
+local function prepare_buf(pr, reuse_buf)
+  local name = bufname(pr)
+  local buf
+  local reusing = false
+  if reuse_buf and vim.api.nvim_buf_is_valid(reuse_buf) then
+    buf = reuse_buf
+    reusing = true
+  else
+    local existing = name and vim.fn.bufnr(name) or -1
+    if existing ~= -1 and vim.api.nvim_buf_is_valid(existing) then
+      buf = existing
+      reusing = true
+      local wins = vim.fn.win_findbuf(buf)
+      if #wins == 0 then
+        local cfg = require('forge').config()
+        local split = cfg.ci.split or cfg.split
+        local prefix = split == 'vertical' and 'vertical' or 'botright'
+        vim.cmd('noautocmd ' .. prefix .. ' sbuffer ' .. buf)
+      end
+    else
+      local cfg = require('forge').config()
+      local split = cfg.ci.split or cfg.split
+      local prefix = split == 'vertical' and 'vertical' or 'botright'
+      vim.cmd('noautocmd ' .. prefix .. ' new')
+      buf = vim.api.nvim_get_current_buf()
+      vim.bo[buf].buftype = 'nofile'
+      vim.bo[buf].bufhidden = 'wipe'
+      vim.bo[buf].swapfile = false
+      vim.bo[buf].modifiable = false
+      vim.bo[buf].filetype = 'forge_log'
+      if name then
+        vim.api.nvim_buf_set_name(buf, name)
+      end
+      vim.api.nvim_create_autocmd('BufWipeout', {
+        buffer = buf,
+        callback = function()
+          stop_proc(buf)
+          buf_data[buf] = nil
+        end,
+      })
+    end
+  end
+  if not reusing then
+    render(buf, render_placeholder('Loading...', 'ForgeDim'))
+  end
+  return buf, reusing
+end
+
+local function normalize_checks(checks, scope)
+  local forge = require('forge')
+  local normalized = vim.deepcopy(checks)
+  for _, check in ipairs(normalized) do
+    check.scope = check.scope or scope
+  end
+  return forge.filter_checks(normalized, 'all')
+end
+
+function M.open(f, pr, opts, reuse_buf)
+  opts = opts or {}
+  local buf, reusing = prepare_buf(pr, reuse_buf)
+  if not reusing then
+    setup_keymaps(buf, f, pr, opts)
+  end
+  local request_id = begin_request(buf)
+  local cmd = f:checks_json_cmd(pr.num, pr.scope)
+  log.debug(('fetching checks for %s #%s...'):format(f.labels.pr_one, pr.num))
+  local proc = vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if not vim.api.nvim_buf_is_valid(buf) or not request_current(buf, request_id) then
+        return
+      end
+      local stdout = result.stdout or ''
+      if result.code ~= 0 or stdout == '' then
+        local msg = system_mod.cmd_error(
+          result,
+          ('failed to fetch checks for %s #%s'):format(f.labels.pr_one, pr.num)
+        )
+        render(buf, render_placeholder(msg, 'ForgeFail'))
+        log.error(msg)
+        return
+      end
+      local ok, decoded = pcall(vim.json.decode, stdout)
+      if not ok or type(decoded) ~= 'table' then
+        local msg = ('failed to parse checks for %s #%s'):format(f.labels.pr_one, pr.num)
+        render(buf, render_placeholder(msg, 'ForgeFail'))
+        log.error(msg)
+        return
+      end
+      local checks = normalize_checks(decoded, pr.scope)
+      if #checks == 0 then
+        render(buf, render_placeholder(('No checks for #%s'):format(pr.num), 'ForgeDim'))
+        return
+      end
+      render(buf, render_rows(checks))
+    end)
+  end)
+  set_data(buf, { proc = proc })
+end
+
+return M

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -342,6 +342,7 @@ describe('command schema', function()
     assert.same({
       'open',
       'browse',
+      'ci',
       'close',
       'reopen',
       'create',

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -615,7 +615,7 @@ describe(':Forge command', function()
     assert.same({}, captured.warnings)
   end)
 
-  it('warns when :Forge pr ci would enter interactive PR checks', function()
+  it('dispatches implicit :Forge pr ci through branch-relative PR lookup', function()
     captured.branch_pr_result = {
       num = '42',
       scope = repo_scope('upstream'),
@@ -623,11 +623,21 @@ describe(':Forge command', function()
 
     vim.cmd('Forge pr ci')
 
+    assert.equals(1, #captured.branch_pr_calls)
+    assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
+    assert.is_nil(captured.branch_pr_calls[1].opts.repo)
+    assert.is_nil(captured.branch_pr_calls[1].opts.head)
     assert.same({
-      "PR checks are not available from :Forge; use require('forge').pr_ci()",
-    }, captured.warnings)
-    assert.same({}, captured.ops_calls)
-    assert.same({}, captured.branch_pr_calls)
+      searches = {
+        { 'open' },
+        { 'closed', 'merged' },
+      },
+    }, captured.branch_pr_calls[1].policy)
+    assert.same({
+      name = 'pr_ci',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({}, captured.warnings)
   end)
 
   it('passes repo= and head= disambiguation through implicit current-PR commands', function()
@@ -660,7 +670,7 @@ describe(':Forge command', function()
     }, captured.ops_calls[2])
   end)
 
-  it('warns for :Forge pr ci even when repo= and head= are provided', function()
+  it('passes repo= and head= disambiguation through implicit :Forge pr ci', function()
     captured.branch_pr_result = {
       num = '57',
       scope = repo_scope('upstream'),
@@ -668,11 +678,18 @@ describe(':Forge command', function()
 
     vim.cmd('Forge pr ci repo=upstream head=origin@topic')
 
+    assert.equals(1, #captured.branch_pr_calls)
+    assert.equals('github', captured.branch_pr_calls[1].opts.forge.name)
+    assert.equals('repo', captured.branch_pr_calls[1].opts.repo.kind)
+    assert.equals('owner/upstream', captured.branch_pr_calls[1].opts.repo.slug)
+    assert.equals('rev', captured.branch_pr_calls[1].opts.head.kind)
+    assert.equals('topic', captured.branch_pr_calls[1].opts.head.rev)
+    assert.equals('owner/current', captured.branch_pr_calls[1].opts.head.repo.slug)
     assert.same({
-      "PR checks are not available from :Forge; use require('forge').pr_ci()",
-    }, captured.warnings)
-    assert.same({}, captured.ops_calls)
-    assert.same({}, captured.branch_pr_calls)
+      name = 'pr_ci',
+      pr = { num = '57', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({}, captured.warnings)
   end)
 
   it('dispatches implicit pr reopen through closed-only branch lookup', function()
@@ -826,10 +843,10 @@ describe(':Forge command', function()
     vim.cmd('Forge pr ci')
 
     assert.same({
-      "PR checks are not available from :Forge; use require('forge').pr_ci()",
+      'no PR found for this branch',
     }, captured.warnings)
     assert.same({}, captured.ops_calls)
-    assert.same({}, captured.branch_pr_calls)
+    assert.equals(1, #captured.branch_pr_calls)
   end)
 
   it('warns cleanly when implicit pr reopen finds no matching branch PR', function()
@@ -872,7 +889,7 @@ describe(':Forge command', function()
     assert.same({}, captured.ops_calls)
   end)
 
-  it('does not consult the resolver for unsupported implicit pr ci flows', function()
+  it('surfaces resolver errors from implicit pr ci branch lookup', function()
     captured.branch_pr_error = {
       code = 'ambiguous_pr',
       message = 'multiple PRs match head owner/current@main; pass repo= or head=',
@@ -881,10 +898,10 @@ describe(':Forge command', function()
     vim.cmd('Forge pr ci')
 
     assert.same({
-      "PR checks are not available from :Forge; use require('forge').pr_ci()",
+      'multiple PRs match head owner/current@main; pass repo= or head=',
     }, captured.warnings)
     assert.same({}, captured.ops_calls)
-    assert.same({}, captured.branch_pr_calls)
+    assert.equals(1, #captured.branch_pr_calls)
   end)
 
   it('surfaces resolver errors from implicit pr reopen branch lookup', function()
@@ -1052,7 +1069,7 @@ describe(':Forge command', function()
     }, captured.ops_calls[2])
   end)
 
-  it('keeps explicit PR open direct while rejecting explicit PR checks from Ex', function()
+  it('keeps explicit PR open and explicit PR checks routed directly through forge.ops', function()
     vim.cmd('Forge pr open 42')
     vim.cmd('Forge pr ci 42 repo=upstream')
 
@@ -1061,8 +1078,10 @@ describe(':Forge command', function()
       pr = { num = '42', scope = nil },
     }, captured.ops_calls[1])
     assert.same({
-      "PR checks are not available from :Forge; use require('forge').pr_ci()",
-    }, captured.warnings)
+      name = 'pr_ci',
+      pr = { num = '42', scope = repo_scope('upstream') },
+    }, captured.ops_calls[2])
+    assert.same({}, captured.warnings)
   end)
 
   it('keeps explicit PR reopen routed directly through forge.ops', function()
@@ -1359,6 +1378,7 @@ describe(':Forge command', function()
         expected = {
           'open',
           'browse',
+          'ci',
           'create',
           'edit',
           'refresh',
@@ -1392,7 +1412,7 @@ describe(':Forge command', function()
       },
       {
         cmdline = 'Forge pr ci ',
-        expected = {},
+        expected = { 'repo=', 'head=' },
       },
       {
         cmdline = 'Forge pr reopen ',
@@ -1442,7 +1462,7 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(families, 'worktrees'))
 
     assert.is_true(vim.tbl_contains(pr, 'open'))
-    assert.is_false(vim.tbl_contains(pr, 'ci'))
+    assert.is_true(vim.tbl_contains(pr, 'ci'))
     assert.is_true(vim.tbl_contains(pr, 'create'))
     assert.is_false(vim.tbl_contains(pr, 'approve'))
     assert.is_false(vim.tbl_contains(pr, 'merge'))
@@ -1466,7 +1486,7 @@ describe(':Forge command', function()
     assert.is_false(vim.tbl_contains(ci, 'repo='))
     assert.is_false(vim.tbl_contains(ci, 'log'))
     assert.is_false(vim.tbl_contains(ci, 'watch'))
-    assert.same({}, pr_ci)
+    assert.same({ 'repo=', 'head=' }, pr_ci)
     assert.is_true(vim.tbl_contains(issue, 'edit'))
     assert.is_true(vim.tbl_contains(issue, 'refresh'))
     assert.is_true(vim.tbl_contains(release, 'browse'))
@@ -1596,6 +1616,7 @@ describe(':Forge command', function()
     assert.same({
       'open',
       'browse',
+      'ci',
       'create',
       'edit',
       'refresh',
@@ -1649,6 +1670,7 @@ describe(':Forge command', function()
         { values = bases, prefix = 'base=' },
         { values = current_pr_heads, prefix = 'head=' },
         { values = review_heads, prefix = 'head=' },
+        { values = pr_ci_heads, prefix = 'head=' },
       }) do
         local values = case.values
         local prefix = case.prefix
@@ -1657,8 +1679,6 @@ describe(':Forge command', function()
         assert.is_true(vim.tbl_contains(values, prefix .. '@main'))
         assert.is_true(vim.tbl_contains(values, prefix .. '@deadbee'))
       end
-
-      assert.same({}, pr_ci_heads)
 
       assert.is_true(vim.tbl_contains(templates, 'template=bug'))
       assert.is_true(vim.tbl_contains(templates, 'template=feature'))
@@ -1787,7 +1807,8 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(merge, 'repo='))
     assert.is_true(vim.tbl_contains(merge, 'head='))
     assert.is_true(vim.tbl_contains(merge, 'method='))
-    assert.same({}, pr_ci)
+    assert.is_true(vim.tbl_contains(pr_ci, 'repo='))
+    assert.is_true(vim.tbl_contains(pr_ci, 'head='))
     assert.is_true(vim.tbl_contains(draft, 'repo='))
     assert.is_true(vim.tbl_contains(draft, 'head='))
     assert.is_true(vim.tbl_contains(ready, 'repo='))

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -30,6 +30,7 @@ describe('shared operations', function()
       ['forge.log'] = package.preload['forge.log'],
       ['forge.logger'] = package.preload['forge.logger'],
       ['forge.pickers'] = package.preload['forge.pickers'],
+      ['forge.pr_checks'] = package.preload['forge.pr_checks'],
       ['forge.term'] = package.preload['forge.term'],
     }
 
@@ -126,6 +127,18 @@ describe('shared operations', function()
       }
     end
 
+    package.preload['forge.pr_checks'] = function()
+      return {
+        open = function(f, pr, opts)
+          captured.pr_checks = {
+            f = f,
+            pr = pr,
+            opts = opts,
+          }
+        end,
+      }
+    end
+
     package.preload['forge.term'] = function()
       return {
         open = function(cmd, opts)
@@ -148,6 +161,7 @@ describe('shared operations', function()
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
     package.loaded['forge.pickers'] = nil
+    package.loaded['forge.pr_checks'] = nil
     package.loaded['forge.term'] = nil
   end)
 
@@ -161,6 +175,7 @@ describe('shared operations', function()
     package.preload['forge.log'] = old_preload['forge.log']
     package.preload['forge.logger'] = old_preload['forge.logger']
     package.preload['forge.pickers'] = old_preload['forge.pickers']
+    package.preload['forge.pr_checks'] = old_preload['forge.pr_checks']
     package.preload['forge.term'] = old_preload['forge.term']
 
     package.loaded['forge'] = nil
@@ -168,6 +183,7 @@ describe('shared operations', function()
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
     package.loaded['forge.pickers'] = nil
+    package.loaded['forge.pr_checks'] = nil
     package.loaded['forge.term'] = nil
   end)
 
@@ -185,14 +201,13 @@ describe('shared operations', function()
 
     assert.same({
       f = f,
-      num = '42',
-      filter = nil,
-      cached_checks = nil,
-      opts = {
-        back = 'root',
+      pr = {
+        num = '42',
         scope = 'owner/repo',
       },
-    }, captured.checks)
+      opts = { back = 'root' },
+    }, captured.pr_checks)
+    assert.is_nil(captured.checks)
     assert.is_nil(captured.ci)
     assert.same({}, captured.infos)
   end)

--- a/spec/pr_checks_spec.lua
+++ b/spec/pr_checks_spec.lua
@@ -1,0 +1,258 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('pr checks buffer', function()
+  local old_system
+  local old_ui_open
+  local old_preload
+  local captured
+
+  local scope = {
+    kind = 'github',
+    host = 'github.com',
+    slug = 'owner/repo',
+  }
+
+  before_each(function()
+    captured = {
+      logs = {},
+      terms = {},
+      urls = {},
+    }
+    old_system = vim.system
+    old_ui_open = vim.ui.open
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.layout'] = package.preload['forge.layout'],
+      ['forge.log'] = package.preload['forge.log'],
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.scope'] = package.preload['forge.scope'],
+      ['forge.system'] = package.preload['forge.system'],
+      ['forge.term'] = package.preload['forge.term'],
+    }
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            split = 'horizontal',
+            ci = { refresh = 5 },
+            keys = {
+              log = {
+                next_step = ']]',
+                prev_step = '[[',
+                refresh = '<c-r>',
+              },
+            },
+          }
+        end,
+        filter_checks = function(checks)
+          return checks
+        end,
+        format_checks = function(checks)
+          local rows = {}
+          for _, check in ipairs(checks) do
+            rows[#rows + 1] = {
+              { check.name, check.bucket == 'fail' and 'ForgeFail' or 'ForgePass' },
+            }
+          end
+          return rows
+        end,
+      }
+    end
+
+    package.preload['forge.layout'] = function()
+      return {
+        picker_width = function()
+          return 80
+        end,
+      }
+    end
+
+    package.preload['forge.log'] = function()
+      return {
+        open = function(cmd, opts)
+          captured.logs[#captured.logs + 1] = { cmd = cmd, opts = opts }
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        error = function() end,
+      }
+    end
+
+    package.preload['forge.scope'] = function()
+      return {
+        bufpath = function()
+          return 'github.com/owner/repo'
+        end,
+      }
+    end
+
+    package.preload['forge.system'] = function()
+      return {
+        cmd_error = function(result, fallback)
+          return result.stderr ~= '' and result.stderr or fallback
+        end,
+      }
+    end
+
+    package.preload['forge.term'] = function()
+      return {
+        open = function(cmd, opts)
+          captured.terms[#captured.terms + 1] = { cmd = cmd, opts = opts }
+        end,
+      }
+    end
+
+    vim.ui.open = function(url)
+      captured.urls[#captured.urls + 1] = url
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.layout'] = nil
+    package.loaded['forge.log'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.pr_checks'] = nil
+    package.loaded['forge.scope'] = nil
+    package.loaded['forge.system'] = nil
+    package.loaded['forge.term'] = nil
+  end)
+
+  after_each(function()
+    vim.system = old_system
+    vim.ui.open = old_ui_open
+
+    for name, loader in pairs(old_preload) do
+      package.preload[name] = loader
+      package.loaded[name] = nil
+    end
+    package.loaded['forge.pr_checks'] = nil
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        local name = vim.api.nvim_buf_get_name(buf)
+        if name:match('^forge://') then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end
+    vim.cmd('silent! %bwipeout!')
+    vim.cmd('enew!')
+  end)
+
+  it('opens completed checks in a buffer and routes enter to check logs', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            name = 'lint',
+            bucket = 'fail',
+            link = 'https://example.com/actions/runs/123/job/456',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.pr_checks')
+    mod.open({
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = { per_pr_checks = true },
+      checks_json_cmd = function()
+        return { 'checks', '42' }
+      end,
+      check_log_cmd = function(_, run_id, failed, job_id)
+        return { 'log', run_id, tostring(failed), job_id or '' }
+      end,
+    }, {
+      num = '42',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    assert.equals('forge://github.com/owner/repo/pr/42/checks', vim.api.nvim_buf_get_name(buf))
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'lint'
+    end)
+    assert.same({ 'lint' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+
+    local enter = vim.fn.maparg('<cr>', 'n', false, true).callback
+    local win = vim.api.nvim_get_current_win()
+    enter()
+
+    assert.same({
+      cmd = { 'log', '123', 'true', '456' },
+      opts = {
+        forge_name = 'github',
+        scope = scope,
+        run_id = '123',
+        url = 'https://example.com/actions/runs/123/job/456',
+        steps_cmd = nil,
+        job_id = '456',
+        in_progress = false,
+        status_cmd = nil,
+        replace_win = win,
+      },
+    }, captured.logs[1])
+  end)
+
+  it('routes pending checks through live tail when available', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            name = 'test',
+            bucket = 'pending',
+            run_id = '123',
+            job_id = '456',
+            link = 'https://example.com/actions/runs/123/job/456',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.pr_checks')
+    mod.open({
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = { per_pr_checks = true },
+      checks_json_cmd = function()
+        return { 'checks', '42' }
+      end,
+      check_log_cmd = function()
+        return { 'log' }
+      end,
+      live_tail_cmd = function(_, run_id, job_id)
+        return { 'tail', run_id, job_id }
+      end,
+    }, {
+      num = '42',
+      scope = scope,
+    })
+
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == 'test'
+    end)
+    local enter = vim.fn.maparg('<cr>', 'n', false, true).callback
+    enter()
+
+    assert.same({
+      cmd = { 'tail', '123', '456' },
+      opts = {
+        url = 'https://example.com/actions/runs/123/job/456',
+      },
+    }, captured.terms[1])
+    assert.same({}, captured.logs)
+  end)
+end)

--- a/spec/pr_checks_spec.lua
+++ b/spec/pr_checks_spec.lua
@@ -1,5 +1,7 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
 describe('pr checks buffer', function()
   local old_system
   local old_ui_open
@@ -20,15 +22,15 @@ describe('pr checks buffer', function()
     }
     old_system = vim.system
     old_ui_open = vim.ui.open
-    old_preload = {
-      ['forge'] = package.preload['forge'],
-      ['forge.layout'] = package.preload['forge.layout'],
-      ['forge.log'] = package.preload['forge.log'],
-      ['forge.logger'] = package.preload['forge.logger'],
-      ['forge.scope'] = package.preload['forge.scope'],
-      ['forge.system'] = package.preload['forge.system'],
-      ['forge.term'] = package.preload['forge.term'],
-    }
+    old_preload = helpers.capture_preload({
+      'forge',
+      'forge.layout',
+      'forge.log',
+      'forge.logger',
+      'forge.scope',
+      'forge.system',
+      'forge.term',
+    })
 
     package.preload['forge'] = function()
       return {
@@ -125,10 +127,14 @@ describe('pr checks buffer', function()
     vim.system = old_system
     vim.ui.open = old_ui_open
 
-    for name, loader in pairs(old_preload) do
-      package.preload[name] = loader
-      package.loaded[name] = nil
-    end
+    helpers.restore_preload(old_preload)
+    package.loaded['forge'] = nil
+    package.loaded['forge.layout'] = nil
+    package.loaded['forge.log'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.scope'] = nil
+    package.loaded['forge.system'] = nil
+    package.loaded['forge.term'] = nil
     package.loaded['forge.pr_checks'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do


### PR DESCRIPTION
## Problem

`pr_ci()` still routes through the nested checks picker, so PR checks remain on the interactive picker path instead of a deterministic buffer-backed surface.

## Solution

Add a dedicated `forge.pr_checks` buffer module, retarget `ops.pr_ci()` into it, and cover the new behavior with focused ops and buffer specs. The new surface renders structured PR checks in a normal Forge buffer and reuses the existing log and live-tail viewers when opening an individual check.

Closes #464.