### PR TITLE
fix(buffers): disambiguate CI branch and run bufnames

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -1299,6 +1299,11 @@ For the implicit-ref rollout:
   checks buffers.
 - bare `:Forge ci` and `require('forge').ci()` now open deterministic
   current-branch CI history buffers.
+- CI buffer names now use explicit namespaces:
+  `forge://.../ci/branch/{branch}` for current-branch CI history,
+  `forge://.../ci/run/{run_id}` for run summaries,
+  `forge://.../ci/run/{run_id}/log` for run logs, and
+  `forge://.../ci/run/{run_id}/job/{job_id}` for job logs.
 - `:Forge pr create` and `require('forge').create_pr()` are create-only.
 - `edit_pr()` is removed; use `pr({ num = '42' })` instead.
 - Prefer `require('forge').pr()`, `review()`, `pr_ci()`, `ci()`, and

--- a/lua/forge/ci_history.lua
+++ b/lua/forge/ci_history.lua
@@ -33,7 +33,7 @@ local function bufname(head)
   if not prefix or not head.branch or head.branch == '' then
     return nil
   end
-  return ('forge://%s/ci/%s'):format(prefix, head.branch)
+  return ('forge://%s/ci/branch/%s'):format(prefix, head.branch)
 end
 
 local function data_for(buf)

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -12,9 +12,9 @@ local function log_bufname(opts)
     return nil
   end
   if opts.job_id and opts.job_id ~= '' then
-    return ('forge://%s/ci/%s/job/%s'):format(prefix, opts.run_id, opts.job_id)
+    return ('forge://%s/ci/run/%s/job/%s'):format(prefix, opts.run_id, opts.job_id)
   end
-  return ('forge://%s/ci/%s/log'):format(prefix, opts.run_id)
+  return ('forge://%s/ci/run/%s/log'):format(prefix, opts.run_id)
 end
 
 ---@param opts forge.SummaryOpts
@@ -24,7 +24,7 @@ local function summary_bufname(opts)
   if not prefix or not opts.run_id or opts.run_id == '' then
     return nil
   end
-  return ('forge://%s/ci/%s'):format(prefix, opts.run_id)
+  return ('forge://%s/ci/run/%s'):format(prefix, opts.run_id)
 end
 
 ---@param name string?

