### PR TITLE
fix(ci): paginate deterministic branch history

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -299,6 +299,8 @@ Top-level keys: ~
   log                      `]d`       Next error
   log                      `[d`       Previous error
   summary                  `<cr>`     Open job under cursor
+  ci history               `]c`       Expand to older runs
+  ci history               `[c`       Shrink back to newer runs
   CI terminal              `q`        Close terminal
   CI terminal              `gx`       Browse current URL/job URL
   CI terminal              `<cr>`     Open job under cursor when available
@@ -644,6 +646,7 @@ CI COMMANDS                                                *forge-ci-commands*
     `repo=`            Override the repo scope for the resolved branch head.
     `head=`            Override the head used for current-branch history.
     Use `<cr>` to inspect the highlighted run and `gx` to open its URL.
+    Use `]c` to fetch older runs and `[c` to shrink back to the newer window.
 
 `:Forge ci open` {run-id} [repo=...]                          *:Forge-ci-open*
     Open the primary local run view for CI run `{run-id}`. Active runs

--- a/lua/forge/ci_history.lua
+++ b/lua/forge/ci_history.lua
@@ -17,7 +17,7 @@ local ns = vim.api.nvim_create_namespace('forge_ci_history')
 ---@field highlights forge.CIHistoryHighlight[]
 ---@field run forge.CIRun?
 
----@type table<integer, { proc?: table, request_id?: integer, lines?: forge.CIHistoryLine[] }>
+---@type table<integer, { proc?: table, request_id?: integer, lines?: forge.CIHistoryLine[], limit?: integer, limit_step?: integer, has_more?: boolean }>
 local buf_data = {}
 
 ---@param f forge.Forge
@@ -83,6 +83,23 @@ end
 
 local function request_current(buf, request_id)
   return data_for(buf).request_id == request_id
+end
+
+local function limit_settings(buf, opts)
+  local cfg = require('forge').config()
+  local step = cfg.display and cfg.display.limits and cfg.display.limits.runs or 30
+  if type(step) ~= 'number' or step < 1 then
+    step = 30
+  end
+  local limit = type(opts) == 'table' and opts.limit or nil
+  if type(limit) ~= 'number' or limit < 1 then
+    limit = data_for(buf).limit
+  end
+  if type(limit) ~= 'number' or limit < 1 then
+    limit = step
+  end
+  limit = math.max(step, math.floor(limit))
+  return step, limit
 end
 
 local function line_positions(buf)
@@ -240,6 +257,11 @@ local function setup_keymaps(buf, f, head, opts)
   local cfg = require('forge').config()
   local ci_keys = type(cfg.keys) == 'table' and cfg.keys.ci or {}
   local log_keys = type(cfg.keys) == 'table' and cfg.keys.log or {}
+  local function reopen(limit)
+    local next_opts = vim.tbl_extend('force', {}, opts or {})
+    next_opts.limit = limit
+    M.open(f, head, next_opts, buf)
+  end
   local function map(key, fn, desc)
     if key and key ~= false then
       vim.keymap.set('n', key, fn, { buffer = buf, desc = desc })
@@ -269,6 +291,17 @@ local function setup_keymaps(buf, f, head, opts)
   map(log_keys.prev_step, function()
     jump(buf, -1)
   end, 'Previous run')
+  vim.keymap.set('n', ']c', function()
+    local step, limit = limit_settings(buf)
+    reopen(limit + step)
+  end, { buffer = buf, desc = 'Older runs' })
+  vim.keymap.set('n', '[c', function()
+    local step, limit = limit_settings(buf)
+    if limit <= step then
+      return
+    end
+    reopen(math.max(step, limit - step))
+  end, { buffer = buf, desc = 'Newer runs' })
 end
 
 ---@param head forge.HeadRef
@@ -330,12 +363,23 @@ end
 function M.open(f, head, opts, reuse_buf)
   opts = opts or {}
   local buf, reusing = prepare_buf(head, reuse_buf)
+  local saved_cursor
+  local limit_step, limit = limit_settings(buf, opts)
+  if reusing then
+    local wins = vim.fn.win_findbuf(buf)
+    if #wins > 0 then
+      saved_cursor = vim.api.nvim_win_get_cursor(wins[1])
+    end
+  end
   if not reusing then
     setup_keymaps(buf, f, head, opts)
   end
+  set_data(buf, {
+    limit = limit,
+    limit_step = limit_step,
+  })
   local request_id = begin_request(buf)
-  local limit = require('forge').config().display.limits.runs
-  local cmd = f:list_runs_json_cmd(head.branch, head.scope, limit)
+  local cmd = f:list_runs_json_cmd(head.branch, head.scope, limit + 1)
   log.debug(('fetching %s for %s...'):format(ci_inline_label(f), head.branch))
   local proc = vim.system(cmd, { text = true }, function(result)
     vim.schedule(function()
@@ -364,7 +408,21 @@ function M.open(f, head, opts, reuse_buf)
         )
         return
       end
+      local has_more = #runs > limit
+      if has_more then
+        runs = vim.list_slice(runs, 1, limit)
+      end
       render(buf, render_rows(runs))
+      set_data(buf, {
+        has_more = has_more,
+      })
+      if saved_cursor then
+        local wins = vim.fn.win_findbuf(buf)
+        if #wins > 0 then
+          saved_cursor[1] = math.min(saved_cursor[1], vim.api.nvim_buf_line_count(buf))
+          vim.api.nvim_win_set_cursor(wins[1], saved_cursor)
+        end
+      end
     end)
   end)
   set_data(buf, { proc = proc })

