### PR TITLE
feat(buffers): split forge_log into forgelist and forgelog

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -913,23 +913,26 @@ layout as issue creation. Writing (`:w`) updates the issue. Editing is
 aborted if the title is empty. Empty bodies are allowed.
 
 Integration: ~                                     *forge-compose-integration*
-  Compose buffers expose a small public buffer-local table for completion
+  Forge-owned buffers expose a small public buffer-local table for completion
   and other integrations: >
       vim.b.forge = {
         version = 1,
-        kind = 'pr' | 'issue',
+        kind = 'pr' | 'issue'
+             | 'ci_history' | 'pr_checks' | 'ci_summary'
+             | 'ci_log',
         url = 'https://host/owner/repo',
       }
 <
-  `kind` identifies the compose target. `url` is the target repository web
-  URL and is an empty string if forge.nvim cannot resolve it.
+  `kind` identifies the forge buffer kind. `url` is the target page when
+  forge.nvim can resolve one and is an empty string otherwise.
 
-  `FileType forgecompose` is the supported hook for compose-buffer
-  customization. `kind` distinguishes PR compose buffers from issue compose
-  buffers.
+  `FileType forgecompose` is the supported hook for authored compose buffers.
+  `FileType forgelist` is the hook for structured read-only viewers
+  (`ci_history`, `pr_checks`, `ci_summary`). `FileType forgelog` is the hook
+  for streamed run/job log buffers.
 
   Completion or integration plugins can use this table to enable
-  forge-specific behavior only inside compose buffers.
+  forge-specific behavior only inside forge-owned buffers.
 
 Template discovery: ~
   forge.nvim searches forge-specific template paths. A single discovered

--- a/lua/forge/ci_history.lua
+++ b/lua/forge/ci_history.lua
@@ -53,6 +53,17 @@ local function set_data(buf, fields)
   return data
 end
 
+---@param buf integer
+---@param kind forge.BufferKind
+---@param url string?
+local function set_public_buffer_state(buf, kind, url)
+  vim.b[buf].forge = {
+    version = 1,
+    kind = kind,
+    url = type(url) == 'string' and url or '',
+  }
+end
+
 local function stop_proc(buf)
   local proc = data_for(buf).proc
   if proc and type(proc.kill) == 'function' then
@@ -292,7 +303,6 @@ local function prepare_buf(head, reuse_buf)
       vim.bo[buf].bufhidden = 'wipe'
       vim.bo[buf].swapfile = false
       vim.bo[buf].modifiable = false
-      vim.bo[buf].filetype = 'forge_log'
       if name then
         vim.api.nvim_buf_set_name(buf, name)
       end
@@ -305,6 +315,8 @@ local function prepare_buf(head, reuse_buf)
       })
     end
   end
+  vim.bo[buf].filetype = 'forgelist'
+  set_public_buffer_state(buf, 'ci_history', scope_mod.branch_web_url(head.scope, head.branch))
   if not reusing then
     render(buf, render_placeholder('Loading...', 'ForgeDim'))
   end

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -57,6 +57,17 @@ local function set_data(buf, fields)
   return d
 end
 
+---@param buf integer
+---@param kind forge.BufferKind
+---@param url string?
+local function set_public_buffer_state(buf, kind, url)
+  vim.b[buf].forge = {
+    version = 1,
+    kind = kind,
+    url = type(url) == 'string' and url or '',
+  }
+end
+
 local function stop_procs(buf)
   local d = buf_data[buf]
   if d and d.procs then
@@ -871,7 +882,6 @@ function M.open(cmd, opts, reuse_buf)
       vim.bo[buf].bufhidden = 'wipe'
       vim.bo[buf].swapfile = false
       vim.bo[buf].modifiable = false
-      vim.bo[buf].filetype = 'forge_log'
       if bufname then
         vim.api.nvim_buf_set_name(buf, bufname)
       end
@@ -886,6 +896,8 @@ function M.open(cmd, opts, reuse_buf)
       })
     end
   end
+  vim.bo[buf].filetype = 'forgelog'
+  set_public_buffer_state(buf, 'ci_log', opts.url)
   if not reusing then
     vim.bo[buf].modifiable = true
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, { 'Loading...' })
@@ -1171,7 +1183,6 @@ function M.open_summary(cmd, opts, reuse_buf)
       vim.bo[buf].bufhidden = 'wipe'
       vim.bo[buf].swapfile = false
       vim.bo[buf].modifiable = false
-      vim.bo[buf].filetype = 'forge_log'
       if bufname then
         vim.api.nvim_buf_set_name(buf, bufname)
       end
@@ -1185,6 +1196,8 @@ function M.open_summary(cmd, opts, reuse_buf)
       })
     end
   end
