### PR TITLE
feat(compose): switch compose buffers to forgecompose

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -856,7 +856,7 @@ block on `:w`; unsupported fields are omitted from the scaffold for the current
 forge and operation.
 
 Creating a PR (without `fill` or `web`) opens a compose buffer at
-`forge://{host}/{slug}/pr/new` with filetype `markdown` and buftype `acwrite`.
+`forge://{host}/{slug}/pr/new` with filetype `forgecompose` and buftype `acwrite`.
 
 Layout: ~
   Line 1      PR title (pre-filled from single commit subject or branch)
@@ -885,7 +885,7 @@ includes a diff stat against `origin/{base}`. Writing (`:w`) updates the PR.
 Editing is aborted if the title or body is empty.
 
 Creating an issue (without `web`) opens a compose buffer at
-`forge://{host}/{slug}/issue/new` with filetype `markdown` and buftype
+`forge://{host}/{slug}/issue/new` with filetype `forgecompose` and buftype
 `acwrite`.
 
 Layout: ~
@@ -923,6 +923,10 @@ Integration: ~                                     *forge-compose-integration*
 <
   `kind` identifies the compose target. `url` is the target repository web
   URL and is an empty string if forge.nvim cannot resolve it.
+
+  `FileType forgecompose` is the supported hook for compose-buffer
+  customization. `kind` distinguishes PR compose buffers from issue compose
+  buffers.
 
   Completion or integration plugins can use this table to enable
   forge-specific behavior only inside compose buffers.

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -83,6 +83,15 @@ local function set_public_buffer_state(buf, forge_name, kind, ref)
   }
 end
 
+---@param win integer
+local function pin_compose_window(win)
+  if not (win and vim.api.nvim_win_is_valid(win)) then
+    return
+  end
+  vim.wo[win].wrap = false
+  vim.wo[win].conceallevel = 0
+end
+
 ---@return integer
 local function create_compose_buf(name)
   local prev_win = vim.api.nvim_get_current_win()
@@ -103,8 +112,28 @@ local function create_compose_buf(name)
   vim.api.nvim_buf_set_name(buf, name)
   vim.bo[buf].buftype = 'acwrite'
   vim.bo[buf].bufhidden = 'wipe'
-  vim.bo[buf].filetype = 'markdown'
+  vim.bo[buf].filetype = 'forgecompose'
   vim.bo[buf].swapfile = false
