### PR TITLE
fix(ci): overwrite fetched nightly tag before publish

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -89,7 +89,7 @@ jobs:
           git push origin :refs/tags/nightly || true
           GIT_COMMITTER_NAME='github-actions[bot]' \
           GIT_COMMITTER_EMAIL='41898282+github-actions[bot]@users.noreply.github.com' \
-          git tag -a nightly "${{ steps.run.outputs.head_sha }}" -m nightly
+          git tag -fa nightly "${{ steps.run.outputs.head_sha }}" -m nightly
           git push --force origin refs/tags/nightly
           gh release create nightly \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Problem

The nightly release workflow fetches tags before publishing, so a local `nightly` tag can still exist after the remote tag is deleted. That makes the publish step fail with `fatal: tag nightly already exists` on new `main` releases.

## Solution

Force-recreate the local `nightly` tag before pushing it back to GitHub so the workflow can republish the moving nightly tag after a fresh fetch. Closes #481.