--- a/spec/ci_history_spec.lua
+++ b/spec/ci_history_spec.lua
@@ -249,6 +249,205 @@ describe('ci history buffer', function()
     }, captured.browsed[1])
   end)
 
+  it('loads older runs with ]c when more branch history is available', function()
+    local calls = {}
+    vim.system = function(cmd, _, cb)
+      calls[#calls + 1] = cmd
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '1',
+            name = 'Newest',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com/runs/1',
+          },
+          {
+            id = '2',
+            name = 'Middle',
+            branch = 'main',
+            status = 'failure',
+            url = 'https://example.com/runs/2',
+          },
+          {
+            id = '3',
+            name = 'Oldest',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com/runs/3',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            split = 'horizontal',
+            ci = { refresh = 5 },
+            display = { limits = { runs = 2 } },
+            keys = {
+              ci = {
+                refresh = '<c-r>',
+              },
+              log = {
+                next_step = ']]',
+                prev_step = '[[',
+              },
+            },
+          }
+        end,
+        filter_runs = function(runs)
+          return runs
+        end,
+        format_runs = function(runs)
+          local rows = {}
+          for _, run in ipairs(runs) do
+            rows[#rows + 1] = { { run.name } }
+          end
+          return rows
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+
+    local mod = require('forge.ci_history')
+    mod.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = 'main',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[2] == 'Middle'
+    end)
+    assert.same({ 'runs', 'main', '3' }, calls[1])
+    assert.same({ 'Newest', 'Middle' }, vim.api.nvim_buf_get_lines(buf, 0, 2, false))
+
+    local older = vim.fn.maparg(']c', 'n', false, true).callback
+    older()
+
+    vim.wait(100, function()
+      return #calls == 2 and vim.api.nvim_buf_get_lines(buf, 0, -1, false)[3] == 'Oldest'
+    end)
+    assert.same({ 'runs', 'main', '5' }, calls[2])
+    assert.same({ 'Newest', 'Middle', 'Oldest' }, vim.api.nvim_buf_get_lines(buf, 0, 3, false))
+  end)
+
+  it('shrinks the current-branch history window with [c after loading more', function()
+    local calls = {}
+    vim.system = function(cmd, _, cb)
+      calls[#calls + 1] = cmd
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '1',
+            name = 'Newest',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com/runs/1',
+          },
+          {
+            id = '2',
+            name = 'Middle',
+            branch = 'main',
+            status = 'failure',
+            url = 'https://example.com/runs/2',
+          },
+          {
+            id = '3',
+            name = 'Oldest',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com/runs/3',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            split = 'horizontal',
+            ci = { refresh = 5 },
+            display = { limits = { runs = 2 } },
+            keys = {
+              ci = {
+                refresh = '<c-r>',
+              },
+              log = {
+                next_step = ']]',
+                prev_step = '[[',
+              },
+            },
+          }
+        end,
+        filter_runs = function(runs)
+          return runs
+        end,
+        format_runs = function(runs)
+          local rows = {}
+          for _, run in ipairs(runs) do
+            rows[#rows + 1] = { { run.name } }
+          end
+          return rows
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+
+    local mod = require('forge.ci_history')
+    mod.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = 'main',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[2] == 'Middle'
+    end)
+
+    vim.fn.maparg(']c', 'n', false, true).callback()
+    vim.wait(100, function()
+      return #calls == 2 and vim.api.nvim_buf_get_lines(buf, 0, -1, false)[3] == 'Oldest'
+    end)
+
+    vim.fn.maparg('[c', 'n', false, true).callback()
+    vim.wait(100, function()
+      return #calls == 3 and vim.api.nvim_buf_get_lines(buf, 0, -1, false)[3] == nil
+    end)
+    assert.same({ 'runs', 'main', '3' }, calls[3])
+    assert.same({ 'Newest', 'Middle' }, vim.api.nvim_buf_get_lines(buf, 0, 2, false))
+  end)
+
   it('keeps branch history distinct from same-id run summary buffers', function()
     vim.system = function(cmd, _, cb)
       if cmd[1] == 'runs' then


### PR DESCRIPTION
## Problem

The deterministic `:Forge ci` branch-history buffer stopped at the configured run limit, so older runs were unreachable without falling back to the interactive picker flow.

## Solution

Track the current history window in `forge.ci_history`, fetch one extra run to detect older history, and add `[c` / `]c` paging to shrink or expand the in-buffer run window while preserving the existing buffer and cursor. Update the docs and regression coverage for the new buffer paging behavior. Closes #482.