+  vim.bo[buf].filetype = 'forgelist'
+  set_public_buffer_state(buf, 'ci_summary', opts.url)
 
   if not reusing then
     vim.bo[buf].modifiable = true

--- a/lua/forge/pr_checks.lua
+++ b/lua/forge/pr_checks.lua
@@ -47,6 +47,17 @@ local function set_data(buf, fields)
   return data
 end
 
+---@param buf integer
+---@param kind forge.BufferKind
+---@param url string?
+local function set_public_buffer_state(buf, kind, url)
+  vim.b[buf].forge = {
+    version = 1,
+    kind = kind,
+    url = type(url) == 'string' and url or '',
+  }
+end
+
 local function stop_proc(buf)
   local proc = data_for(buf).proc
   if proc and type(proc.kill) == 'function' then
@@ -315,7 +326,6 @@ local function prepare_buf(pr, reuse_buf)
       vim.bo[buf].bufhidden = 'wipe'
       vim.bo[buf].swapfile = false
       vim.bo[buf].modifiable = false
-      vim.bo[buf].filetype = 'forge_log'
       if name then
         vim.api.nvim_buf_set_name(buf, name)
       end
@@ -328,6 +338,8 @@ local function prepare_buf(pr, reuse_buf)
       })
     end
   end
+  vim.bo[buf].filetype = 'forgelist'
+  set_public_buffer_state(buf, 'pr_checks', scope_mod.subject_web_url('pr', pr.num, pr.scope))
   if not reusing then
     render(buf, render_placeholder('Loading...', 'ForgeDim'))
   end

--- a/lua/forge/scope.lua
+++ b/lua/forge/scope.lua
@@ -29,6 +29,27 @@ local function split_url(url)
   return host, path
 end
 
+local SUBJECT_PATHS = {
+  github = {
+    pr = '/pull/',
+    issue = '/issues/',
+  },
+  gitlab = {
+    pr = '/-/merge_requests/',
+    issue = '/-/issues/',
+  },
+  codeberg = {
+    pr = '/pulls/',
+    issue = '/issues/',
+  },
+}
+
+local BRANCH_PATHS = {
+  github = '/tree/',
+  gitlab = '/-/tree/',
+  codeberg = '/src/branch/',
+}
+
 ---@param url string
 ---@return forge.Scope?
 local function github_scope(url)
@@ -172,9 +193,65 @@ function M.web_url(scope)
 end
 
 ---@param scope forge.Scope?
+---@return string
+function M.resolved_web_url(scope)
+  local url = M.web_url(scope)
+  if url ~= '' then
+    return url
+  end
+  if type(scope) ~= 'table' then
+    return ''
+  end
+  local host = scope.host
+  local slug = scope.slug
+  if type(host) ~= 'string' or host == '' or type(slug) ~= 'string' or slug == '' then
+    return ''
+  end
+  return ('https://%s/%s'):format(host, slug)
+end
+
+---@param scope forge.Scope?
+---@param branch string?
+---@return string
+function M.branch_web_url(scope, branch)
+  if type(branch) ~= 'string' or branch == '' or type(scope) ~= 'table' then
+    return ''
+  end
+  local base = M.resolved_web_url(scope)
+  if base == '' then
+    return ''
+  end
+  local path = BRANCH_PATHS[scope.kind]
+  if not path then
+    return ''
+  end
+  return base .. path .. branch
+end
+
+---@param kind forge.SubjectKind
+---@param num string?
+---@param scope forge.Scope?
+---@return string
+function M.subject_web_url(kind, num, scope)
+  if type(num) ~= 'string' or num == '' or type(scope) ~= 'table' then
+    return ''
+  end
+  local base = M.resolved_web_url(scope)
+  if base == '' then
+    return ''
+  end
+  local paths = SUBJECT_PATHS[scope.kind]
+  local path = paths and paths[kind]
+  if not path then
+    return ''
+  end
+  return base .. path .. num
+end
+
+---@param scope forge.Scope?
 ---@return string?
 function M.git_url(scope)
-  local url = M.web_url(scope)
+  local url = M.resolved_web_url(scope)
   if url == '' then
     return nil
   end

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -3,6 +3,8 @@
 ---@alias forge.ScopeKind 'github'|'gitlab'|'codeberg'
 
 ---@alias forge.WebKind 'pr'|'issue'|'ci'|'release'
+---@alias forge.SubjectKind 'pr'|'issue'
+---@alias forge.BufferKind 'pr'|'issue'|'ci_history'|'pr_checks'|'ci_summary'|'ci_log'
 ---@alias forge.CommandFamily 'pr'|'review'|'issue'|'ci'|'release'|'browse'|'clear'
 ---@alias forge.SectionName 'prs'|'issues'|'ci'|'browse'|'releases'
 ---@alias forge.RouteName
