### PR TITLE
feat(browse): accept shorthand target paths

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -717,9 +717,11 @@ BROWSE COMMANDS                                        *forge-browse-commands*
                        anchored to that branch instead; otherwise the
                        branch landing page is opened.
     `commit=<sha>`     Open the given commit on the forge.
-    `target=<addr>`    Open an explicit location address on the forge, such
-                       as `@main:README.md#L10` or
-                       `upstream@release:doc/forge.nvim.txt#L300-L340`.
+    `target=<addr>`    Open an explicit location address on the forge. Full
+                       addresses such as `@main:README.md#L10` and
+                       `upstream@release:doc/forge.nvim.txt#L300-L340` pin an
+                       explicit revision. Bare paths such as `README.md` or
+                       `README.md:10-20` use the current branch.
 
 REVIEW COMMANDS                                        *forge-review-commands*
 

--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -27,7 +27,7 @@ local target_modifier_parsers = {
   repo = 'resolve_repo',
   branch = 'parse_branch',
   commit = 'parse_commit',
-  target = 'parse_location',
+  target = 'parse_browse_target',
   head = 'parse_rev',
   base = 'parse_rev',
 }
@@ -742,7 +742,19 @@ local function dispatch_browse(command)
   end
   local location = command.parsed_modifiers.target
   if location then
-    ops.browse_location(f, location, scope)
+    local branch = location.rev and location.rev.rev or nil
+    if not branch then
+      local explicit_branch = command.parsed_modifiers.branch
+      branch = explicit_branch and explicit_branch.branch or nil
+    end
+    if not branch then
+      local ctx = forge_mod.current_context()
+      branch = type(ctx) == 'table' and ctx.branch or nil
+    end
+    if ops.browse_location(f, location, scope, branch) then
+      return
+    end
+    require('forge.logger').warn('detached HEAD')
     return
   end
   local commit = command.parsed_modifiers.commit

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -706,13 +706,18 @@ end
 ---@param f forge.Forge
 ---@param location table
 ---@param scope? forge.Scope
+---@param branch? string
 ---@return boolean
-function M.browse_location(f, location, scope)
+function M.browse_location(f, location, scope, branch)
   local loc = location_arg(location)
   if not loc then
     return false
   end
-  f:browse(loc, location.rev.rev, scope)
+  local rev = location.rev and location.rev.rev or trim(branch)
+  if rev == '' then
+    return false
+  end
+  f:browse(loc, rev, scope)
   return true
 end
 

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -184,6 +184,89 @@ local function parse_range(fragment)
   return nil, 'invalid range: ' .. fragment
 end
 
+---@param path string?
+---@param start_line string?
+---@param end_line string?
+---@return forge.LocationTarget?
+local function shorthand_location(path, start_line, end_line)
+  local value = trim(path)
+  if not value then
+    return nil
+  end
+  local range = nil
+  if start_line then
+    local start_num = tonumber(start_line)
+    local end_num = tonumber(end_line or start_line)
+    range = {
+      start_line = start_num,
+      end_line = end_num,
+    }
+  end
+  return {
+    kind = 'location',
+    text = value,
+    rev = nil,
+    path = value,
+    range = range,
+  }
+end
+
+---@param text string
+---@return forge.LocationTarget?, string?
+local function parse_browse_shorthand(text)
+  local value = trim(text)
+  if not value then
+    return nil, 'empty location address'
+  end
+
+  local body = value
+  local fragment = nil
+  local hash = value:find('#', 1, true)
+  if hash then
+    body = value:sub(1, hash - 1)
+    fragment = value:sub(hash + 1)
+    local range, err = parse_range(fragment)
+    if not range then
+      return nil, err
+    end
+    local location = shorthand_location(body)
+    if not location then
+      return nil, 'invalid location address: ' .. value
+    end
+    location.text = value
+    location.range = range
+    return location
+  end
+
+  local path, start_line, end_line = value:match('^(.-):(%d+)%-(%d+)$')
+  if path and path ~= '' then
+    local location = shorthand_location(path, start_line, end_line)
+    if location then
+      location.text = value
+      return location
+    end
+  end
+
+  path, start_line = value:match('^(.-):(%d+)$')
+  if path and path ~= '' then
+    local location = shorthand_location(path, start_line)
+    if location then
+      location.text = value
+      return location
+    end
+  end
+
+  if not value:find('@', 1, true) and not value:find(':', 1, true) then
+    local location = shorthand_location(value)
+    if location then
+      location.text = value
+      return location
+    end
+  end
+
+  return nil
+end
+
 ---@param text string
 ---@return forge.RepoTarget?, string?
 function M.parse_repo(text)
@@ -626,6 +709,21 @@ function M.parse_location(text, opts)
     path = path,
     range = range,
   }
+end
+
+---@param text string
+---@param opts forge.TargetParseOpts?
+---@return forge.LocationTarget?, string?
+function M.parse_browse_target(text, opts)
+  local location, err = M.parse_location(text, opts)
+  if location then
+    return location
+  end
+  local shorthand, shorthand_err = parse_browse_shorthand(text)
+  if shorthand then
+    return shorthand
+  end
+  return nil, shorthand_err or err
 end
 
 ---@param repo forge.RepoTarget?

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -73,7 +73,7 @@
 ---@class forge.LocationTarget
 ---@field kind 'location'
 ---@field text string
----@field rev forge.RevTarget
+---@field rev forge.RevTarget?
 ---@field path string
 ---@field range forge.LineRange?
 

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -221,6 +221,10 @@ describe('command schema', function()
       'browse',
       'target=upstream@main:lua/forge/init.lua#L10-L20',
     }))
