### PR TITLE
feat(ci): make bare current-branch CI deterministic (#465)

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -345,7 +345,7 @@ COMMANDS                                                              *:Forge*
     Direct commands cover explicit forge actions with stable targets such as
     PR/issue/release numbers, tags, and CI run ids, plus current-ref actions
     rooted in the current branch such as bare `:Forge pr`, `:Forge review`,
-    and `:Forge pr ci`.
+    `:Forge pr ci`, and `:Forge ci`.
 
 TARGET DEFAULTS AND OVERRIDES                          *forge-target-defaults*
     Supported verbs accept explicit target modifiers such as `repo=...`,
@@ -407,11 +407,8 @@ The user-facing surface is organized into three layers:
    - `require('forge.picker').pick(opts)`
    - Root sections, list routes, filters, load-more, nested picker actions
 
-Today, `:Forge` commands and `require('forge').pr_ci()` stay on the
-deterministic side of that boundary.
-The remaining current-ref helper that still bridges into the interactive
-layer is Lua-only:
-- `require('forge').ci(opts?)`
+Today, `:Forge` commands, `require('forge').pr_ci()`, and
+`require('forge').ci()` stay on the deterministic side of that boundary.
 
 PR COMMANDS                                                *forge-pr-commands*
 
@@ -639,10 +636,12 @@ ISSUE COMMANDS                                          *forge-issue-commands*
 
 CI COMMANDS                                                *forge-ci-commands*
 
-`:Forge ci`                                                        *:Forge-ci*
-    Current-branch CI history is interactive-only and is not
-    available from `:Forge`. Use `require('forge').ci()` for the
-    interactive current-branch flow.
+`:Forge ci` [repo=...] [head=...]                                  *:Forge-ci*
+    Open current-branch CI history in the buffer-native runs view.
+    Default target is the current branch push context.
+    `repo=`            Override the repo scope for the resolved branch head.
+    `head=`            Override the head used for current-branch history.
+    Use `<cr>` to inspect the highlighted run and `gx` to open its URL.
 
 `:Forge ci open` {run-id} [repo=...]                          *:Forge-ci-open*
     Open the primary local run view for CI run `{run-id}`. Active runs
@@ -662,6 +661,20 @@ CI COMMANDS                                                *forge-ci-commands*
 
     Cancel/rerun remains a picker action via `keys.ci.toggle`; there are
     no direct `:Forge ci cancel`, `rerun`, or `toggle` verbs.
+
+IMPLICIT CURRENT-BRANCH CI RESOLUTION ~              *forge-current-branch-ci*
+    `:Forge ci` and `require('forge').ci()` resolve current-branch run history
+    from the current branch push context when `head=` is omitted.
+
+    Default lookup policy:
+    - head = current branch push context
+    - explicit `repo=` overrides the resolved head scope
+    - explicit `head=` overrides the current branch push context
+
+    Outcomes:
+    - resolved head: open the branch's CI history buffer
+    - invalid head: warn with the resolver message
+    - detached HEAD: warn `detached HEAD`
 
 RELEASE COMMANDS                                      *forge-release-commands*
 
@@ -1153,9 +1166,8 @@ mirror the Ex surface and reuse the shared resolver layer. >lua
     forge.ci({ repo = 'upstream' })
 <
 
-`pr_ci()` now opens the deterministic PR checks buffer. `ci()` still currently
-enters the interactive current-branch CI history layer, so only `ci()` remains
-outside the deterministic Ex contract.
+`pr_ci()` now opens the deterministic PR checks buffer. `ci()` now opens the
+deterministic current-branch CI history buffer.
 
 Internal layers such as `lua/forge/ops.lua` and `lua/forge/pickers.lua`
 power the built-in commands and pickers, but they are not the public
@@ -1238,7 +1250,7 @@ contracts live in the source:
 
 Most integrations only need one of these entrypoints:
 - Deterministic helpers:
-  `require('forge').pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`,
+  `require('forge').pr(opts?)`, `review(opts?)`, `pr_ci(opts?)`, `ci(opts?)`,
   `edit_issue(num, scope?)`, `current_pr(opts?)`, `status()`,
   `create_pr(opts?)`, `create_issue(opts?)`
 - Interactive built-in routes:
@@ -1258,9 +1270,9 @@ The canonical user-facing Lua surface lives in `lua/forge/init.lua`.
 Prefer these helpers for normal integrations:
 - `pr(opts?)`, `review(opts?)`, `edit_issue(num, scope?)`,
   `current_pr(opts?)`, `status()`, `create_pr(opts?)`,
-  `create_issue(opts?)`, and `pr_ci(opts?)` for deterministic integrations
+  `create_issue(opts?)`, `pr_ci(opts?)`, and `ci(opts?)` for deterministic
+  integrations
 - `open(route?, opts?)` for built-in interactive routes
-- `ci(opts?)` for the current interactive CI history helper
 - `pr({ num = '42' })`, `review({ num = '42' })`, and `pr_ci({ num = '42' })`
   for explicit PR targeting
 
@@ -1274,8 +1286,8 @@ For the implicit-ref rollout:
   `{num}` is omitted.
 - `:Forge pr ci` and `require('forge').pr_ci()` now open deterministic PR
   checks buffers.
-- bare `:Forge ci` is still not available from Ex; use `require('forge').ci()`
-  for the current interactive CI history flow.
+- bare `:Forge ci` and `require('forge').ci()` now open deterministic
+  current-branch CI history buffers.
 - `:Forge pr create` and `require('forge').create_pr()` are create-only.
 - `edit_pr()` is removed; use `pr({ num = '42' })` instead.
 - Prefer `require('forge').pr()`, `review()`, `pr_ci()`, `ci()`, and

--- a/lua/forge/ci_history.lua
+++ b/lua/forge/ci_history.lua
@@ -1,0 +1,361 @@
+local M = {}
+
+local layout = require('forge.layout')
+local log = require('forge.logger')
+local scope_mod = require('forge.scope')
+local system_mod = require('forge.system')
+
+local ns = vim.api.nvim_create_namespace('forge_ci_history')
+
+---@class forge.CIHistoryHighlight
+---@field col integer
+---@field end_col integer
+---@field group string
+
+---@class forge.CIHistoryLine
+---@field text string
+---@field highlights forge.CIHistoryHighlight[]
+---@field run forge.CIRun?
+
+---@type table<integer, { proc?: table, request_id?: integer, lines?: forge.CIHistoryLine[] }>
+local buf_data = {}
+
+---@param f forge.Forge
+---@return string
+local function ci_inline_label(f)
+  return (f.labels and f.labels.ci_inline) or 'runs'
+end
+
+---@param head forge.HeadRef
+---@return string?
+local function bufname(head)
+  local prefix = scope_mod.bufpath(head.scope)
+  if not prefix or not head.branch or head.branch == '' then
+    return nil
+  end
+  return ('forge://%s/ci/%s'):format(prefix, head.branch)
+end
+
+local function data_for(buf)
+  local data = buf_data[buf]
+  if not data then
+    data = {}
+    buf_data[buf] = data
+  end
+  return data
+end
+
+local function set_data(buf, fields)
+  local data = data_for(buf)
+  for key, value in pairs(fields) do
+    data[key] = value
+  end
+  return data
+end
+
+local function stop_proc(buf)
+  local proc = data_for(buf).proc
+  if proc and type(proc.kill) == 'function' then
+    pcall(function()
+      proc:kill()
+    end)
+  end
+  data_for(buf).proc = nil
+end
+
+local function begin_request(buf)
+  local data = data_for(buf)
+  data.request_id = (data.request_id or 0) + 1
+  stop_proc(buf)
+  return data.request_id
+end
+
+local function request_current(buf, request_id)
+  return data_for(buf).request_id == request_id
+end
+
+local function line_positions(buf)
+  local lines = data_for(buf).lines or {}
+  local positions = {}
+  for lnum, line in ipairs(lines) do
+    if line.run ~= nil then
+      positions[#positions + 1] = lnum
+    end
+  end
+  return positions
+end
+
+local function jump(buf, dir)
+  local positions = line_positions(buf)
+  if #positions == 0 then
+    return
+  end
+  local current = vim.api.nvim_win_get_cursor(0)[1]
+  if dir > 0 then
+    for _, lnum in ipairs(positions) do
+      if lnum > current then
+        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+        return
+      end
+    end
+    vim.api.nvim_win_set_cursor(0, { positions[1], 0 })
+    return
+  end
+  for i = #positions, 1, -1 do
+    if positions[i] < current then
+      vim.api.nvim_win_set_cursor(0, { positions[i], 0 })
+      return
+    end
+  end
+  vim.api.nvim_win_set_cursor(0, { positions[#positions], 0 })
+end
+
+---@param buf integer
+---@return forge.CIRun?
+local function current_run(buf)
+  local line = vim.api.nvim_win_get_cursor(0)[1]
+  local lines = data_for(buf).lines or {}
+  local entry = lines[line]
+  return entry and entry.run or nil
+end
+
+---@param run forge.CIRun
+---@return forge.RunRef
+local function run_ref(run)
+  return {
+    id = run.id,
+    scope = run.scope,
+    status = run.status,
+    url = run.url,
+  }
+end
+
+---@param runs forge.CIRun[]
+---@return forge.CIHistoryLine[]
+local function render_rows(runs)
+  local forge = require('forge')
+  local rows = forge.format_runs(runs, { width = layout.picker_width() })
+  local lines = {}
+  for index, row in ipairs(rows) do
+    local text = {}
+    local highlights = {}
+    local col = 0
+    for _, seg in ipairs(row) do
+      local part = seg[1] or ''
+      text[#text + 1] = part
+      if seg[2] then
+        highlights[#highlights + 1] = {
+          col = col,
+          end_col = col + #part,
+          group = seg[2],
+        }
+      end
+      col = col + #part
+    end
+    lines[#lines + 1] = {
+      text = table.concat(text),
+      highlights = highlights,
+      run = runs[index],
+    }
+  end
+  return lines
+end
+
+---@param text string
+---@param group string?
+---@return forge.CIHistoryLine[]
+local function render_placeholder(text, group)
+  return {
+    {
+      text = text,
+      highlights = group and {
+        {
+          col = 0,
+          end_col = #text,
+          group = group,
+        },
+      } or {},
+      run = nil,
+    },
+  }
+end
+
+---@param buf integer
+---@param lines forge.CIHistoryLine[]
+local function render(buf, lines)
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(
+    buf,
+    0,
+    -1,
+    false,
+    vim.tbl_map(function(line)
+      return line.text
+    end, lines)
+  )
+  vim.bo[buf].modifiable = false
+  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+  for lnum, line in ipairs(lines) do
+    for _, hl in ipairs(line.highlights or {}) do
+      vim.api.nvim_buf_set_extmark(buf, ns, lnum - 1, hl.col, {
+        end_col = hl.end_col,
+        hl_group = hl.group,
+      })
+    end
+  end
+  set_data(buf, { lines = lines })
+end
+
+---@param f forge.Forge
+---@param runs table[]
+---@param scope forge.Scope?
+---@return forge.CIRun[]
+local function normalize_runs(f, runs, scope)
+  local forge = require('forge')
+  local normalized = {}
+  for _, entry in ipairs(runs) do
+    local run = f:normalize_run(entry)
+    run.scope = run.scope or scope
+    normalized[#normalized + 1] = run
+  end
+  return forge.filter_runs(normalized, 'all')
+end
+
+---@param buf integer
+---@param f forge.Forge
+---@param head forge.HeadRef
+---@param opts table?
+local function setup_keymaps(buf, f, head, opts)
+  local cfg = require('forge').config()
+  local ci_keys = type(cfg.keys) == 'table' and cfg.keys.ci or {}
+  local log_keys = type(cfg.keys) == 'table' and cfg.keys.log or {}
+  local function map(key, fn, desc)
+    if key and key ~= false then
+      vim.keymap.set('n', key, fn, { buffer = buf, desc = desc })
+    end
+  end
+  vim.keymap.set('n', 'q', function()
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end, { buffer = buf, desc = 'Close' })
+  vim.keymap.set('n', 'gx', function()
+    local run = current_run(buf)
+    if run then
+      require('forge.ops').ci_browse(f, run_ref(run))
+    end
+  end, { buffer = buf, desc = 'Browse' })
+  vim.keymap.set('n', '<cr>', function()
+    local run = current_run(buf)
+    if run then
+      require('forge.ops').ci_open(f, run_ref(run))
+    end
+  end, { buffer = buf, desc = 'Open' })
+  map(ci_keys.refresh, function()
+    M.open(f, head, opts, buf)
+  end, 'Refresh')
+  map(log_keys.next_step, function()
+    jump(buf, 1)
+  end, 'Next run')
+  map(log_keys.prev_step, function()
+    jump(buf, -1)
+  end, 'Previous run')
+end
+
+---@param head forge.HeadRef
+---@param reuse_buf integer?
+---@return integer, boolean
+local function prepare_buf(head, reuse_buf)
+  local name = bufname(head)
+  local buf
+  local reusing = false
+  if reuse_buf and vim.api.nvim_buf_is_valid(reuse_buf) then
+    buf = reuse_buf
+    reusing = true
+  else
+    local existing = name and vim.fn.bufnr(name) or -1
+    if existing ~= -1 and vim.api.nvim_buf_is_valid(existing) then
+      buf = existing
+      reusing = true
+      local wins = vim.fn.win_findbuf(buf)
+      if #wins == 0 then
+        local cfg = require('forge').config()
+        local split = cfg.ci.split or cfg.split
+        local prefix = split == 'vertical' and 'vertical' or 'botright'
+        vim.cmd('noautocmd ' .. prefix .. ' sbuffer ' .. buf)
+      end
+    else
+      local cfg = require('forge').config()
+      local split = cfg.ci.split or cfg.split
+      local prefix = split == 'vertical' and 'vertical' or 'botright'
+      vim.cmd('noautocmd ' .. prefix .. ' new')
+      buf = vim.api.nvim_get_current_buf()
+      vim.bo[buf].buftype = 'nofile'
+      vim.bo[buf].bufhidden = 'wipe'
+      vim.bo[buf].swapfile = false
+      vim.bo[buf].modifiable = false
+      vim.bo[buf].filetype = 'forge_log'
+      if name then
+        vim.api.nvim_buf_set_name(buf, name)
+      end
+      vim.api.nvim_create_autocmd('BufWipeout', {
+        buffer = buf,
+        callback = function()
+          stop_proc(buf)
+          buf_data[buf] = nil
+        end,
+      })
+    end
+  end
+  if not reusing then
+    render(buf, render_placeholder('Loading...', 'ForgeDim'))
+  end
+  return buf, reusing
+end
+
+---@param f forge.Forge
+---@param head forge.HeadRef
+---@param opts table?
+---@param reuse_buf integer?
+function M.open(f, head, opts, reuse_buf)
+  opts = opts or {}
+  local buf, reusing = prepare_buf(head, reuse_buf)
+  if not reusing then
+    setup_keymaps(buf, f, head, opts)
+  end
+  local request_id = begin_request(buf)
+  local limit = require('forge').config().display.limits.runs
+  local cmd = f:list_runs_json_cmd(head.branch, head.scope, limit)
+  log.debug(('fetching %s for %s...'):format(ci_inline_label(f), head.branch))
+  local proc = vim.system(cmd, { text = true }, function(result)
+    vim.schedule(function()
+      if not vim.api.nvim_buf_is_valid(buf) or not request_current(buf, request_id) then
+        return
+      end
+      local stdout = result.stdout or ''
+      if result.code ~= 0 or stdout == '' then
+        local msg = system_mod.cmd_error(result, ('failed to fetch %s'):format(ci_inline_label(f)))
+        render(buf, render_placeholder(msg, 'ForgeFail'))
+        log.error(msg)
+        return
+      end
+      local ok, decoded = pcall(vim.json.decode, stdout)
+      if not ok or type(decoded) ~= 'table' then
+        local msg = ('failed to parse %s details'):format(ci_inline_label(f))
+        render(buf, render_placeholder(msg, 'ForgeFail'))
+        log.error(msg)
+        return
+      end
+      local runs = normalize_runs(f, decoded, head.scope)
+      if #runs == 0 then
+        render(
+          buf,
+          render_placeholder(('No %s for %s'):format(ci_inline_label(f), head.branch), 'ForgeDim')
+        )
+        return
+      end
+      render(buf, render_rows(runs))
+    end)
+  end)
+  set_data(buf, { proc = proc })
+end
+
+return M

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -154,7 +154,7 @@ local families = {
     verbs = {
       open = {
         subject = { kind = 'run', min = 0, max = 1 },
-        modifiers = { 'repo' },
+        modifiers = { 'repo', 'head' },
       },
       browse = {
         subject = { kind = 'run', min = 0, max = 1 },
@@ -305,13 +305,6 @@ end
 
 local function warn(msg)
   require('forge.logger').warn(msg)
-end
-
-local function unavailable_ci_history_message(f)
-  local ci_inline = (f and f.labels and f.labels.ci_inline) or 'CI runs'
-  return ("current-branch %s are not available from :Forge; use require('forge').ci()"):format(
-    ci_inline
-  )
 end
 
 local function error_result(msg, opts)
@@ -671,11 +664,10 @@ local function dispatch_ci(command)
     return
   end
   if command.name == 'open' and command.subjects[1] == nil then
-    local f = require_forge_or_warn()
-    if not f then
-      return
-    end
-    warn(unavailable_ci_history_message(f))
+    require('forge').ci({
+      repo = command.parsed_modifiers.repo,
+      head = command.parsed_modifiers.head,
+    })
     return
   end
   local f = require_forge_or_warn()

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -61,15 +61,6 @@ local function declares_modifier(command, flag_name)
 end
 
 function M.family_slot(command)
-  if command and command.family == 'ci' and command.name == 'open' and command.implicit then
-    return {
-      slot_class = 'family',
-      include_verbs = true,
-      include_modifiers = false,
-      include_subjects = false,
-      static_before_dynamic = true,
-    }
-  end
   if command and command.family == 'browse' and command.name == 'open' then
     return {
       slot_class = 'family',
@@ -189,9 +180,6 @@ function M.subject(command)
 end
 
 function M.modifier_value(command, flag_name, spec)
-  if command.family == 'ci' and command.name == 'open' and command.implicit then
-    return nil
-  end
   if not declares_modifier(command, flag_name) then
     return nil
   end

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -860,14 +860,11 @@ end
 
 ---@param opts forge.BranchCIOpts?
 function M.ci(opts)
-  local _, head = resolve_ci_head(opts)
-  if not head then
+  local forge, head = resolve_ci_head(opts)
+  if not forge or not head then
     return
   end
-  M.open('ci.current_branch', {
-    branch = head.branch,
-    scope = head.scope,
-  })
+  require('forge.ops').ci(forge, head)
 end
 
 ---@param opts forge.CreatePROpts?

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -232,6 +232,17 @@ function M.pr_ci(f, pr, opts)
 end
 
 ---@param f forge.Forge
+---@param head forge.HeadRef
+---@param opts? table
+function M.ci(f, head, opts)
+  if not f.list_runs_json_cmd then
+    log.warn('structured CI data not available for this forge')
+    return
+  end
+  require('forge.ci_history').open(f, head, opts)
+end
+
+---@param f forge.Forge
 ---@param pr forge.PRRefLike
 ---@param opts? forge.OpCallbacks
 function M.pr_close(f, pr, opts)

--- a/spec/api_spec.lua
+++ b/spec/api_spec.lua
@@ -163,6 +163,9 @@ describe('high-level implicit-ref API', function()
 
     package.preload['forge.ops'] = function()
       return {
+        ci = function(f, head, opts)
+          table.insert(captured.ops_calls, { name = 'ci', f = f, head = head, opts = opts })
+        end,
         pr_ci = function(f, pr, opts)
           table.insert(captured.ops_calls, { name = 'pr_ci', f = f, pr = pr, opts = opts })
         end,
@@ -411,14 +414,17 @@ describe('high-level implicit-ref API', function()
     assert.is_nil(captured.head_calls[1].head)
     assert.equals('upstream@release', captured.head_calls[2].head)
     assert.same({
-      route = 'ci.current_branch',
-      opts = { branch = 'feature', scope = repo_scope('current') },
-    }, captured.opens[1])
+      name = 'ci',
+      f = { name = 'github', cli = 'gh', labels = { ci = 'CI', pr_one = 'PR' } },
+      head = { branch = 'feature', scope = repo_scope('current') },
+    }, captured.ops_calls[1])
     assert.same({
-      route = 'ci.current_branch',
-      opts = { branch = 'release', scope = repo_scope('upstream') },
-    }, captured.opens[2])
+      name = 'ci',
+      f = { name = 'github', cli = 'gh', labels = { ci = 'CI', pr_one = 'PR' } },
+      head = { branch = 'release', scope = repo_scope('upstream') },
+    }, captured.ops_calls[2])
     assert.same({}, captured.repo_calls)
+    assert.same({}, captured.opens)
   end)
 
   it('uses explicit repo targeting for ci() when only the repo is overridden', function()
@@ -434,9 +440,11 @@ describe('high-level implicit-ref API', function()
     assert.is_nil(captured.repo_calls[1].repo)
     assert.equals('upstream', captured.repo_calls[1].opts.repo)
     assert.same({
-      route = 'ci.current_branch',
-      opts = { branch = 'feature', scope = repo_scope('upstream') },
-    }, captured.opens[1])
+      name = 'ci',
+      f = { name = 'github', cli = 'gh', labels = { ci = 'CI', pr_one = 'PR' } },
+      head = { branch = 'feature', scope = repo_scope('upstream') },
+    }, captured.ops_calls[1])
+    assert.same({}, captured.opens)
   end)
 
   it('warns cleanly when no current PR matches the high-level current-ref entrypoints', function()

--- a/spec/ci_history_spec.lua
+++ b/spec/ci_history_spec.lua
@@ -1,0 +1,240 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+describe('ci history buffer', function()
+  local old_system
+  local old_preload
+  local captured
+
+  local scope = {
+    kind = 'github',
+    host = 'github.com',
+    slug = 'owner/repo',
+    repo_arg = 'owner/repo',
+    web_url = 'https://github.com/owner/repo',
+  }
+
+  before_each(function()
+    captured = {
+      opened = {},
+      browsed = {},
+    }
+    old_system = vim.system
+    old_preload = helpers.capture_preload({
+      'forge',
+      'forge.layout',
+      'forge.logger',
+      'forge.ops',
+      'forge.scope',
+      'forge.system',
+    })
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            split = 'horizontal',
+            ci = { refresh = 5 },
+            display = { limits = { runs = 30 } },
+            keys = {
+              ci = {
+                refresh = '<c-r>',
+              },
+              log = {
+                next_step = ']]',
+                prev_step = '[[',
+              },
+            },
+          }
+        end,
+        filter_runs = function(runs)
+          return runs
+        end,
+        format_runs = function(runs)
+          local rows = {}
+          for _, run in ipairs(runs) do
+            rows[#rows + 1] = {
+              { run.name, run.status == 'failure' and 'ForgeFail' or 'ForgePass' },
+            }
+          end
+          return rows
+        end,
+      }
+    end
+
+    package.preload['forge.layout'] = function()
+      return {
+        picker_width = function()
+          return 80
+        end,
+      }
+    end
+
+    package.preload['forge.logger'] = function()
+      return {
+        debug = function() end,
+        error = function() end,
+      }
+    end
+
+    package.preload['forge.ops'] = function()
+      return {
+        ci_open = function(_, run)
+          captured.opened[#captured.opened + 1] = run
+        end,
+        ci_browse = function(_, run)
+          captured.browsed[#captured.browsed + 1] = run
+        end,
+      }
+    end
+
+    package.preload['forge.scope'] = function()
+      return {
+        bufpath = function()
+          return 'github.com/owner/repo'
+        end,
+      }
+    end
+
+    package.preload['forge.system'] = function()
+      return {
+        cmd_error = function(result, fallback)
+          return result.stderr ~= '' and result.stderr or fallback
+        end,
+      }
+    end
+
+    package.loaded['forge'] = nil
+    package.loaded['forge.ci_history'] = nil
+    package.loaded['forge.layout'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
+    package.loaded['forge.scope'] = nil
+    package.loaded['forge.system'] = nil
+  end)
+
+  after_each(function()
+    vim.system = old_system
+
+    helpers.restore_preload(old_preload)
+    package.loaded['forge'] = nil
+    package.loaded['forge.ci_history'] = nil
+    package.loaded['forge.layout'] = nil
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.ops'] = nil
+    package.loaded['forge.scope'] = nil
+    package.loaded['forge.system'] = nil
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        local name = vim.api.nvim_buf_get_name(buf)
+        if name:match('^forge://') then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end
+    vim.cmd('silent! %bwipeout!')
+    vim.cmd('enew!')
+  end)
+
+  it('opens recent runs in a buffer and routes enter through ops.ci_open', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '123',
+            name = 'CI',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com/runs/123',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.ci_history')
+    mod.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = 'main',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    assert.equals('forge://github.com/owner/repo/ci/main', vim.api.nvim_buf_get_name(buf))
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'CI'
+    end)
+    assert.same({ 'CI' }, vim.api.nvim_buf_get_lines(buf, 0, -1, false))
+
+    local enter = vim.fn.maparg('<cr>', 'n', false, true).callback
+    enter()
+
+    assert.same({
+      id = '123',
+      scope = scope,
+      status = 'success',
+      url = 'https://example.com/runs/123',
+    }, captured.opened[1])
+  end)
+
+  it('routes gx through ops.ci_browse for the highlighted run', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '456',
+            name = 'Lint',
+            branch = 'main',
+            status = 'failure',
+            url = 'https://example.com/runs/456',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.ci_history')
+    mod.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = 'main',
+      scope = scope,
+    })
+
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == 'Lint'
+    end)
+    local browse = vim.fn.maparg('gx', 'n', false, true).callback
+    browse()
+
+    assert.same({
+      id = '456',
+      scope = scope,
+      status = 'failure',
+      url = 'https://example.com/runs/456',
+    }, captured.browsed[1])
+  end)
+end)

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -262,6 +262,19 @@ describe('command schema', function()
   end)
 
   it(
+    'attaches implicit current-branch CI disambiguation modifiers to normalized commands',
+    function()
+      local ci = assert(cmd.parse({ 'ci', 'repo=upstream', 'head=origin@topic' }))
+
+      assert.equals('open', ci.name)
+      assert.same({}, ci.subjects)
+      assert.equals('owner/upstream', ci.parsed_modifiers.repo.slug)
+      assert.equals('topic', ci.parsed_modifiers.head.rev)
+      assert.equals('owner/current', ci.parsed_modifiers.head.repo.slug)
+    end
+  )
+
+  it(
     'attaches implicit current-open-PR mutator disambiguation modifiers to normalized commands',
     function()
       local close = assert(cmd.parse({ 'pr', 'close', 'repo=upstream', 'head=origin@topic' }))
@@ -332,7 +345,7 @@ describe('command schema', function()
     assert.same({ 'repo', 'head', 'method' }, cmd.modifier_names('pr', 'merge'))
     assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'draft'))
     assert.same({ 'repo', 'head' }, cmd.modifier_names('pr', 'ready'))
-    assert.same({ 'repo' }, cmd.modifier_names('ci', 'open'))
+    assert.same({ 'repo', 'head' }, cmd.modifier_names('ci', 'open'))
     assert.same({ 'repo' }, cmd.modifier_names('ci', 'browse'))
     assert.same({ 'repo', 'web', 'blank', 'template' }, cmd.modifier_names('issue', 'create'))
     assert.same({ 'repo', 'head', 'adapter' }, cmd.modifier_names('review'))

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -576,15 +576,24 @@ describe(':Forge command', function()
     assert.is_nil(captured.ops_calls[1])
   end)
 
-  it('warns when bare :Forge ci would enter interactive current-branch history', function()
+  it('dispatches bare :Forge ci through the high-level current-branch helper', function()
     vim.cmd('Forge ci')
-    vim.cmd('Forge ci repo=upstream')
 
-    assert.same({
-      "current-branch CI runs are not available from :Forge; use require('forge').ci()",
-      "current-branch CI runs are not available from :Forge; use require('forge').ci()",
-    }, captured.warnings)
-    assert.same({}, captured.ci_calls)
+    assert.same({ {} }, captured.ci_calls)
+    assert.same({}, captured.warnings)
+    assert.same({}, captured.ops_calls)
+  end)
+
+  it('passes repo= and head= disambiguation through bare :Forge ci', function()
+    vim.cmd('Forge ci repo=upstream head=origin@topic')
+
+    assert.equals(1, #captured.ci_calls)
+    assert.equals('repo', captured.ci_calls[1].repo.kind)
+    assert.equals('owner/upstream', captured.ci_calls[1].repo.slug)
+    assert.equals('rev', captured.ci_calls[1].head.kind)
+    assert.equals('topic', captured.ci_calls[1].head.rev)
+    assert.equals('owner/current', captured.ci_calls[1].head.repo.slug)
+    assert.same({}, captured.warnings)
     assert.same({}, captured.ops_calls)
   end)
 
@@ -1392,7 +1401,7 @@ describe(':Forge command', function()
       },
       {
         cmdline = 'Forge ci ',
-        expected = { 'open', 'browse', 'refresh' },
+        expected = { 'open', 'browse', 'refresh', 'repo=', 'head=' },
       },
       {
         cmdline = 'Forge release ',
@@ -1483,7 +1492,8 @@ describe(':Forge command', function()
     assert.is_true(vim.tbl_contains(ci, 'open'))
     assert.is_true(vim.tbl_contains(ci, 'browse'))
     assert.is_true(vim.tbl_contains(ci, 'refresh'))
-    assert.is_false(vim.tbl_contains(ci, 'repo='))
+    assert.is_true(vim.tbl_contains(ci, 'repo='))
+    assert.is_true(vim.tbl_contains(ci, 'head='))
     assert.is_false(vim.tbl_contains(ci, 'log'))
     assert.is_false(vim.tbl_contains(ci, 'watch'))
     assert.same({ 'repo=', 'head=' }, pr_ci)
@@ -1623,7 +1633,7 @@ describe(':Forge command', function()
       'repo=',
       'head=',
     }, mr)
-    assert.same({ 'open', 'browse', 'refresh' }, pipeline)
+    assert.same({ 'open', 'browse', 'refresh', 'repo=', 'head=' }, pipeline)
   end)
 
   it(
@@ -1639,6 +1649,7 @@ describe(':Forge command', function()
       local current_pr_heads = completion('Forge pr head=')
       local review_heads = completion('Forge review head=')
       local pr_ci_heads = completion('Forge pr ci head=')
+      local ci_heads = completion('Forge ci head=')
       local templates = completion('Forge issue create template=')
       local adapters = completion('Forge review 42 adapter=')
       local methods = completion('Forge pr merge method=')
@@ -1671,6 +1682,7 @@ describe(':Forge command', function()
         { values = current_pr_heads, prefix = 'head=' },
         { values = review_heads, prefix = 'head=' },
         { values = pr_ci_heads, prefix = 'head=' },
+        { values = ci_heads, prefix = 'head=' },
       }) do
         local values = case.values
         local prefix = case.prefix
@@ -1925,6 +1937,7 @@ describe(':Forge command', function()
     local release_delete = vim.fn.getcompletion('Forge release delete ', 'cmdline')
 
     assert.is_true(vim.tbl_contains(open, 'repo='))
+    assert.is_true(vim.tbl_contains(open, 'head='))
     assert.is_true(vim.tbl_contains(browse, 'repo='))
     assert.is_false(vim.tbl_contains(open, '401'))
     assert.is_false(vim.tbl_contains(open, '402'))

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -30,6 +30,7 @@ describe('shared operations', function()
       ['forge.log'] = package.preload['forge.log'],
       ['forge.logger'] = package.preload['forge.logger'],
       ['forge.pickers'] = package.preload['forge.pickers'],
+      ['forge.ci_history'] = package.preload['forge.ci_history'],
       ['forge.pr_checks'] = package.preload['forge.pr_checks'],
       ['forge.term'] = package.preload['forge.term'],
     }
@@ -139,6 +140,18 @@ describe('shared operations', function()
       }
     end
 
+    package.preload['forge.ci_history'] = function()
+      return {
+        open = function(f, head, opts)
+          captured.ci_history = {
+            f = f,
+            head = head,
+            opts = opts,
+          }
+        end,
+      }
+    end
+
     package.preload['forge.term'] = function()
       return {
         open = function(cmd, opts)
@@ -161,6 +174,7 @@ describe('shared operations', function()
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
     package.loaded['forge.pickers'] = nil
+    package.loaded['forge.ci_history'] = nil
     package.loaded['forge.pr_checks'] = nil
     package.loaded['forge.term'] = nil
   end)
@@ -175,6 +189,7 @@ describe('shared operations', function()
     package.preload['forge.log'] = old_preload['forge.log']
     package.preload['forge.logger'] = old_preload['forge.logger']
     package.preload['forge.pickers'] = old_preload['forge.pickers']
+    package.preload['forge.ci_history'] = old_preload['forge.ci_history']
     package.preload['forge.pr_checks'] = old_preload['forge.pr_checks']
     package.preload['forge.term'] = old_preload['forge.term']
 
@@ -183,8 +198,45 @@ describe('shared operations', function()
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
     package.loaded['forge.pickers'] = nil
+    package.loaded['forge.ci_history'] = nil
     package.loaded['forge.pr_checks'] = nil
     package.loaded['forge.term'] = nil
+  end)
+
+  it('opens deterministic current-branch CI history when structured runs are supported', function()
+    local ops = require('forge.ops')
+    local f = {
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function()
+        return { 'runs' }
+      end,
+    }
+
+    ops.ci(f, { branch = 'feature', scope = 'owner/repo' }, { back = 'root' })
+
+    assert.same({
+      f = f,
+      head = {
+        branch = 'feature',
+        scope = 'owner/repo',
+      },
+      opts = { back = 'root' },
+    }, captured.ci_history)
+    assert.is_nil(captured.ci)
+    assert.same({}, captured.infos)
+  end)
+
+  it('warns when structured current-branch CI data is unavailable', function()
+    local ops = require('forge.ops')
+
+    ops.ci({
+      name = 'custom',
+      labels = { ci_inline = 'runs' },
+    }, { branch = 'feature', scope = 'owner/repo' }, { back = 'root' })
+
+    assert.is_nil(captured.ci_history)
+    assert.same({ 'structured CI data not available for this forge' }, captured.infos)
   end)
 
   it('opens PR checks when the backend supports per-PR checks', function()


### PR DESCRIPTION
## Problem

Bare `:Forge ci` and `require('forge').ci()` still crossed into the interactive route layer instead of staying on the deterministic current-ref surface, which left the last current-branch CI entrypoint outside the Ex/API contract tracked by #465.

## Solution

Add a buffer-native current-branch CI history surface backed by structured run JSON, route bare `:Forge ci` and `require('forge').ci()` through shared deterministic ops, allow `repo=` and `head=` disambiguation on bare CI commands, and update specs/docs to treat current-branch CI history as part of the deterministic core surface.

Closes #465.