--- a/spec/ci_history_spec.lua
+++ b/spec/ci_history_spec.lua
@@ -111,6 +111,7 @@ describe('ci history buffer', function()
     package.loaded['forge'] = nil
     package.loaded['forge.ci_history'] = nil
     package.loaded['forge.layout'] = nil
+    package.loaded['forge.log'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
     package.loaded['forge.scope'] = nil
@@ -124,6 +125,7 @@ describe('ci history buffer', function()
     package.loaded['forge'] = nil
     package.loaded['forge.ci_history'] = nil
     package.loaded['forge.layout'] = nil
+    package.loaded['forge.log'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.ops'] = nil
     package.loaded['forge.scope'] = nil
@@ -176,7 +178,7 @@ describe('ci history buffer', function()
     })
 
     local buf = vim.api.nvim_get_current_buf()
-    assert.equals('forge://github.com/owner/repo/ci/main', vim.api.nvim_buf_get_name(buf))
+    assert.equals('forge://github.com/owner/repo/ci/branch/main', vim.api.nvim_buf_get_name(buf))
     assert.equals('forgelist', vim.bo[buf].filetype)
     assert.same({
       version = 1,
@@ -245,5 +247,149 @@ describe('ci history buffer', function()
       status = 'failure',
       url = 'https://example.com/runs/456',
     }, captured.browsed[1])
+  end)
+
+  it('keeps branch history distinct from same-id run summary buffers', function()
+    vim.system = function(cmd, _, cb)
+      if cmd[1] == 'runs' then
+        cb({
+          code = 0,
+          stdout = vim.json.encode({
+            {
+              id = '123',
+              name = 'Branch CI',
+              branch = '123',
+              status = 'success',
+              url = 'https://example.com/runs/123',
+            },
+          }),
+        })
+      else
+        cb({
+          code = 0,
+          stdout = '✓ summary job (ID 1)',
+        })
+      end
+      return {
+        kill = function() end,
+      }
+    end
+
+    local ci_history = require('forge.ci_history')
+    local log_mod = require('forge.log')
+
+    ci_history.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = '123',
+      scope = scope,
+    })
+
+    local branch_buf = vim.api.nvim_get_current_buf()
+    assert.equals(
+      'forge://github.com/owner/repo/ci/branch/123',
+      vim.api.nvim_buf_get_name(branch_buf)
+    )
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(branch_buf, 0, -1, false)[1] == 'Branch CI'
+    end)
+
+    log_mod.open_summary({ 'summary', '123' }, {
+      forge_name = 'github',
+      scope = scope,
+      run_id = '123',
+      url = 'https://example.com/runs/123',
+    })
+
+    local summary_buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(summary_buf, 0, -1, false)[1] == '✓ summary job (ID 1)'
+    end)
+    assert.equals(
+      'forge://github.com/owner/repo/ci/run/123',
+      vim.api.nvim_buf_get_name(summary_buf)
+    )
+    assert.is_not.equals(branch_buf, summary_buf)
+    assert.same({ 'Branch CI' }, vim.api.nvim_buf_get_lines(branch_buf, 0, -1, false))
+    assert.same({ '✓ summary job (ID 1)' }, vim.api.nvim_buf_get_lines(summary_buf, 0, -1, false))
+  end)
+
+  it('keeps branch history distinct from same-id run log buffers', function()
+    vim.system = function(cmd, _, cb)
+      if cmd[1] == 'runs' then
+        cb({
+          code = 0,
+          stdout = vim.json.encode({
+            {
+              id = '321',
+              name = 'Slash Branch',
+              branch = '123/log',
+              status = 'success',
+              url = 'https://example.com/runs/321',
+            },
+          }),
+        })
+      else
+        cb({
+          code = 0,
+          stdout = 'build\tstep\t2024-01-01T00:00:00Z hello',
+        })
+      end
+      return {
+        kill = function() end,
+      }
+    end
+
+    local ci_history = require('forge.ci_history')
+    local log_mod = require('forge.log')
+
+    ci_history.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = '123/log',
+      scope = scope,
+    })
+
+    local branch_buf = vim.api.nvim_get_current_buf()
+    assert.equals(
+      'forge://github.com/owner/repo/ci/branch/123/log',
+      vim.api.nvim_buf_get_name(branch_buf)
+    )
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(branch_buf, 0, -1, false)[1] == 'Slash Branch'
+    end)
+
+    log_mod.open({ 'log', '123' }, {
+      forge_name = 'github',
+      scope = scope,
+      run_id = '123',
+      url = 'https://example.com/runs/123',
+    })
+
+    local log_buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(log_buf, 0, -1, false)[1] == 'build'
+    end)
+    assert.equals(
+      'forge://github.com/owner/repo/ci/run/123/log',
+      vim.api.nvim_buf_get_name(log_buf)
+    )
+    assert.is_not.equals(branch_buf, log_buf)
+    assert.same({ 'Slash Branch' }, vim.api.nvim_buf_get_lines(branch_buf, 0, -1, false))
+    assert.same({ 'build' }, vim.api.nvim_buf_get_lines(log_buf, 0, 1, false))
   end)
 end)

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -838,6 +838,10 @@ describe('summary job mappings', function()
       return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'build'
     end)
 
+    assert.equals(
+      'forge://github.com/owner/repo/ci/run/77/job/12345',
+      vim.api.nvim_buf_get_name(buf)
+    )
     local browse = vim.fn.maparg('gx', 'n', false, true).callback
     browse()
 
@@ -890,6 +894,7 @@ describe('public buffer identity', function()
       return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'build'
     end)
 
+    assert.equals('forge://github.com/owner/repo/ci/run/77/log', vim.api.nvim_buf_get_name(buf))
     assert.equals('forgelog', vim.bo[buf].filetype)
     assert.same({
       version = 1,
@@ -921,6 +926,7 @@ describe('public buffer identity', function()
       return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == '✓ lint (ID 12345)'
     end)
 
+    assert.equals('forge://github.com/owner/repo/ci/run/12345', vim.api.nvim_buf_get_name(buf))
     assert.equals('forgelist', vim.bo[buf].filetype)
     assert.same({
       version = 1,


### PR DESCRIPTION
## Problem

Branch-scoped CI history buffers and run-scoped summary/log buffers currently share overlapping `forge://.../ci/...` names, so branch names like `123` or `123/log` can alias run buffers and trigger the wrong reuse path.

## Solution

Move CI branch history under `ci/branch/...` and run summary/log buffers under `ci/run/...`, add regression coverage for the numeric and slashy branch collisions, and document the new CI buffer namespaces in migration notes.