+    local browse_target_shorthand = assert(cmd.parse({
+      'browse',
+      'target=README.md:10-20',
+    }))
 
     assert.equals('main', create.parsed_modifiers.base.rev)
     assert.equals('topic', create.parsed_modifiers.head.rev)
@@ -231,6 +235,12 @@ describe('command schema', function()
     assert.equals('owner/upstream', browse_target.parsed_modifiers.target.rev.repo.slug)
     assert.equals('lua/forge/init.lua', browse_target.parsed_modifiers.target.path)
     assert.same({ start_line = 10, end_line = 20 }, browse_target.parsed_modifiers.target.range)
+    assert.is_nil(browse_target_shorthand.parsed_modifiers.target.rev)
+    assert.equals('README.md', browse_target_shorthand.parsed_modifiers.target.path)
+    assert.same(
+      { start_line = 10, end_line = 20 },
+      browse_target_shorthand.parsed_modifiers.target.range
+    )
   end)
 
   it('attaches implicit current-PR disambiguation modifiers to normalized commands', function()
@@ -423,12 +433,12 @@ describe('command schema', function()
   end)
 
   it('rejects obsolete browse modifiers and malformed browse target syntax', function()
-    local _, target_err = cmd.parse({ 'browse', 'target=README.md#L10' })
+    local _, target_err = cmd.parse({ 'browse', 'target=README.md#oops' })
     local _, rev_err = cmd.parse({ 'browse', 'rev=main' })
     local _, branch_err = cmd.parse({ 'browse', 'branch=@main' })
     local _, commit_err = cmd.parse({ 'browse', 'commit=abc:def' })
 
-    assert.equals('invalid location address: README.md#L10', target_err.message)
+    assert.equals('invalid range: oops', target_err.message)
     assert.equals('unknown modifier: rev', rev_err.message)
     assert.equals('invalid branch: @main', branch_err.message)
     assert.equals('invalid commit: abc:def', commit_err.message)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -510,12 +510,20 @@ describe(':Forge command', function()
           vim.ui.open(require('forge').remote_web_url(opts and opts.scope or nil))
           return true
         end,
-        browse_location = function(f, location, scope)
+        browse_location = function(f, location, scope, branch)
           table.insert(
             captured.ops_calls,
             { name = 'browse_location', location = location, scope = scope }
           )
-          f:browse(location.path .. ':10-20', location.rev.rev, scope)
+          local loc = location.path
+          if location.range then
+            if location.range.start_line == location.range.end_line then
+              loc = ('%s:%d'):format(loc, location.range.start_line)
+            else
+              loc = ('%s:%d-%d'):format(loc, location.range.start_line, location.range.end_line)
+            end
+          end
+          f:browse(loc, location.rev and location.rev.rev or branch, scope)
           return true
         end,
         browse_file = function(f, file_loc, branch, scope)
@@ -1100,6 +1108,21 @@ describe(':Forge command', function()
       loc = 'lua/forge/init.lua:10-20',
       branch = 'main',
       scope = repo_scope('upstream'),
+    }, captured.browse_calls[1])
+  end)
+
+  it('dispatches shorthand target browsing against the current branch', function()
+    vim.cmd('Forge browse target=README.md:10-20')
+
+    assert.equals('browse_location', captured.ops_calls[1].name)
+    assert.equals('README.md', captured.ops_calls[1].location.path)
+    assert.same({ start_line = 10, end_line = 20 }, captured.ops_calls[1].location.range)
+    assert.is_nil(captured.ops_calls[1].location.rev)
+    assert.same(repo_scope('current'), captured.ops_calls[1].scope)
+    assert.same({
+      loc = 'README.md:10-20',
+      branch = 'main',
+      scope = repo_scope('current'),
     }, captured.browse_calls[1])
   end)
 

--- a/spec/target_spec.lua
+++ b/spec/target_spec.lua
@@ -58,6 +58,23 @@ describe('target parsing', function()
     assert.same({ start_line = 10, end_line = 40 }, location.range)
   end)
 
+  it('parses shorthand browse targets without an explicit revision', function()
+    local target = require('forge.target')
+    local line_range = assert(target.parse_browse_target('README.md:10-40'))
+    local fragment_range = assert(target.parse_browse_target('doc/forge.nvim.txt#L300-L340'))
+    local path_only = assert(target.parse_browse_target('lua/forge/init.lua'))
+
+    assert.is_nil(line_range.rev)
+    assert.equals('README.md', line_range.path)
+    assert.same({ start_line = 10, end_line = 40 }, line_range.range)
+    assert.is_nil(fragment_range.rev)
+    assert.equals('doc/forge.nvim.txt', fragment_range.path)
+    assert.same({ start_line = 300, end_line = 340 }, fragment_range.range)
+    assert.is_nil(path_only.rev)
+    assert.equals('lua/forge/init.lua', path_only.path)
+    assert.is_nil(path_only.range)
+  end)
+
   it('resolves aliases before remotes', function()
     vim.system = function(cmd)
       if table.concat(cmd, ' ') == 'git remote get-url upstream' then


### PR DESCRIPTION
## Problem

`:Forge browse target=` only accepted full revision addresses, so bare file targets like `README.md` and `README.md:10-20` failed even though browse already has current-branch context.

## Solution

Add a browse-specific target parser for shorthand file paths and line ranges, resolve revisionless targets against an explicit or current branch, and update specs and help text to document the shorthand.