### PR TITLE
fix(deps): make fzf-lua optional outside interactive routes (#466)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ without leaving your editor.
 - At least one forge CLI: [`gh`](https://cli.github.com/),
   [`glab`](https://gitlab.com/gitlab-org/cli), or
   [`tea`](https://gitea.com/gitea/tea)
-- (Optionally) [fzf-lua](https://github.com/ibhagwan/fzf-lua) >= 0.40 for the
-  picker UI
+- (Optionally) [fzf-lua](https://github.com/ibhagwan/fzf-lua) >= 0.40 for
+  interactive built-in routes (`require('forge').open()`) and the picker API
+  (`require('forge.picker').pick()`)
 - (Optionally) a code reviewing plugin:
   [`diffview.nvim`](https://github.com/sindrets/diffview.nvim),
   [`codediff.nvim`](https://github.com/esmuellert/codediff.nvim), or

--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -42,7 +42,9 @@ Requirements: ~
   - `gh` for GitHub
   - `glab` for GitLab
   - `tea` for Codeberg/Gitea/Forgejo
-- Optional: `fzf-lua` >= 0.40.0 for interactive picker workflows
+- Optional: `fzf-lua` >= 0.40.0 for interactive built-in routes
+  (`require('forge').open()`) and the picker API
+  (`require('forge.picker').pick()`)
 
 Run |:checkhealth| forge to verify CLIs and dependencies.
 
@@ -832,7 +834,9 @@ On GitLab, both canonical and provider-native route arguments work here, such
 as `require('forge').open('prs')` or `require('forge').open('mrs')`; route
 config keys still remain `routes.prs` and `routes.ci`.
 
-This interactive surface requires `fzf-lua`. Direct `:Forge` commands do not.
+This interactive surface requires `fzf-lua`. Direct `:Forge` commands and
+deterministic Lua helpers such as `require('forge').pr()`, `review()`,
+`pr_ci()`, `ci()`, `create_pr()`, and `create_issue()` do not.
 
 The picker surface covers workflows that do not fit cleanly in a single
 command, such as list navigation, row-scoped actions, filters, refresh,
@@ -1137,8 +1141,8 @@ Choose the surface by workflow type instead of by call depth:
 
 The top-level current-ref helpers mirror the Ex command semantics, including
 explicit `num=` targeting for PR actions. `require('forge').open()` is the
-entrypoint for built-in route and picker flows. `forge.picker.pick()` is the
-low-level UI primitive wired to `fzf-lua`.
+entrypoint for built-in interactive routes and picker flows.
+`forge.picker.pick()` is the low-level UI primitive wired to `fzf-lua`.
 On GitLab, route arguments also accept provider-native aliases such as `mrs`,
 `mrs.open`, `pipelines`, and `pipelines.current_branch`.
 

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -55,13 +55,13 @@ function M.check()
   end
 
   vim.health.start('Interactive picker UI')
-  local ok = pcall(require, 'fzf-lua')
-  if ok then
-    vim.health.ok('fzf-lua found (interactive picker UI enabled)')
-  else
-    vim.health.info(
-      'fzf-lua not found (interactive picker UI disabled; direct :Forge commands still available)'
+  local picker = require('forge.picker')
+  if picker.ui_available() then
+    vim.health.ok(
+      "fzf-lua found (require('forge').open() and require('forge.picker').pick() enabled)"
     )
+  else
+    vim.health.info(picker.unavailable_message())
   end
 
   vim.health.start('Tree-sitter')

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -4,6 +4,10 @@ local ci = require('forge.ci')
 local detect = require('forge.detect')
 local surface = require('forge.surface')
 
+local function has_fzf()
+  return pcall(require, 'fzf-lua')
+end
+
 ---@alias forge.Segment {[1]: string, [2]: string?}
 
 ---@class forge.PickerEntry
@@ -350,9 +354,23 @@ function M.ci_toggle_verb(entry)
   return ci.toggle_verb(value)
 end
 
+---@return boolean
+function M.ui_available()
+  return has_fzf()
+end
+
+---@return string
+function M.unavailable_message()
+  return "fzf-lua not found (interactive routes and require('forge.picker').pick() disabled; direct :Forge commands and deterministic Lua helpers still available)"
+end
+
 ---@param opts forge.PickerOpts
 ---@return forge.PickerHandle?
 function M.pick(opts)
+  if not M.ui_available() then
+    require('forge.logger').warn(M.unavailable_message())
+    return nil
+  end
   return require('forge.picker.fzf').pick(opts)
 end
 

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -53,12 +53,22 @@ end
 
 ---@return table<string, fun(ctx: forge.Context, opts: forge.RouteOpts): boolean?, string?>
 local function route_handlers()
-  local pickers = require('forge.pickers')
+  local function require_pickers()
+    local picker = require('forge.picker')
+    if not picker.ui_available() then
+      return nil, picker.unavailable_message()
+    end
+    return require('forge.pickers')
+  end
 
   return {
     ['prs.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
+      end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
       end
       pickers.pr('all', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
@@ -66,11 +76,19 @@ local function route_handlers()
       if not ctx.forge then
         return false, 'no forge detected'
       end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
+      end
       pickers.pr('open', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['prs.closed'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
+      end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
       end
       pickers.pr('closed', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
@@ -78,11 +96,19 @@ local function route_handlers()
       if not ctx.forge then
         return false, 'no forge detected'
       end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
+      end
       pickers.issue('all', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['issues.open'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
+      end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
       end
       pickers.issue('open', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
@@ -90,17 +116,29 @@ local function route_handlers()
       if not ctx.forge then
         return false, 'no forge detected'
       end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
+      end
       pickers.issue('closed', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['ci.all'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
+      end
       pickers.ci(ctx.forge, nil, nil, { back = opts.back, scope = opts.scope })
     end,
     ['ci.current_branch'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
+      end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
       end
       local branch = opts.branch
       if branch == nil or branch == '' then
@@ -153,17 +191,29 @@ local function route_handlers()
       if not ctx.forge then
         return false, 'no forge detected'
       end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
+      end
       pickers.release('all', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['releases.draft'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
       end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
+      end
       pickers.release('draft', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
     ['releases.prerelease'] = function(ctx, opts)
       if not ctx.forge then
         return false, 'no forge detected'
+      end
+      local pickers, err = require_pickers()
+      if not pickers then
+        return false, err
       end
       pickers.release('prerelease', ctx.forge, { back = opts.back, scope = opts.scope })
     end,
@@ -230,8 +280,13 @@ end
 
 ---@param ctx forge.Context
 ---@param opts? forge.RouteOpts
+---@return boolean?, string?
 local function open_root(ctx, opts)
   opts = opts or {}
+  local picker = require('forge.picker')
+  if not picker.ui_available() then
+    return false, picker.unavailable_message()
+  end
   local cfg = require('forge').config()
   local sections = rawget(cfg, 'sections') or {}
   local routes = rawget(cfg, 'routes') or {}
@@ -274,7 +329,7 @@ local function open_root(ctx, opts)
     return
   end
 
-  require('forge.picker').pick({
+  picker.pick({
     prompt = prompt(ctx),
     entries = entries,
     actions = { default_action },
@@ -297,7 +352,10 @@ function M.open(name, opts)
   local forge_name = route_forge_name(ctx, opts)
 
   if not name or name == '' then
-    open_root(ctx, vim.tbl_extend('force', opts, { forge_name = forge_name }))
+    local ok, msg = open_root(ctx, vim.tbl_extend('force', opts, { forge_name = forge_name }))
+    if ok == false and msg then
+      log.warn(msg)
+    end
     return
   end
 

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -95,10 +95,12 @@ describe('health', function()
 
     package.preload['forge.picker'] = function()
       return {
-        backend = function()
-          return 'fzf-lua'
+        ui_available = function()
+          return pcall(require, 'fzf-lua')
         end,
-        detect_order = { 'fzf-lua' },
+        unavailable_message = function()
+          return "fzf-lua not found (interactive routes and require('forge.picker').pick() disabled; direct :Forge commands and deterministic Lua helpers still available)"
+        end,
       }
     end
 
@@ -141,7 +143,12 @@ describe('health', function()
     assert.is_true(vim.tbl_contains(captured.starts, 'Review adapters'))
     assert.is_true(vim.tbl_contains(captured.oks, 'git found'))
     assert.is_true(vim.tbl_contains(captured.oks, 'configured review adapter "checkout" available'))
-    assert.is_true(vim.tbl_contains(captured.oks, 'fzf-lua found (interactive picker UI enabled)'))
+    assert.is_true(
+      vim.tbl_contains(
+        captured.oks,
+        "fzf-lua found (require('forge').open() and require('forge.picker').pick() enabled)"
+      )
+    )
     assert.is_true(
       vim.tbl_contains(captured.infos, 'diffview.nvim not found (adapter=diffview unavailable)')
     )
@@ -160,7 +167,9 @@ describe('health', function()
   end)
 
   it('reports missing optional interactive picker UI as info', function()
-    package.preload['fzf-lua'] = nil
+    package.preload['fzf-lua'] = function()
+      error("module 'fzf-lua' not found")
+    end
     package.loaded['fzf-lua'] = nil
     package.loaded['forge.health'] = nil
 
@@ -169,7 +178,7 @@ describe('health', function()
     assert.is_true(
       vim.tbl_contains(
         captured.infos,
-        'fzf-lua not found (interactive picker UI disabled; direct :Forge commands still available)'
+        "fzf-lua not found (interactive routes and require('forge.picker').pick() disabled; direct :Forge commands and deterministic Lua helpers still available)"
       )
     )
   end)

--- a/spec/picker_init_spec.lua
+++ b/spec/picker_init_spec.lua
@@ -247,3 +247,85 @@ describe('forge.picker.order_hints', function()
     assert.same({ 'default', 'create', 'filter', 'refresh', 'mystery_a' }, names(ordered))
   end)
 end)
+
+describe('forge.picker.pick', function()
+  local old_preload
+  local warnings
+
+  before_each(function()
+    warnings = {}
+    old_preload = {
+      ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.picker.fzf'] = package.preload['forge.picker.fzf'],
+      ['fzf-lua'] = package.preload['fzf-lua'],
+    }
+
+    package.preload['forge.logger'] = function()
+      return {
+        warn = function(msg)
+          warnings[#warnings + 1] = msg
+        end,
+      }
+    end
+
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.fzf'] = nil
+    package.loaded['fzf-lua'] = nil
+  end)
+
+  after_each(function()
+    package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.picker.fzf'] = old_preload['forge.picker.fzf']
+    package.preload['fzf-lua'] = old_preload['fzf-lua']
+
+    package.loaded['forge.logger'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.picker.fzf'] = nil
+    package.loaded['fzf-lua'] = nil
+  end)
+
+  it('warns cleanly when fzf-lua is unavailable', function()
+    package.preload['fzf-lua'] = function()
+      error("module 'fzf-lua' not found")
+    end
+
+    local picker = require('forge.picker')
+    local handle = picker.pick({
+      entries = {},
+      actions = {},
+      picker_name = 'pr',
+    })
+
+    assert.is_nil(handle)
+    assert.same({
+      "fzf-lua not found (interactive routes and require('forge.picker').pick() disabled; direct :Forge commands and deterministic Lua helpers still available)",
+    }, warnings)
+  end)
+
+  it('delegates to the fzf backend when available', function()
+    local captured
+    package.preload['fzf-lua'] = function()
+      return {}
+    end
+    package.preload['forge.picker.fzf'] = function()
+      return {
+        pick = function(opts)
+          captured = opts
+          return { refresh = function() end }
+        end,
+      }
+    end
+
+    local picker = require('forge.picker')
+    local handle = picker.pick({
+      entries = {},
+      actions = {},
+      picker_name = 'pr',
+    })
+
+    assert.is_table(handle)
+    assert.same('pr', captured.picker_name)
+    assert.same({}, warnings)
+  end)
+end)

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -117,6 +117,7 @@ describe('routes', function()
       ['forge.logger'] = package.preload['forge.logger'],
       ['forge.picker'] = package.preload['forge.picker'],
       ['forge.pickers'] = package.preload['forge.pickers'],
+      ['fzf-lua'] = package.preload['fzf-lua'],
     }
 
     package.preload['forge'] = function()
@@ -156,13 +157,14 @@ describe('routes', function()
     package.preload['forge.picker'] = function()
       local picker = dofile(vim.fn.getcwd() .. '/lua/forge/picker/init.lua')
       return vim.tbl_extend('force', picker, {
-        backend = function()
-          return 'fzf-lua'
-        end,
         pick = function(opts)
           captured.root = opts
         end,
       })
+    end
+
+    package.preload['fzf-lua'] = function()
+      return {}
     end
 
     package.preload['forge.pickers'] = function()
@@ -205,11 +207,13 @@ describe('routes', function()
     package.preload['forge.logger'] = old_preload['forge.logger']
     package.preload['forge.picker'] = old_preload['forge.picker']
     package.preload['forge.pickers'] = old_preload['forge.pickers']
+    package.preload['fzf-lua'] = old_preload['fzf-lua']
 
     package.loaded['forge'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.pickers'] = nil
+    package.loaded['fzf-lua'] = nil
     package.loaded['forge.routes'] = nil
   end)
 
@@ -297,6 +301,45 @@ describe('routes', function()
     )
   end)
 
+  it('warns cleanly when fzf-lua is missing for the root picker surface', function()
+    package.preload['fzf-lua'] = function()
+      error("module 'fzf-lua' not found")
+    end
+    package.loaded['fzf-lua'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.routes'] = nil
+
+    require('forge.routes').open()
+
+    assert.equals(
+      "fzf-lua not found (interactive routes and require('forge.picker').pick() disabled; direct :Forge commands and deterministic Lua helpers still available)",
+      captured.warn
+    )
+    assert.is_nil(captured.root)
+    assert.is_nil(captured.pr)
+    assert.is_nil(captured.issue)
+    assert.is_nil(captured.ci)
+    assert.is_nil(captured.release)
+  end)
+
+  it('warns cleanly when fzf-lua is missing for picker-backed routes', function()
+    package.preload['fzf-lua'] = function()
+      error("module 'fzf-lua' not found")
+    end
+    package.loaded['fzf-lua'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.routes'] = nil
+
+    require('forge.routes').open('prs.open')
+
+    assert.equals(
+      "fzf-lua not found (interactive routes and require('forge.picker').pick() disabled; direct :Forge commands and deterministic Lua helpers still available)",
+      captured.warn
+    )
+    assert.is_nil(captured.pr)
+    assert.is_nil(captured.root)
+  end)
+
   it('accepts GitLab route aliases in root route defaults while keeping canonical keys', function()
     detected_forge = fake_gitlab_forge()
     current_config.routes.prs = 'mrs.closed'
@@ -330,6 +373,21 @@ describe('routes', function()
 
     assert.equals('https://github.com/owner/current', captured.opened_url)
     assert.is_nil(captured.browse)
+  end)
+
+  it('still allows non-picker browse routes when fzf-lua is missing', function()
+    package.preload['fzf-lua'] = function()
+      error("module 'fzf-lua' not found")
+    end
+    package.loaded['fzf-lua'] = nil
+    package.loaded['forge.picker'] = nil
+    package.loaded['forge.routes'] = nil
+
+    vim.api.nvim_set_current_buf(vim.api.nvim_create_buf(false, true))
+    require('forge.routes').open('browse.contextual')
+
+    assert.equals('https://github.com/owner/current', captured.opened_url)
+    assert.is_nil(captured.warn)
   end)
 
   it('treats special URI buffers as non-file context for contextual browse', function()


### PR DESCRIPTION
## Problem

`fzf-lua` was documented as optional, but the boundary stayed implicit: picker-backed built-in routes could still fall into interactive code paths without a clean dependency check, and the health/docs wording did not clearly distinguish interactive surfaces from deterministic commands and helpers.

## Solution

Add an explicit picker UI availability contract in `forge.picker`, fail picker-backed routes and the public picker API with a clean warning when `fzf-lua` is missing, keep non-picker browse routes untouched, and update health/specs/docs so the optional dependency boundary is enforced and documented consistently.

Closes #466.