+  pin_compose_window(win)
+  pcall(function()
+    vim.treesitter.start(buf, 'markdown')
+  end)
+  local repin_autocmd = vim.api.nvim_create_autocmd('BufWinEnter', {
+    buffer = buf,
+    callback = function()
+      local current_win = vim.api.nvim_get_current_win()
+      if vim.api.nvim_win_get_buf(current_win) == buf then
+        pin_compose_window(current_win)
+      end
+    end,
+  })
+  vim.api.nvim_create_autocmd('BufWipeout', {
+    buffer = buf,
+    once = true,
+    callback = function()
+      pcall(vim.api.nvim_del_autocmd, repin_autocmd)
+    end,
+  })
   vim.b[buf].forge_compose_prev_win = prev_win
   vim.b[buf].forge_compose_win = win
   return buf

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -30,6 +30,8 @@ describe('compose issue create', function()
   local captured
   local old_system
   local old_preload
+  local old_wrap
+  local old_conceallevel
 
   before_each(function()
     captured = {
@@ -40,6 +42,8 @@ describe('compose issue create', function()
     }
 
     old_system = vim.system
+    old_wrap = vim.o.wrap
+    old_conceallevel = vim.o.conceallevel
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
@@ -109,6 +113,8 @@ describe('compose issue create', function()
 
   after_each(function()
     vim.system = old_system
+    vim.o.wrap = old_wrap
+    vim.o.conceallevel = old_conceallevel
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
@@ -305,6 +311,23 @@ describe('compose issue create', function()
     assert.same({ 'ForgeComposeForge' }, extmark_groups_for_line(0, '  Creating issue via github.'))
   end)
 
+  it('uses forgecompose and pinned compose window options for issue create', function()
+    vim.o.wrap = true
+    vim.o.conceallevel = 3
+
+    local compose = require('forge.compose')
+    compose.open_issue({
+      name = 'github',
+      create_issue_cmd = function()
+        return { 'create-issue' }
+      end,
+    })
+
+    assert.equals('forgecompose', vim.bo[0].filetype)
+    assert.is_false(vim.wo[0].wrap)
+    assert.equals(0, vim.wo[0].conceallevel)
+  end)
+
   it('keeps template labels without rendering editable metadata', function()
     local compose = require('forge.compose')
     local f = {
@@ -445,6 +468,8 @@ describe('compose issue edit', function()
   local captured
   local old_system
   local old_preload
+  local old_wrap
+  local old_conceallevel
 
   before_each(function()
     captured = {
@@ -455,6 +480,8 @@ describe('compose issue edit', function()
     }
 
     old_system = vim.system
+    old_wrap = vim.o.wrap
+    old_conceallevel = vim.o.conceallevel
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
@@ -524,6 +551,8 @@ describe('compose issue edit', function()
 
   after_each(function()
     vim.system = old_system
+    vim.o.wrap = old_wrap
+    vim.o.conceallevel = old_conceallevel
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
@@ -622,6 +651,33 @@ describe('compose issue edit', function()
       { 'ForgeComposeForge' },
       extmark_groups_for_line(0, '  Editing issue #42 via github.')
     )
+  end)
+
+  it('uses forgecompose and pinned compose window options for issue edit', function()
+    vim.o.wrap = true
+    vim.o.conceallevel = 3
+
+    local compose = require('forge.compose')
+    compose.open_issue_edit(
+      {
+        name = 'github',
+        update_issue_cmd = function()
+          return { 'update-issue' }
+        end,
+      },
+      '42',
+      {
+        title = 'existing issue',
+        body = 'body',
+        labels = {},
+        assignees = {},
+        milestone = '',
+      }
+    )
+
+    assert.equals('forgecompose', vim.bo[0].filetype)
+    assert.is_false(vim.wo[0].wrap)
+    assert.equals(0, vim.wo[0].conceallevel)
   end)
 
   it('extracts issue metadata from the comment block on write', function()

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -6,6 +6,8 @@ describe('compose pr create', function()
   local old_system
   local old_feedkeys
   local old_preload
+  local old_wrap
+  local old_conceallevel
 
   local function line_index(lines, target)
     for i, line in ipairs(lines) do
@@ -36,6 +38,12 @@ describe('compose pr create', function()
     return groups
   end
 
+  local function assert_compose_surface(buf, win)
+    assert.equals('forgecompose', vim.bo[buf].filetype)
+    assert.is_false(vim.wo[win].wrap)
+    assert.equals(0, vim.wo[win].conceallevel)
+  end
+
   before_each(function()
     captured = {
       diff_stat = '',
@@ -45,6 +53,8 @@ describe('compose pr create', function()
     old_fn_system = vim.fn.system
     old_system = vim.system
     old_feedkeys = vim.api.nvim_feedkeys
+    old_wrap = vim.o.wrap
+    old_conceallevel = vim.o.conceallevel
     old_preload = {
       ['forge.template'] = package.preload['forge.template'],
     }
@@ -97,6 +107,8 @@ describe('compose pr create', function()
     vim.fn.system = old_fn_system
     vim.system = old_system
     vim.api.nvim_feedkeys = old_feedkeys
+    vim.o.wrap = old_wrap
+    vim.o.conceallevel = old_conceallevel
 
     package.preload['forge.template'] = old_preload['forge.template']
 
@@ -209,6 +221,20 @@ describe('compose pr create', function()
       extmark_groups_for_line(0, '   lua/forge/pickers.lua | 2 +-')
     )
     assert.same({}, extmark_groups_for_line(0, '   1 file changed, 1 insertion(+), 1 deletion(-)'))
+  end)
+
+  it('uses forgecompose and pinned compose window options for PR create', function()
+    vim.o.wrap = true
+    vim.o.conceallevel = 3
+
+    local compose = require('forge.compose')
+    compose.open_pr({
+      labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+      capabilities = { draft = true, reviewers = false },
+      name = 'github',
+    }, 'new', 'main', false, nil, nil, 'origin', 'origin/main', 'HEAD')
+
+    assert_compose_surface(vim.api.nvim_get_current_buf(), vim.api.nvim_get_current_win())
   end)
 
   it('exposes public forge buffer metadata for PR compose buffers', function()

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -6,6 +6,8 @@ describe('compose pr edit', function()
   local old_system
   local old_feedkeys
   local old_preload
+  local old_wrap
+  local old_conceallevel
 
   local function line_index(lines, target)
     for i, line in ipairs(lines) do
@@ -36,6 +38,12 @@ describe('compose pr edit', function()
     return groups
   end
 
+  local function assert_compose_surface(buf, win)
+    assert.equals('forgecompose', vim.bo[buf].filetype)
+    assert.is_false(vim.wo[win].wrap)
+    assert.equals(0, vim.wo[win].conceallevel)
+  end
+
   before_each(function()
     captured = {
       infos = {},
@@ -48,6 +56,8 @@ describe('compose pr edit', function()
     old_fn_system = vim.fn.system
     old_system = vim.system
     old_feedkeys = vim.api.nvim_feedkeys
+    old_wrap = vim.o.wrap
+    old_conceallevel = vim.o.conceallevel
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
@@ -116,6 +126,8 @@ describe('compose pr edit', function()
     vim.fn.system = old_fn_system
     vim.system = old_system
     vim.api.nvim_feedkeys = old_feedkeys
+    vim.o.wrap = old_wrap
+    vim.o.conceallevel = old_conceallevel
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
@@ -342,6 +354,35 @@ describe('compose pr edit', function()
       extmark_groups_for_line(0, '   lua/forge/init.lua | 2 +-')
     )
     assert.same({}, extmark_groups_for_line(0, '   1 file changed, 1 insertion(+), 1 deletion(-)'))
+  end)
+
+  it('uses forgecompose and pinned compose window options for PR edit', function()
+    vim.o.wrap = true
+    vim.o.conceallevel = 3
+
+    local compose = require('forge.compose')
+    compose.open_pr_edit(
+      {
+        labels = { pr_full = 'Pull Requests', pr_one = 'PR' },
+        capabilities = { draft = true, reviewers = true },
+        name = 'github',
+      },
+      '23',
+      {
+        title = 'PR title',
+        body = 'PR body',
+        draft = false,
+        head_branch = 'feature',
+        base_branch = 'main',
+        reviewers = {},
+        labels = {},
+        assignees = {},
+        milestone = '',
+      },
+      'feature'
+    )
+
+    assert_compose_surface(vim.api.nvim_get_current_buf(), vim.api.nvim_get_current_win())
   end)
 
   it('extracts PR metadata from the comment block on write', function()

--- a/spec/compose_split_spec.lua
+++ b/spec/compose_split_spec.lua
@@ -5,6 +5,9 @@ describe('compose split session', function()
   local old_system
   local old_feedkeys
   local old_preload
+  local old_wrap
+  local old_conceallevel
+  local hostile_group
 
   local function issue_forge()
     return {
@@ -39,14 +42,23 @@ describe('compose split session', function()
     }
   end
 
+  local function assert_compose_surface(buf, win)
+    assert.equals('forgecompose', vim.bo[buf].filetype)
+    assert.is_false(vim.wo[win].wrap)
+    assert.equals(0, vim.wo[win].conceallevel)
+  end
+
   before_each(function()
     captured = {
       cleared = 0,
       split = 'horizontal',
     }
+    hostile_group = nil
 
     old_system = vim.system
     old_feedkeys = vim.api.nvim_feedkeys
+    old_wrap = vim.o.wrap
+    old_conceallevel = vim.o.conceallevel
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.config'] = package.preload['forge.config'],
@@ -128,6 +140,11 @@ describe('compose split session', function()
   after_each(function()
     vim.system = old_system
     vim.api.nvim_feedkeys = old_feedkeys
+    vim.o.wrap = old_wrap
+    vim.o.conceallevel = old_conceallevel
+    if hostile_group then
+      pcall(vim.api.nvim_del_augroup_by_id, hostile_group)
+    end
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.config'] = old_preload['forge.config']
@@ -187,6 +204,34 @@ describe('compose split session', function()
     assert.equals(2, #vim.api.nvim_tabpage_list_wins(0))
     assert.equals(base_pos[1], compose_pos[1])
     assert.is_not.equals(base_pos[2], compose_pos[2])
+  end)
+
+  it('re-pins compose window options after BufWinEnter resets them', function()
+    vim.o.wrap = true
+    vim.o.conceallevel = 3
+    hostile_group = vim.api.nvim_create_augroup('forge_compose_test_bufwinenter', { clear = true })
+    vim.api.nvim_create_autocmd('BufWinEnter', {
+      group = hostile_group,
+      callback = function()
+        vim.wo.wrap = true
+        vim.wo.conceallevel = 3
+      end,
+    })
+
+    local compose = require('forge.compose')
+    local base_win = vim.api.nvim_get_current_win()
+
+    compose.open_issue(issue_forge())
+
+    local compose_win = vim.api.nvim_get_current_win()
+    local compose_buf = vim.api.nvim_get_current_buf()
+
+    assert_compose_surface(compose_buf, compose_win)
+
+    vim.api.nvim_set_current_win(base_win)
+    vim.api.nvim_set_current_win(compose_win)
+
+    assert_compose_surface(compose_buf, compose_win)
   end)
 
   it('closes the issue compose split and returns focus to the prior buffer on success', function()


### PR DESCRIPTION
## Problem

Compose buffers currently claim the `markdown` filetype, so user markdown tooling and window defaults can reshape the title and scaffold layout. This closes #475 and #462.

## Solution

Move compose buffers onto `forgecompose`, pin `wrap=false` and `conceallevel=0` when the compose window opens and re-enters, keep body highlighting through markdown treesitter, and update the help/docs and compose specs around the new contract.