@@ -34,6 +36,11 @@
 ---@class forge.LineRange
 ---@field start_line integer
 ---@field end_line integer
+
+---@class forge.BufferState
+---@field version integer
+---@field kind forge.BufferKind
+---@field url string
 
 ---@class forge.RepoTarget
 ---@field kind 'repo'

--- a/spec/ci_history_spec.lua
+++ b/spec/ci_history_spec.lua
@@ -94,6 +94,9 @@ describe('ci history buffer', function()
         bufpath = function()
           return 'github.com/owner/repo'
         end,
+        branch_web_url = function(_, branch)
+          return 'https://github.com/owner/repo/tree/' .. branch
+        end,
       }
     end
 
@@ -174,6 +177,12 @@ describe('ci history buffer', function()
 
     local buf = vim.api.nvim_get_current_buf()
     assert.equals('forge://github.com/owner/repo/ci/main', vim.api.nvim_buf_get_name(buf))
+    assert.equals('forgelist', vim.bo[buf].filetype)
+    assert.same({
+      version = 1,
+      kind = 'ci_history',
+      url = 'https://github.com/owner/repo/tree/main',
+    }, vim.b[buf].forge)
     vim.wait(100, function()
       return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'CI'
     end)

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -845,6 +845,91 @@ describe('summary job mappings', function()
   end)
 end)
 
+describe('public buffer identity', function()
+  local original_system
+
+  before_each(function()
+    original_system = vim.system
+  end)
+
+  after_each(function()
+    vim.system = original_system
+
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.api.nvim_buf_is_valid(buf) then
+        local name = vim.api.nvim_buf_get_name(buf)
+        if name:match('^forge://') then
+          vim.api.nvim_buf_delete(buf, { force = true })
+        end
+      end
+    end
+    vim.cmd('silent! %bwipeout!')
+    vim.cmd('enew!')
+  end)
+
+  it('marks log buffers as forgelog with ci_log public state', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = 'build\tstep\t2024-01-01T00:00:00Z hello',
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    log_mod.open({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      scope = test_scope,
+      run_id = '77',
+      url = 'https://example.com/runs/77',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'build'
+    end)
+
+    assert.equals('forgelog', vim.bo[buf].filetype)
+    assert.same({
+      version = 1,
+      kind = 'ci_log',
+      url = 'https://example.com/runs/77',
+    }, vim.b[buf].forge)
+  end)
+
+  it('marks summary buffers as forgelist with ci_summary public state', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = '✓ lint (ID 12345)',
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    log_mod.open_summary({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      scope = test_scope,
+      run_id = '12345',
+      url = 'https://example.com/runs/12345',
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == '✓ lint (ID 12345)'
+    end)
+
+    assert.equals('forgelist', vim.bo[buf].filetype)
+    assert.same({
+      version = 1,
+      kind = 'ci_summary',
+      url = 'https://example.com/runs/12345',
+    }, vim.b[buf].forge)
+  end)
+end)
+
 describe('log folds', function()
   local original_system
 

--- a/spec/pr_checks_spec.lua
+++ b/spec/pr_checks_spec.lua
@@ -12,6 +12,7 @@ describe('pr checks buffer', function()
     kind = 'github',
     host = 'github.com',
     slug = 'owner/repo',
+    web_url = 'https://github.com/owner/repo',
   }
 
   before_each(function()
@@ -89,6 +90,9 @@ describe('pr checks buffer', function()
       return {
         bufpath = function()
           return 'github.com/owner/repo'
+        end,
+        subject_web_url = function(_, num)
+          return 'https://github.com/owner/repo/pull/' .. num
         end,
       }
     end
@@ -184,6 +188,12 @@ describe('pr checks buffer', function()
 
     local buf = vim.api.nvim_get_current_buf()
     assert.equals('forge://github.com/owner/repo/pr/42/checks', vim.api.nvim_buf_get_name(buf))
+    assert.equals('forgelist', vim.bo[buf].filetype)
+    assert.same({
+      version = 1,
+      kind = 'pr_checks',
+      url = 'https://github.com/owner/repo/pull/42',
+    }, vim.b[buf].forge)
     vim.wait(100, function()
       return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'lint'
     end)


### PR DESCRIPTION
## Problem

The branch CI history buffer, PR checks buffer, run summary buffer, and streamed log buffer all currently claim the same `forge_log` filetype, and only compose buffers expose public `vim.b.forge` state. That makes structured row viewers indistinguishable from actual log buffers for users and integrations.

## Solution

Split the readonly buffer contracts into `forgelist` and `forgelog`, publish `vim.b.forge` across the readonly forge buffer family, add backend-aware URL helpers for branch and subject pages, and document the expanded buffer identity surface.
