### PR TITLE
feat(ci): align CI rows and deterministic affordances

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -305,6 +305,9 @@ Top-level keys: ~
   CI terminal              `gx`       Browse current URL/job URL
   CI terminal              `<cr>`     Open job under cursor when available
 
+    When the current-branch CI history buffer can page, Forge renders the
+    `]c` / `[c` affordance directly in the buffer instead of leaving it hidden.
+
 `display`                                               *forge-config-display*
   Controls status icons and fetch limits used in picker formatting. Picker
   column widths are derived automatically from content and window width.
@@ -458,6 +461,7 @@ PR COMMANDS                                                *forge-pr-commands*
     `head=`            Override the head used for implicit branch-relative
                        lookup. Only used when `{num}` is omitted.
     Use `<cr>` to inspect the highlighted check and `gx` to open its URL.
+    Browse-only and unavailable rows are labeled directly in the buffer.
 
 `:Forge review` [repo=...] [head=...] [adapter=...]              *:Forge-review*
 `:Forge review` {num} [repo=...] [adapter=...]
@@ -647,6 +651,7 @@ CI COMMANDS                                                *forge-ci-commands*
     `head=`            Override the head used for current-branch history.
     Use `<cr>` to inspect the highlighted run and `gx` to open its URL.
     Use `]c` to fetch older runs and `[c` to shrink back to the newer window.
+    Repo-wide CI browsing stays on the interactive route surface.
 
 `:Forge ci open` {run-id} [repo=...]                          *:Forge-ci-open*
     Open the primary local run view for CI run `{run-id}`. Active runs
@@ -846,6 +851,9 @@ deterministic Lua helpers such as `require('forge').pr()`, `review()`,
 The picker surface covers workflows that do not fit cleanly in a single
 command, such as list navigation, row-scoped actions, filters, refresh,
 load-more rows, nested per-PR/MR checks, and copy helpers.
+Repo-wide CI browsing stays here through `require('forge').open('ci.all')`,
+while bare `:Forge ci` and `require('forge').ci()` intentionally remain narrow
+current-branch history surfaces.
 
 ==============================================================================
 COMPOSE BUFFER                                                 *forge-compose*

--- a/lua/forge/availability.lua
+++ b/lua/forge/availability.lua
@@ -1,4 +1,5 @@
 local M = {}
+local surface_policy = require('forge.surface_policy')
 
 local function entry_value(entry)
   if type(entry) ~= 'table' or type(entry.value) ~= 'table' then
@@ -27,7 +28,7 @@ local function pr_state(f, entry)
 end
 
 local function pr_open(entry)
-  return require('forge.picker').pr_toggle_verb(entry) == 'close'
+  return surface_policy.pr_toggle_verb(entry) == 'close'
 end
 
 local function merge_permission(info)

--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -410,14 +410,17 @@ function M:normalize_run(entry)
   if status == 'completed' then
     status = entry.conclusion or 'unknown'
   end
+  local name = entry.display_title or entry.displayTitle or entry.name or ''
+  local context = entry.workflow_name or entry.workflowName or entry.name or ''
   return {
     id = tostring(entry.id or ''),
-    name = entry.name or '',
-    branch = entry.head_branch or '',
+    name = name,
+    context = context,
+    branch = entry.head_branch or entry.headBranch or '',
     status = status,
     event = entry.event or '',
     url = entry.html_url or '',
-    created_at = entry.created_at or '',
+    created_at = entry.created_at or entry.createdAt or '',
   }
 end
 

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -480,7 +480,7 @@ function M:list_runs_json_cmd(branch, scope, limit)
     'run',
     'list',
     '--json',
-    'databaseId,name,headBranch,status,conclusion,event,url,createdAt',
+    'databaseId,displayTitle,workflowName,name,headBranch,status,conclusion,event,url,createdAt',
     '--limit',
     tostring(limit or forge.config().display.limits.runs),
   }
@@ -503,9 +503,11 @@ function M:normalize_run(entry)
   if status == 'completed' then
     status = entry.conclusion or 'unknown'
   end
+  local workflow = entry.workflowName or entry.name or ''
   return {
     id = tostring(entry.databaseId or ''),
-    name = entry.displayTitle or entry.name or '',
+    name = entry.displayTitle or workflow or '',
+    context = workflow,
     branch = entry.headBranch or '',
     status = status,
     event = entry.event or '',

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -476,10 +476,12 @@ end
 function M:normalize_run(entry)
   local ref = entry.ref or ''
   local mr_num = ref:match('^refs/merge%-requests/(%d+)/head$')
+  local context = mr_num and ('!%s'):format(mr_num) or ''
   return {
     id = tostring(entry.id or ''),
-    name = mr_num and ('!%s'):format(mr_num) or ref,
-    branch = '',
+    name = entry.name or (context ~= '' and context or ref),
+    context = context,
+    branch = context ~= '' and '' or ref,
     status = entry.status or '',
     event = entry.source or '',
     url = entry.web_url or '',

--- a/lua/forge/ci_history.lua
+++ b/lua/forge/ci_history.lua
@@ -180,8 +180,18 @@ local function render_rows(runs)
       end
       col = col + #part
     end
+    local line_text = table.concat(text):gsub('%s+$', '')
+    local end_col = #line_text
+    for i = #highlights, 1, -1 do
+      local hl = highlights[i]
+      if hl.col >= end_col then
+        table.remove(highlights, i)
+      elseif hl.end_col > end_col then
+        hl.end_col = end_col
+      end
+    end
     lines[#lines + 1] = {
-      text = table.concat(text),
+      text = line_text,
       highlights = highlights,
       run = runs[index],
     }
@@ -205,6 +215,37 @@ local function render_placeholder(text, group)
       } or {},
       run = nil,
     },
+  }
+end
+
+local function pager_line(label, visible_count, limit_step, limit, has_more)
+  local actions = {}
+  if has_more then
+    actions[#actions + 1] = ']c older ' .. label
+  end
+  if limit > limit_step then
+    actions[#actions + 1] = '[c fewer ' .. label
+  end
+  if #actions == 0 then
+    return nil
+  end
+  local prefix
+  if has_more then
+    prefix = ('Showing newest %d %s'):format(visible_count, label)
+  else
+    prefix = ('Showing %d %s'):format(visible_count, label)
+  end
+  local text = prefix .. ' · ' .. table.concat(actions, ' · ')
+  return {
+    text = text,
+    highlights = {
+      {
+        col = 0,
+        end_col = #text,
+        group = 'ForgeDim',
+      },
+    },
+    run = nil,
   }
 end
 
@@ -412,7 +453,12 @@ function M.open(f, head, opts, reuse_buf)
       if has_more then
         runs = vim.list_slice(runs, 1, limit)
       end
-      render(buf, render_rows(runs))
+      local lines = render_rows(runs)
+      local pager = pager_line(ci_inline_label(f), #runs, limit_step, limit, has_more)
+      if pager then
+        lines[#lines + 1] = pager
+      end
+      render(buf, lines)
       set_data(buf, {
         has_more = has_more,
       })

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 local availability = require('forge.availability')
-local picker = require('forge.picker')
+local surface_policy = require('forge.surface_policy')
 
 local implicit_pr_completion_verbs = {
   approve = true,
@@ -26,20 +26,20 @@ local function pr_completion_available(verb, f, entry)
     return availability.pr_can_mark_ready(f, entry)
   end
   if verb == 'close' then
-    return picker.pr_toggle_verb(entry) == 'close'
+    return surface_policy.pr_toggle_verb(entry) == 'close'
   end
   if verb == 'reopen' then
-    return picker.pr_toggle_verb(entry) == 'reopen'
+    return surface_policy.pr_toggle_verb(entry) == 'reopen'
   end
   return true
 end
 
 local function issue_completion_available(verb, _, entry)
   if verb == 'close' then
-    return picker.issue_toggle_verb(entry) == 'close'
+    return surface_policy.issue_toggle_verb(entry) == 'close'
   end
   if verb == 'reopen' then
-    return picker.issue_toggle_verb(entry) == 'reopen'
+    return surface_policy.issue_toggle_verb(entry) == 'reopen'
   end
   return true
 end

--- a/lua/forge/format.lua
+++ b/lua/forge/format.lua
@@ -337,17 +337,31 @@ function M.format_runs(runs, opts)
   local display = require('forge.config').config().display
   local icons = display.icons
   local names = {}
+  local contexts = {}
   local branches = {}
   local events = {}
   local ages = {}
   for _, run in ipairs(runs) do
-    names[#names + 1] = run.name or ''
-    branches[#branches + 1] = run.branch or ''
+    local name = run.name or ''
+    local context = run.context or ''
+    if context == name then
+      context = ''
+    end
+    local branch = run.branch or ''
+    if branch == '' or branch == context or branch == name then
+      branch = ''
+    end
+    names[#names + 1] = name
+    contexts[#contexts + 1] = context
+    branches[#branches + 1] = branch
     events[#events + 1] = M.abbreviate_event(run.event)
     ages[#ages + 1] = M.relative_time(run.created_at)
   end
   local name_pref, name_max = elastic_width(35, names, 10)
+  local context_pref, context_max = elastic_width(18, contexts, 4)
   local branch_pref, branch_max = elastic_width(25, branches, 8)
+  local context_min = context_max > 0 and 4 or 0
+  local branch_min = branch_max > 0 and 8 or 0
   local plan = layout.plan({
     width = opts and opts.width or layout.picker_width(),
     columns = {
@@ -364,9 +378,22 @@ function M.format_runs(runs, opts)
         pack_on = 'compact',
       },
       {
+        key = 'context',
+        gap = ' ',
+        min = context_min,
+        preferred = context_pref,
+        max = context_max,
+        optional = true,
+        drop = 4,
+        shrink = 2,
+        overflow = 'tail',
+        pack_on = 'compact',
+        hide_if_empty = true,
+      },
+      {
         key = 'branch',
         gap = ' ',
-        min = 8,
+        min = branch_min,
         preferred = branch_pref,
         max = branch_max,
         optional = true,
@@ -401,6 +428,7 @@ function M.format_runs(runs, opts)
     rows[i] = layout.render(plan, {
       state = { icon, group },
       name = names[i],
+      context = { contexts[i], 'ForgeDim' },
       branch = { branches[i], 'ForgeBranch' },
       event = { events[i], 'ForgeDim' },
       age = { ages[i], 'ForgeTime' },

--- a/lua/forge/picker/fzf.lua
+++ b/lua/forge/picker/fzf.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local surface_policy = require('forge.surface_policy')
+
 local fzf_args = (vim.env.FZF_DEFAULT_OPTS or '')
   :gsub('%-%-bind=[^%s]+', '')
   :gsub('%-%-color=[^%s]+', '')
@@ -163,7 +165,7 @@ local function render_header_for(actions, bindings, entry, header_order)
   for index, def in ipairs(actions) do
     local key = def.name == 'default' and '<cr>' or bindings[def.name]
     local header_key = key and to_header_key(key) or nil
-    local label = header_key and picker_mod.resolve_label(def, entry) or nil
+    local label = header_key and surface_policy.resolve_label(def, entry) or nil
     if header_key and label then
       hints[#hints + 1] = {
         name = def.name,
@@ -205,9 +207,8 @@ end
 ---@param actions forge.PickerActionDef[]
 ---@return boolean
 local function has_dynamic_label(actions)
-  local picker_mod = require('forge.picker')
   for _, def in ipairs(actions) do
-    if picker_mod.has_dynamic_label(def) then
+    if surface_policy.has_dynamic_label(def) then
       return true
     end
   end
@@ -246,7 +247,6 @@ function M.pick(opts)
   if keys == false then
     keys = {}
   end
-  local picker_mod = require('forge.picker')
   local bindings = keys[opts.picker_name] or {}
   local entries = opts.entries or {}
   local stream = rawget(opts, 'stream')
@@ -266,11 +266,11 @@ function M.pick(opts)
     if stream then
       return true
     end
-    if not picker_mod.closes(def) then
+    if not surface_policy.closes(def) then
       return true
     end
     for _, entry in ipairs(seed_entries) do
-      if not picker_mod.closes(def, entry) then
+      if not surface_policy.closes(def, entry) then
         return true
       end
     end
@@ -373,10 +373,10 @@ function M.pick(opts)
       local reloads = action_reloads(def)
       local action_fn = function(selected)
         if not selected[1] then
-          if not picker_mod.available(def, nil) then
+          if not surface_policy.available(def, nil) then
             return
           end
-          if reloads and picker_mod.closes(def) then
+          if reloads and surface_policy.closes(def) then
             local utils = require('fzf-lua.utils')
             local win = type(utils.fzf_winobj) == 'function' and utils.fzf_winobj() or nil
             if win and type(win.close) == 'function' then
@@ -394,8 +394,8 @@ function M.pick(opts)
           return
         end
         local idx = selected_index(selected[1])
-        local entry = picker_mod.selected(idx and entries[idx] or nil)
-        if not picker_mod.available(def, entry) then
+        local entry = surface_policy.selected(idx and entries[idx] or nil)
+        if not surface_policy.available(def, entry) then
           return
         end
         if reloads and entry and rawget(entry, 'load_more') and tracked and idx then
@@ -406,7 +406,7 @@ function M.pick(opts)
         else
           track_redirect = nil
         end
-        if reloads and picker_mod.closes(def, entry) then
+        if reloads and surface_policy.closes(def, entry) then
           local utils = require('fzf-lua.utils')
           local win = type(utils.fzf_winobj) == 'function' and utils.fzf_winobj() or nil
           if win and type(win.close) == 'function' then

--- a/lua/forge/picker/init.lua
+++ b/lua/forge/picker/init.lua
@@ -1,6 +1,5 @@
 local M = {}
 
-local ci = require('forge.ci')
 local detect = require('forge.detect')
 local surface = require('forge.surface')
 
@@ -129,7 +128,7 @@ M.search_keys = {
   ci = function(entry)
     local value = entry.value
     if type(value) == 'table' then
-      return join_search_terms({ value.name or '', value.branch or '' })
+      return join_search_terms({ value.name or '', value.context or '', value.branch or '' })
     end
     return M.ordinal(entry)
   end,
@@ -163,85 +162,6 @@ function M.search_key(picker_name, entry)
     return builder(entry)
   end
   return M.ordinal(entry)
-end
-
----@param entry forge.PickerEntry?
----@return forge.PickerEntry?
-function M.selected(entry)
-  if entry and entry.placeholder then
-    return nil
-  end
-  return entry
-end
-
----@param entry forge.PickerEntry?
----@return 'none'|'entity'|'load_more'|'empty'|'error'
-function M.row_kind(entry)
-  if entry == nil then
-    return 'none'
-  end
-  if rawget(entry, 'load_more') then
-    return 'load_more'
-  end
-  if rawget(entry, 'placeholder') then
-    return rawget(entry, 'placeholder_kind') == 'error' and 'error' or 'empty'
-  end
-  return 'entity'
-end
-
----@param def forge.PickerActionDef
----@param entry forge.PickerEntry?
----@return boolean
-function M.closes(def, entry)
-  if entry and entry.keep_open then
-    return false
-  end
-  if entry and entry.force_close then
-    return true
-  end
-  return rawget(def, 'close') ~= false
-end
-
----@param def forge.PickerActionDef
----@param entry forge.PickerEntry?
----@return boolean
-function M.available(def, entry)
-  local available = rawget(def, 'available')
-  if type(available) == 'function' then
-    local ok, result = pcall(available, entry)
-    return ok and result ~= false
-  end
-  if available ~= nil then
-    return available ~= false
-  end
-  return true
-end
-
----@param def forge.PickerActionDef
----@param entry forge.PickerEntry?
----@return string?
-function M.resolve_label(def, entry)
-  if not M.available(def, entry) then
-    return nil
-  end
-  local label = rawget(def, 'label')
-  if type(label) == 'function' then
-    local ok, result = pcall(label, entry)
-    if ok and type(result) == 'string' then
-      return result
-    end
-    return nil
-  end
-  if type(label) == 'string' then
-    return label
-  end
-  return nil
-end
-
----@param def forge.PickerActionDef
----@return boolean
-function M.has_dynamic_label(def)
-  return type(rawget(def, 'label')) == 'function' or type(rawget(def, 'available')) == 'function'
 end
 
 ---@param hints forge.PickerHint[]
@@ -280,78 +200,6 @@ function M.order_hints(hints, order)
     end
   end
   return ordered
-end
-
----@param entry forge.PickerEntry?
----@return table?
-local function entry_value(entry)
-  if not entry or rawget(entry, 'placeholder') or rawget(entry, 'load_more') then
-    return nil
-  end
-  if type(entry.value) ~= 'table' then
-    return nil
-  end
-  return entry.value
-end
-
----@alias forge.IssueToggleVerb 'close'|'reopen'
-
----Verb that the issue toggle action will execute on `entry`, or `nil` when no
----valid transition exists (missing/unknown state, placeholder, or load_more
----row).
----@param entry forge.PickerEntry?
----@return forge.IssueToggleVerb?
-function M.issue_toggle_verb(entry)
-  local value = entry_value(entry)
-  if not value then
-    return nil
-  end
-  local state = (value.state or ''):lower()
-  if state == 'open' or state == 'opened' then
-    return 'close'
-  end
-  if state == 'closed' then
-    return 'reopen'
-  end
-  return nil
-end
-
----@alias forge.PRToggleVerb 'close'|'reopen'
-
----Verb that the PR toggle action will execute on `entry`, or `nil` when no
----valid transition exists. Merged PRs return `nil` because merged is a
----terminal state (`gh pr reopen` and its GitLab/Codeberg analogues all
----refuse a merged PR).
----@param entry forge.PickerEntry?
----@return forge.PRToggleVerb?
-function M.pr_toggle_verb(entry)
-  local value = entry_value(entry)
-  if not value then
-    return nil
-  end
-  local state = (value.state or ''):lower()
-  if state == 'open' or state == 'opened' then
-    return 'close'
-  end
-  if state == 'closed' then
-    return 'reopen'
-  end
-  return nil
-end
-
----@alias forge.CIToggleVerb 'cancel'|'rerun'
-
----Verb that the CI toggle action will execute on `entry`, or `nil` when no
----valid transition exists. `skipped` runs return `nil` because neither
----cancel nor rerun makes sense for a workflow that never started.
----@param entry forge.PickerEntry?
----@return forge.CIToggleVerb?
-function M.ci_toggle_verb(entry)
-  local value = entry_value(entry)
-  if not value then
-    return nil
-  end
-  return ci.toggle_verb(value)
 end
 
 ---@return boolean

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -7,6 +7,7 @@ local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker = require('forge.picker')
 local picker_session = require('forge.picker.session')
+local surface_policy = require('forge.surface_policy')
 
 local next_ci_filter = {
   all = 'fail',
@@ -306,19 +307,7 @@ local function actionable_entry(entry)
 end
 
 local function picker_row_kind(entry)
-  if type(picker.row_kind) ~= 'function' then
-    if entry == nil then
-      return 'none'
-    end
-    if entry.load_more then
-      return 'load_more'
-    end
-    if entry.placeholder then
-      return entry.placeholder_kind == 'error' and 'error' or 'empty'
-    end
-    return 'entity'
-  end
-  return picker.row_kind(entry)
+  return surface_policy.row_kind(entry)
 end
 
 local function entity_row(entry)
@@ -330,11 +319,11 @@ local function load_more_row(entry)
 end
 
 local function pr_toggle_entry(entry)
-  return actionable_entry(entry) and picker.pr_toggle_verb(entry) ~= nil
+  return actionable_entry(entry) and surface_policy.pr_toggle_verb(entry) ~= nil
 end
 
 local function issue_toggle_entry(entry)
-  return actionable_entry(entry) and picker.issue_toggle_verb(entry) ~= nil
+  return actionable_entry(entry) and surface_policy.issue_toggle_verb(entry) ~= nil
 end
 
 local function check_openable(entry)
@@ -668,13 +657,19 @@ function M.ci(f, branch, filter, opts)
 
     local entries = {}
     for i, run in ipairs(filtered) do
+      local ordinal = table.concat(
+        vim.tbl_filter(function(part)
+          return type(part) == 'string' and vim.trim(part) ~= ''
+        end, { run.name or '', run.context or '', run.branch or '' }),
+        ' '
+      )
       table.insert(entries, {
         display = displays[i],
         render_display = function(width)
           return rows_for(width)[i]
         end,
         value = run,
-        ordinal = run.name .. ' ' .. run.branch,
+        ordinal = ordinal,
       })
     end
     if has_more then
@@ -884,7 +879,7 @@ function M.ci(f, branch, filter, opts)
         if entry == nil then
           return 'cancel/rerun'
         end
-        return picker.ci_toggle_verb(entry)
+        return surface_policy.ci_toggle_verb(entry)
       end,
       fn = function(entry)
         if not entry or entry.load_more then
@@ -1420,13 +1415,13 @@ function M.pr(state, f, opts)
         if entry == nil then
           return 'close/reopen'
         end
-        return picker.pr_toggle_verb(entry)
+        return surface_policy.pr_toggle_verb(entry)
       end,
       fn = function(entry)
         if not entry or entry.load_more then
           return
         end
-        local verb = picker.pr_toggle_verb(entry)
+        local verb = surface_policy.pr_toggle_verb(entry)
         local callbacks = {
           on_success = function()
             locally_toggle_pr(entry, verb)
@@ -1806,13 +1801,13 @@ function M.issue(state, f, opts)
         if entry == nil then
           return 'close/reopen'
         end
-        return picker.issue_toggle_verb(entry)
+        return surface_policy.issue_toggle_verb(entry)
       end,
       fn = function(entry)
         if not entry or entry.load_more then
           return
         end
-        local verb = picker.issue_toggle_verb(entry)
+        local verb = surface_policy.issue_toggle_verb(entry)
         local callbacks = {
           on_success = function()
             locally_toggle_issue(entry, verb)

--- a/lua/forge/pr_checks.lua
+++ b/lua/forge/pr_checks.lua
@@ -136,11 +136,32 @@ local function check_job_id(check)
   return check.job_id or (check.link or ''):match('/job/(%d+)')
 end
 
+local function browseable_check(check)
+  return type(check) == 'table' and type(check.link) == 'string' and check.link ~= ''
+end
+
+local openable_check
+local inspect_check
+
 ---@param checks forge.Check[]
 ---@return forge.PRChecksLine[]
 local function render_rows(checks)
   local forge = require('forge')
-  local rows = forge.format_checks(checks, { width = layout.picker_width() })
+  local display_checks = {}
+  for _, check in ipairs(checks) do
+    local label = check.name or ''
+    if not openable_check(check) then
+      if browseable_check(check) then
+        label = label .. ' [web]'
+      else
+        label = label .. ' [unavailable]'
+      end
+    end
+    display_checks[#display_checks + 1] = vim.tbl_extend('force', {}, check, {
+      name = label,
+    })
+  end
+  local rows = forge.format_checks(display_checks, { width = layout.picker_width() })
   local lines = {}
   for index, row in ipairs(rows) do
     local text = {}
@@ -158,8 +179,18 @@ local function render_rows(checks)
       end
       col = col + #part
     end
+    local line_text = table.concat(text):gsub('%s+$', '')
+    local end_col = #line_text
+    for i = #highlights, 1, -1 do
+      local hl = highlights[i]
+      if hl.col >= end_col then
+        table.remove(highlights, i)
+      elseif hl.end_col > end_col then
+        hl.end_col = end_col
+      end
+    end
     lines[#lines + 1] = {
-      text = table.concat(text),
+      text = line_text,
       highlights = highlights,
       check = checks[index],
     }
@@ -214,7 +245,7 @@ end
 
 ---@param check forge.Check?
 ---@return boolean
-local function openable_check(check)
+openable_check = function(check)
   if type(check) ~= 'table' then
     return false
   end
@@ -224,10 +255,17 @@ local function openable_check(check)
   return check_run_id(check) ~= nil
 end
 
----@param f forge.Forge
----@param check forge.Check
----@param scope forge.Scope?
-local function inspect_check(f, check, scope)
+local function open_check(f, check, scope)
+  if openable_check(check) then
+    inspect_check(f, check, scope)
+    return
+  end
+  if browseable_check(check) then
+    vim.ui.open(check.link)
+  end
+end
+
+inspect_check = function(f, check, scope)
   if not openable_check(check) then
     return
   end
@@ -280,7 +318,7 @@ local function setup_keymaps(buf, f, pr, opts)
   vim.keymap.set('n', '<cr>', function()
     local check = current_check(buf)
     if check then
-      inspect_check(f, check, pr.scope)
+      open_check(f, check, pr.scope)
     end
   end, { buffer = buf, desc = 'Open' })
   map(keys.refresh, function()

--- a/lua/forge/surface_policy.lua
+++ b/lua/forge/surface_policy.lua
@@ -1,0 +1,117 @@
+local ci = require('forge.ci')
+
+local M = {}
+
+local function entry_value(entry)
+  if not entry or rawget(entry, 'placeholder') or rawget(entry, 'load_more') then
+    return nil
+  end
+  if type(entry.value) ~= 'table' then
+    return nil
+  end
+  return entry.value
+end
+
+function M.selected(entry)
+  if entry and rawget(entry, 'placeholder') then
+    return nil
+  end
+  return entry
+end
+
+function M.row_kind(entry)
+  if entry == nil then
+    return 'none'
+  end
+  if rawget(entry, 'load_more') then
+    return 'load_more'
+  end
+  if rawget(entry, 'placeholder') then
+    return rawget(entry, 'placeholder_kind') == 'error' and 'error' or 'empty'
+  end
+  return 'entity'
+end
+
+function M.closes(def, entry)
+  if entry and entry.keep_open then
+    return false
+  end
+  if entry and entry.force_close then
+    return true
+  end
+  return rawget(def, 'close') ~= false
+end
+
+function M.available(def, entry)
+  local available = rawget(def, 'available')
+  if type(available) == 'function' then
+    local ok, result = pcall(available, entry)
+    return ok and result ~= false
+  end
+  if available ~= nil then
+    return available ~= false
+  end
+  return true
+end
+
+function M.resolve_label(def, entry)
+  if not M.available(def, entry) then
+    return nil
+  end
+  local label = rawget(def, 'label')
+  if type(label) == 'function' then
+    local ok, result = pcall(label, entry)
+    if ok and type(result) == 'string' then
+      return result
+    end
+    return nil
+  end
+  if type(label) == 'string' then
+    return label
+  end
+  return nil
+end
+
+function M.has_dynamic_label(def)
+  return type(rawget(def, 'label')) == 'function' or type(rawget(def, 'available')) == 'function'
+end
+
+function M.issue_toggle_verb(entry)
+  local value = entry_value(entry)
+  if not value then
+    return nil
+  end
+  local state = (value.state or ''):lower()
+  if state == 'open' or state == 'opened' then
+    return 'close'
+  end
+  if state == 'closed' then
+    return 'reopen'
+  end
+  return nil
+end
+
+function M.pr_toggle_verb(entry)
+  local value = entry_value(entry)
+  if not value then
+    return nil
+  end
+  local state = (value.state or ''):lower()
+  if state == 'open' or state == 'opened' then
+    return 'close'
+  end
+  if state == 'closed' then
+    return 'reopen'
+  end
+  return nil
+end
+
+function M.ci_toggle_verb(entry)
+  local value = entry_value(entry)
+  if not value then
+    return nil
+  end
+  return ci.toggle_verb(value)
+end
+
+return M

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -371,6 +371,7 @@
 ---@class forge.CIRun
 ---@field id string
 ---@field name string
+---@field context string?
 ---@field branch string
 ---@field status string
 ---@field event string

--- a/spec/ci_history_spec.lua
+++ b/spec/ci_history_spec.lua
@@ -201,6 +201,82 @@ describe('ci history buffer', function()
     }, captured.opened[1])
   end)
 
+  it('trims trailing padding from rendered run rows before writing the buffer', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            split = 'horizontal',
+            ci = { refresh = 5 },
+            display = { limits = { runs = 30 } },
+            keys = {
+              ci = {
+                refresh = '<c-r>',
+              },
+              log = {
+                next_step = ']]',
+                prev_step = '[[',
+              },
+            },
+          }
+        end,
+        filter_runs = function(runs)
+          return runs
+        end,
+        format_runs = function()
+          return {
+            {
+              { 'CI', 'ForgePass' },
+              { ' main   ', 'ForgeBranch' },
+            },
+          }
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+    package.loaded['forge.ci_history'] = nil
+
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '123',
+            name = 'CI',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com/runs/123',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.ci_history')
+    mod.open({
+      name = 'github',
+      labels = { ci_inline = 'runs' },
+      list_runs_json_cmd = function(_, branch, _, limit)
+        return { 'runs', branch, tostring(limit) }
+      end,
+      normalize_run = function(_, run)
+        return run
+      end,
+    }, {
+      branch = 'main',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'CI main'
+    end)
+
+    assert.same({ 'CI main' }, vim.api.nvim_buf_get_lines(buf, 0, 1, false))
+  end)
+
   it('routes gx through ops.ci_browse for the highlighted run', function()
     vim.system = function(_, _, cb)
       cb({
@@ -337,6 +413,10 @@ describe('ci history buffer', function()
     end)
     assert.same({ 'runs', 'main', '3' }, calls[1])
     assert.same({ 'Newest', 'Middle' }, vim.api.nvim_buf_get_lines(buf, 0, 2, false))
+    assert.equals(
+      'Showing newest 2 runs · ]c older runs',
+      vim.api.nvim_buf_get_lines(buf, 2, 3, false)[1]
+    )
 
     local older = vim.fn.maparg(']c', 'n', false, true).callback
     older()
@@ -346,6 +426,10 @@ describe('ci history buffer', function()
     end)
     assert.same({ 'runs', 'main', '5' }, calls[2])
     assert.same({ 'Newest', 'Middle', 'Oldest' }, vim.api.nvim_buf_get_lines(buf, 0, 3, false))
+    assert.equals(
+      'Showing 3 runs · [c fewer runs',
+      vim.api.nvim_buf_get_lines(buf, 3, 4, false)[1]
+    )
   end)
 
   it('shrinks the current-branch history window with [c after loading more', function()
@@ -442,10 +526,16 @@ describe('ci history buffer', function()
 
     vim.fn.maparg('[c', 'n', false, true).callback()
     vim.wait(100, function()
-      return #calls == 3 and vim.api.nvim_buf_get_lines(buf, 0, -1, false)[3] == nil
+      return #calls == 3
+        and vim.api.nvim_buf_get_lines(buf, 0, -1, false)[3]
+          == 'Showing newest 2 runs · ]c older runs'
     end)
     assert.same({ 'runs', 'main', '3' }, calls[3])
     assert.same({ 'Newest', 'Middle' }, vim.api.nvim_buf_get_lines(buf, 0, 2, false))
+    assert.equals(
+      'Showing newest 2 runs · ]c older runs',
+      vim.api.nvim_buf_get_lines(buf, 2, 3, false)[1]
+    )
   end)
 
   it('keeps branch history distinct from same-id run summary buffers', function()

--- a/spec/completion_policy_spec.lua
+++ b/spec/completion_policy_spec.lua
@@ -3,15 +3,15 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 describe('forge.completion_policy', function()
   local policy
   local old_availability
-  local old_picker
+  local old_surface_policy
 
   before_each(function()
     old_availability = package.preload['forge.availability']
-    old_picker = package.preload['forge.picker']
+    old_surface_policy = package.preload['forge.surface_policy']
 
     package.loaded['forge.completion_policy'] = nil
     package.loaded['forge.availability'] = nil
-    package.loaded['forge.picker'] = nil
+    package.loaded['forge.surface_policy'] = nil
 
     package.preload['forge.availability'] = function()
       return {
@@ -30,7 +30,7 @@ describe('forge.completion_policy', function()
       }
     end
 
-    package.preload['forge.picker'] = function()
+    package.preload['forge.surface_policy'] = function()
       return {
         pr_toggle_verb = function(entry)
           return entry and entry.value and entry.value.pr_toggle or nil
@@ -46,11 +46,11 @@ describe('forge.completion_policy', function()
 
   after_each(function()
     package.preload['forge.availability'] = old_availability
-    package.preload['forge.picker'] = old_picker
+    package.preload['forge.surface_policy'] = old_surface_policy
 
     package.loaded['forge.completion_policy'] = nil
     package.loaded['forge.availability'] = nil
-    package.loaded['forge.picker'] = nil
+    package.loaded['forge.surface_policy'] = nil
   end)
 
   it('returns slot-composition policies for family and argument slots', function()

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -33,11 +33,11 @@ end
 
 function M.action_labels(actions, entry)
   local labels = {}
-  local ok, picker = pcall(require, 'forge.picker')
+  local ok, surface_policy = pcall(require, 'forge.surface_policy')
   for _, def in ipairs(actions or {}) do
     local label
-    if ok and type(picker.resolve_label) == 'function' then
-      label = picker.resolve_label(def, entry)
+    if ok and type(surface_policy.resolve_label) == 'function' then
+      label = surface_policy.resolve_label(def, entry)
     else
       label = def.label
       if type(label) == 'function' then

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -617,6 +617,42 @@ describe('format_runs', function()
     assert.equals('ForgeBranch', rows[2][3][2])
     assert.equals(3, #rows[2])
   end)
+
+  it('renders CI context before branch metadata when both are present', function()
+    local rows = forge.format_runs({
+      {
+        name = 'feat(browse): accept shorthand target paths (#486)',
+        context = 'quality',
+        branch = 'main',
+        status = 'success',
+        event = 'push',
+        created_at = '',
+      },
+    }, { width = 96 })
+
+    local result = flatten(rows[1])
+    assert.truthy(result:find('quality', 1, true))
+    assert.truthy(result:find('main', 1, true))
+    assert.equals('ForgeDim', rows[1][3][2])
+    assert.equals('ForgeBranch', rows[1][4][2])
+  end)
+
+  it('hides duplicate CI context and branch metadata', function()
+    local rows = forge.format_runs({
+      {
+        name = 'main',
+        context = 'main',
+        branch = 'main',
+        status = 'success',
+        event = 'push',
+        created_at = '',
+      },
+    }, { width = 64 })
+
+    assert.equals(3, #rows[1])
+    assert.equals('ForgeDim', rows[1][3][2])
+    assert.truthy(flatten(rows[1]):find('push', 1, true))
+  end)
 end)
 
 describe('format_checks', function()

--- a/spec/picker_init_spec.lua
+++ b/spec/picker_init_spec.lua
@@ -6,85 +6,101 @@ local function names(items)
   end, items)
 end
 
-describe('forge.picker.pr_toggle_verb', function()
-  local picker
+describe('forge.surface_policy.pr_toggle_verb', function()
+  local surface_policy
 
   before_each(function()
-    package.loaded['forge.picker'] = nil
-    picker = require('forge.picker')
+    package.loaded['forge.surface_policy'] = nil
+    surface_policy = require('forge.surface_policy')
   end)
 
   it('returns close for open prs', function()
-    assert.equals('close', picker.pr_toggle_verb({ value = { num = '1', state = 'OPEN' } }))
+    assert.equals('close', surface_policy.pr_toggle_verb({ value = { num = '1', state = 'OPEN' } }))
   end)
 
   it('returns close for lowercase opened state (gitlab)', function()
-    assert.equals('close', picker.pr_toggle_verb({ value = { num = '1', state = 'opened' } }))
+    assert.equals(
+      'close',
+      surface_policy.pr_toggle_verb({ value = { num = '1', state = 'opened' } })
+    )
   end)
 
   it('returns reopen for closed (non-merged) prs', function()
-    assert.equals('reopen', picker.pr_toggle_verb({ value = { num = '1', state = 'CLOSED' } }))
+    assert.equals(
+      'reopen',
+      surface_policy.pr_toggle_verb({ value = { num = '1', state = 'CLOSED' } })
+    )
   end)
 
   it('returns nil for merged prs because merged is a terminal state', function()
-    assert.is_nil(picker.pr_toggle_verb({ value = { num = '1', state = 'MERGED' } }))
+    assert.is_nil(surface_policy.pr_toggle_verb({ value = { num = '1', state = 'MERGED' } }))
   end)
 
   it('returns nil for placeholder or load_more rows', function()
-    assert.is_nil(picker.pr_toggle_verb({ placeholder = true, value = { state = 'OPEN' } }))
-    assert.is_nil(picker.pr_toggle_verb({ load_more = true, value = { state = 'OPEN' } }))
+    assert.is_nil(surface_policy.pr_toggle_verb({ placeholder = true, value = { state = 'OPEN' } }))
+    assert.is_nil(surface_policy.pr_toggle_verb({ load_more = true, value = { state = 'OPEN' } }))
   end)
 
   it('returns nil when the entry has no value table', function()
-    assert.is_nil(picker.pr_toggle_verb(nil))
-    assert.is_nil(picker.pr_toggle_verb({ value = 'not-a-table' }))
+    assert.is_nil(surface_policy.pr_toggle_verb(nil))
+    assert.is_nil(surface_policy.pr_toggle_verb({ value = 'not-a-table' }))
   end)
 end)
 
-describe('forge.picker.issue_toggle_verb', function()
-  local picker
+describe('forge.surface_policy.issue_toggle_verb', function()
+  local surface_policy
 
   before_each(function()
-    package.loaded['forge.picker'] = nil
-    picker = require('forge.picker')
+    package.loaded['forge.surface_policy'] = nil
+    surface_policy = require('forge.surface_policy')
   end)
 
   it('returns close for open issues', function()
-    assert.equals('close', picker.issue_toggle_verb({ value = { num = '1', state = 'opened' } }))
+    assert.equals(
+      'close',
+      surface_policy.issue_toggle_verb({ value = { num = '1', state = 'opened' } })
+    )
   end)
 
   it('returns reopen for closed issues', function()
-    assert.equals('reopen', picker.issue_toggle_verb({ value = { num = '1', state = 'closed' } }))
+    assert.equals(
+      'reopen',
+      surface_policy.issue_toggle_verb({ value = { num = '1', state = 'closed' } })
+    )
   end)
 
   it('does not treat merged as a valid issue state', function()
-    assert.is_nil(picker.issue_toggle_verb({ value = { num = '1', state = 'merged' } }))
+    assert.is_nil(surface_policy.issue_toggle_verb({ value = { num = '1', state = 'merged' } }))
   end)
 
   it('returns nil for placeholder or load_more rows', function()
-    assert.is_nil(picker.issue_toggle_verb({ placeholder = true, value = { state = 'OPEN' } }))
-    assert.is_nil(picker.issue_toggle_verb({ load_more = true, value = { state = 'OPEN' } }))
+    assert.is_nil(
+      surface_policy.issue_toggle_verb({ placeholder = true, value = { state = 'OPEN' } })
+    )
+    assert.is_nil(
+      surface_policy.issue_toggle_verb({ load_more = true, value = { state = 'OPEN' } })
+    )
   end)
 
   it('returns nil when the entry has no value table', function()
-    assert.is_nil(picker.issue_toggle_verb(nil))
-    assert.is_nil(picker.issue_toggle_verb({ value = 'not-a-table' }))
+    assert.is_nil(surface_policy.issue_toggle_verb(nil))
+    assert.is_nil(surface_policy.issue_toggle_verb({ value = 'not-a-table' }))
   end)
 end)
 
-describe('forge.picker.ci_toggle_verb', function()
-  local picker
+describe('forge.surface_policy.ci_toggle_verb', function()
+  local surface_policy
 
   before_each(function()
-    package.loaded['forge.picker'] = nil
-    picker = require('forge.picker')
+    package.loaded['forge.surface_policy'] = nil
+    surface_policy = require('forge.surface_policy')
   end)
 
   it('returns cancel for in-progress runs', function()
     for _, status in ipairs({ 'in_progress', 'queued', 'pending', 'running' }) do
       assert.equals(
         'cancel',
-        picker.ci_toggle_verb({ value = { id = '1', status = status } }),
+        surface_policy.ci_toggle_verb({ value = { id = '1', status = status } }),
         'status=' .. status
       )
     end
@@ -94,41 +110,45 @@ describe('forge.picker.ci_toggle_verb', function()
     for _, status in ipairs({ 'success', 'failure', 'cancelled', 'timed_out' }) do
       assert.equals(
         'rerun',
-        picker.ci_toggle_verb({ value = { id = '1', status = status } }),
+        surface_policy.ci_toggle_verb({ value = { id = '1', status = status } }),
         'status=' .. status
       )
     end
   end)
 
   it('returns rerun when a run status is missing', function()
-    assert.equals('rerun', picker.ci_toggle_verb({ value = { id = '1' } }))
+    assert.equals('rerun', surface_policy.ci_toggle_verb({ value = { id = '1' } }))
   end)
 
   it('returns nil for skipped runs', function()
-    assert.is_nil(picker.ci_toggle_verb({ value = { id = '1', status = 'skipped' } }))
+    assert.is_nil(surface_policy.ci_toggle_verb({ value = { id = '1', status = 'skipped' } }))
   end)
 
   it('returns nil for placeholder or load_more rows', function()
-    assert.is_nil(picker.ci_toggle_verb({ placeholder = true, value = { status = 'running' } }))
-    assert.is_nil(picker.ci_toggle_verb({ load_more = true, value = { status = 'running' } }))
+    assert.is_nil(
+      surface_policy.ci_toggle_verb({ placeholder = true, value = { status = 'running' } })
+    )
+    assert.is_nil(
+      surface_policy.ci_toggle_verb({ load_more = true, value = { status = 'running' } })
+    )
   end)
 
   it('returns nil when the entry has no value table', function()
-    assert.is_nil(picker.ci_toggle_verb(nil))
-    assert.is_nil(picker.ci_toggle_verb({ value = 'not-a-table' }))
+    assert.is_nil(surface_policy.ci_toggle_verb(nil))
+    assert.is_nil(surface_policy.ci_toggle_verb({ value = 'not-a-table' }))
   end)
 end)
 
-describe('forge.picker.resolve_label', function()
-  local picker
+describe('forge.surface_policy.resolve_label', function()
+  local surface_policy
 
   before_each(function()
-    package.loaded['forge.picker'] = nil
-    picker = require('forge.picker')
+    package.loaded['forge.surface_policy'] = nil
+    surface_policy = require('forge.surface_policy')
   end)
 
   it('returns string labels verbatim', function()
-    assert.equals('merge', picker.resolve_label({ name = 'merge', label = 'merge' }))
+    assert.equals('merge', surface_policy.resolve_label({ name = 'merge', label = 'merge' }))
   end)
 
   it('hides labels when the action is unavailable', function()
@@ -140,7 +160,7 @@ describe('forge.picker.resolve_label', function()
       end,
     }
 
-    assert.is_nil(picker.resolve_label(def, { value = { state = 'OPEN' } }))
+    assert.is_nil(surface_policy.resolve_label(def, { value = { state = 'OPEN' } }))
   end)
 
   it('invokes function labels with the entry', function()
@@ -152,7 +172,7 @@ describe('forge.picker.resolve_label', function()
         return 'close'
       end,
     }
-    local label = picker.resolve_label(def, { value = { state = 'OPEN' } })
+    local label = surface_policy.resolve_label(def, { value = { state = 'OPEN' } })
     assert.equals('close', label)
     assert.same({ value = { state = 'OPEN' } }, captured)
   end)
@@ -164,7 +184,7 @@ describe('forge.picker.resolve_label', function()
         error('boom')
       end,
     }
-    assert.is_nil(picker.resolve_label(def, nil))
+    assert.is_nil(surface_policy.resolve_label(def, nil))
   end)
 
   it('treats availability function failures as unavailable', function()
@@ -176,20 +196,20 @@ describe('forge.picker.resolve_label', function()
       end,
     }
 
-    assert.is_nil(picker.resolve_label(def, nil))
-    assert.is_false(picker.available(def, nil))
+    assert.is_nil(surface_policy.resolve_label(def, nil))
+    assert.is_false(surface_policy.available(def, nil))
   end)
 
   it('resolves static and dynamic availability', function()
-    assert.is_true(picker.available({ name = 'a' }, nil))
-    assert.is_false(picker.available({ name = 'b', available = false }, nil))
-    assert.is_true(picker.available({
+    assert.is_true(surface_policy.available({ name = 'a' }, nil))
+    assert.is_false(surface_policy.available({ name = 'b', available = false }, nil))
+    assert.is_true(surface_policy.available({
       name = 'c',
       available = function(entry)
         return entry ~= nil
       end,
     }, { value = 1 }))
-    assert.is_false(picker.available({
+    assert.is_false(surface_policy.available({
       name = 'd',
       available = function(entry)
         return entry ~= nil
@@ -198,10 +218,10 @@ describe('forge.picker.resolve_label', function()
   end)
 
   it('reports dynamic labels', function()
-    assert.is_true(picker.has_dynamic_label({ name = 'a', label = function() end }))
-    assert.is_false(picker.has_dynamic_label({ name = 'b', label = 'static' }))
-    assert.is_true(picker.has_dynamic_label({ name = 'c', available = function() end }))
-    assert.is_false(picker.has_dynamic_label({ name = 'd' }))
+    assert.is_true(surface_policy.has_dynamic_label({ name = 'a', label = function() end }))
+    assert.is_false(surface_policy.has_dynamic_label({ name = 'b', label = 'static' }))
+    assert.is_true(surface_policy.has_dynamic_label({ name = 'c', available = function() end }))
+    assert.is_false(surface_policy.has_dynamic_label({ name = 'd' }))
   end)
 end)
 
@@ -245,6 +265,27 @@ describe('forge.picker.order_hints', function()
     })
 
     assert.same({ 'default', 'create', 'filter', 'refresh', 'mystery_a' }, names(ordered))
+  end)
+end)
+
+describe('forge.picker.search_key', function()
+  local picker
+
+  before_each(function()
+    package.loaded['forge.picker'] = nil
+    picker = require('forge.picker')
+  end)
+
+  it('includes CI context alongside the run name and branch', function()
+    local key = picker.search_key('ci', {
+      value = {
+        name = 'feat(browse): accept shorthand target paths (#486)',
+        context = 'quality',
+        branch = 'main',
+      },
+    })
+
+    assert.equals('feat(browse): accept shorthand target paths (#486) quality main', key)
   end)
 end)
 

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -21,6 +21,7 @@ local preload_modules = {
   'forge.logger',
   'forge.ops',
   'forge.picker',
+  'forge.surface_policy',
 }
 local loaded_modules = {
   'forge',
@@ -31,6 +32,7 @@ local loaded_modules = {
   'forge.picker.session',
   'forge.pickers',
   'forge.review',
+  'forge.surface_policy',
 }
 
 local function fake_forge(opts)
@@ -238,16 +240,6 @@ describe('pickers', function()
       }
     end
     package.preload['forge.picker'] = function()
-      local function available(def, entry)
-        local fn = rawget(def, 'available')
-        if type(fn) == 'function' then
-          return fn(entry) ~= false
-        end
-        if fn ~= nil then
-          return fn ~= false
-        end
-        return true
-      end
       return {
         backends = { ['fzf-lua'] = 'forge.picker.fzf' },
         backend = function()
@@ -280,6 +272,32 @@ describe('pickers', function()
               return true
             end,
           }
+        end,
+      }
+    end
+    package.preload['forge.surface_policy'] = function()
+      local function available(def, entry)
+        local fn = rawget(def, 'available')
+        if type(fn) == 'function' then
+          return fn(entry) ~= false
+        end
+        if fn ~= nil then
+          return fn ~= false
+        end
+        return true
+      end
+      return {
+        row_kind = function(entry)
+          if entry == nil then
+            return 'none'
+          end
+          if entry.load_more then
+            return 'load_more'
+          end
+          if entry.placeholder then
+            return entry.placeholder_kind == 'error' and 'error' or 'empty'
+          end
+          return 'entity'
         end,
         available = available,
         resolve_label = function(def, entry)
@@ -2514,6 +2532,50 @@ describe('pickers', function()
         scope = nil,
       },
     }, op_calls[2])
+  end)
+
+  it('includes CI context in picker ordinals', function()
+    local old_system = vim.system
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            id = '1',
+            name = 'feat(browse): accept shorthand target paths (#486)',
+            context = 'quality',
+            branch = 'main',
+            status = 'success',
+            url = 'https://example.com',
+          },
+        }),
+      })
+      return {
+        wait = function()
+          return { code = 0 }
+        end,
+      }
+    end
+
+    local pickers = require('forge.pickers')
+    pickers.ci(fake_ci_forge(), 'main', 'all')
+    local streamed = {}
+    captured.stream(function(entry)
+      if entry == nil then
+        streamed.done = true
+        return
+      end
+      streamed[#streamed + 1] = entry
+    end)
+    vim.wait(100, function()
+      return streamed.done == true
+    end)
+    vim.system = old_system
+
+    assert.equals(
+      'feat(browse): accept shorthand target paths (#486) quality main',
+      streamed[1].ordinal
+    )
   end)
 
   it('routes the CI toggle action through forge.ops.ci_toggle', function()

--- a/spec/pr_checks_spec.lua
+++ b/spec/pr_checks_spec.lua
@@ -219,6 +219,78 @@ describe('pr checks buffer', function()
     }, captured.logs[1])
   end)
 
+  it('trims trailing padding from rendered check rows before writing the buffer', function()
+    package.preload['forge'] = function()
+      return {
+        config = function()
+          return {
+            split = 'horizontal',
+            ci = { refresh = 5 },
+            keys = {
+              log = {
+                next_step = ']]',
+                prev_step = '[[',
+                refresh = '<c-r>',
+              },
+            },
+          }
+        end,
+        filter_checks = function(checks)
+          return checks
+        end,
+        format_checks = function()
+          return {
+            {
+              { 'lint', 'ForgeFail' },
+              { ' [web]   ', 'ForgeDim' },
+            },
+          }
+        end,
+      }
+    end
+    package.loaded['forge'] = nil
+    package.loaded['forge.pr_checks'] = nil
+
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            name = 'lint',
+            bucket = 'fail',
+            link = 'https://example.com/actions/runs/123/job/456',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.pr_checks')
+    mod.open({
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = { per_pr_checks = true },
+      checks_json_cmd = function()
+        return { 'checks', '42' }
+      end,
+      check_log_cmd = function(_, run_id, failed, job_id)
+        return { 'log', run_id, tostring(failed), job_id or '' }
+      end,
+    }, {
+      num = '42',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(buf, 0, -1, false)[1] == 'lint [web]'
+    end)
+
+    assert.same({ 'lint [web]' }, vim.api.nvim_buf_get_lines(buf, 0, 1, false))
+  end)
+
   it('routes pending checks through live tail when available', function()
     vim.system = function(_, _, cb)
       cb({
@@ -270,5 +342,90 @@ describe('pr checks buffer', function()
       },
     }, captured.terms[1])
     assert.same({}, captured.logs)
+  end)
+
+  it('renders browse-only checks explicitly and opens them in the browser on enter', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            name = 'skipped',
+            bucket = 'skipping',
+            link = 'https://example.com/actions/runs/123/job/456',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.pr_checks')
+    mod.open({
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = { per_pr_checks = true },
+      checks_json_cmd = function()
+        return { 'checks', '42' }
+      end,
+      check_log_cmd = function()
+        return { 'log' }
+      end,
+    }, {
+      num = '42',
+      scope = scope,
+    })
+
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == 'skipped [web]'
+    end)
+    vim.fn.maparg('<cr>', 'n', false, true).callback()
+
+    assert.same({ 'https://example.com/actions/runs/123/job/456' }, captured.urls)
+    assert.same({}, captured.logs)
+    assert.same({}, captured.terms)
+  end)
+
+  it('renders unavailable checks explicitly and leaves enter inert', function()
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            name = 'waiting',
+            bucket = 'skipping',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.pr_checks')
+    mod.open({
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = { per_pr_checks = true },
+      checks_json_cmd = function()
+        return { 'checks', '42' }
+      end,
+      check_log_cmd = function()
+        return { 'log' }
+      end,
+    }, {
+      num = '42',
+      scope = scope,
+    })
+
+    vim.wait(100, function()
+      return vim.api.nvim_buf_get_lines(0, 0, -1, false)[1] == 'waiting [unavailable]'
+    end)
+    vim.fn.maparg('<cr>', 'n', false, true).callback()
+
+    assert.same({}, captured.urls)
+    assert.same({}, captured.logs)
+    assert.same({}, captured.terms)
   end)
 end)

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -180,6 +180,7 @@ describe('routes', function()
           captured.issue_scope = opts and opts.scope or nil
         end,
         ci = function(_, branch, _, opts)
+          captured.ci_called = true
           captured.ci = branch
           captured.ci_back = opts and opts.back or nil
           captured.ci_scope = opts and opts.scope or nil
@@ -256,6 +257,14 @@ describe('routes', function()
 
     assert.same(scope, captured.pr_scope)
     assert.same(scope, captured.ci_scope)
+  end)
+
+  it('keeps repo-wide ci on the interactive picker surface', function()
+    require('forge.routes').open('ci.all')
+
+    assert.is_true(captured.ci_called)
+    assert.is_nil(captured.ci)
+    assert.is_nil(captured.warn)
   end)
 
   it('opens the configured root sections through the picker client', function()

--- a/spec/sources_spec.lua
+++ b/spec/sources_spec.lua
@@ -301,6 +301,19 @@ describe('github', function()
     assert.equals('createdAt', f.created_at)
   end)
 
+  it('requests displayTitle and workflowName in GitHub run list queries', function()
+    local cmd = gh:list_runs_json_cmd('main', { repo_arg = 'owner/repo' }, 55)
+    assert.truthy(vim.tbl_contains(cmd, '--json'))
+    assert.truthy(
+      vim.tbl_contains(
+        cmd,
+        'databaseId,displayTitle,workflowName,name,headBranch,status,conclusion,event,url,createdAt'
+      )
+    )
+    assert.truthy(vim.tbl_contains(cmd, '--branch'))
+    assert.truthy(vim.tbl_contains(cmd, 'main'))
+  end)
+
   it('normalizes completed run to conclusion', function()
     local run = gh:normalize_run({
       databaseId = 123,
@@ -334,6 +347,7 @@ describe('github', function()
       conclusion = 'success',
     })
     assert.equals('fix(ci): add load more for repo runs (#196)', run.name)
+    assert.equals('quality', run.context)
   end)
 
   it('builds list_web_url for each kind', function()
@@ -778,9 +792,10 @@ describe('gitlab', function()
     assert.equals('created_at', f.created_at)
   end)
 
-  it('extracts MR number from ref in normalize_run', function()
+  it('keeps GitLab MR context separate from the normalized run name', function()
     local run = gl:normalize_run({
       id = 456,
+      name = 'merge request pipeline',
       ref = 'refs/merge-requests/10/head',
       status = 'success',
       source = 'push',
@@ -788,11 +803,16 @@ describe('gitlab', function()
       created_at = '2025-01-01T00:00:00Z',
     })
     assert.equals('456', run.id)
-    assert.equals('!10', run.name)
+    assert.equals('merge request pipeline', run.name)
+    assert.equals('!10', run.context)
+    assert.equals('', run.branch)
   end)
 
-  it('uses ref as name for non-MR refs', function()
-    assert.equals('main', gl:normalize_run({ id = 1, ref = 'main', status = 'running' }).name)
+  it('uses ref as name and branch for non-MR refs', function()
+    local run = gl:normalize_run({ id = 1, ref = 'main', status = 'running' })
+    assert.equals('main', run.name)
+    assert.equals('', run.context)
+    assert.equals('main', run.branch)
   end)
 
   it('builds list_web_url for each kind', function()
@@ -1118,6 +1138,33 @@ describe('codeberg', function()
     assert.equals('index', f.number)
     assert.equals('head', f.branch)
     assert.equals('poster', f.author)
+  end)
+
+  it('prefers a Codeberg display title while keeping workflow identity as context', function()
+    local run = cb:normalize_run({
+      id = 789,
+      name = 'quality',
+      display_title = 'feat(browse): accept shorthand target paths (#486)',
+      head_branch = 'main',
+      status = 'completed',
+      conclusion = 'success',
+      event = 'push',
+      html_url = 'https://example.com',
+      created_at = '2025-01-01T00:00:00Z',
+    })
+    assert.equals('789', run.id)
+    assert.equals('feat(browse): accept shorthand target paths (#486)', run.name)
+    assert.equals('quality', run.context)
+    assert.equals('main', run.branch)
+    assert.equals('success', run.status)
+  end)
+
+  it('falls back to the Codeberg run name when no display title is present', function()
+    local run =
+      cb:normalize_run({ id = 1, name = 'quality', status = 'running', head_branch = 'main' })
+    assert.equals('quality', run.name)
+    assert.equals('quality', run.context)
+    assert.equals('main', run.branch)
   end)
 
   it('returns nil from draft_toggle_cmd', function()


### PR DESCRIPTION
## Problem

Forge's CI and checks surfaces were split between picker-only semantics and deterministic buffers, and CI runs did not preserve a shared secondary identity across backends. That left hidden affordances, inconsistent row labels, and trailing padding in some cmdline-opened buffers.

## Solution

Extract shared surface policy out of picker-specific code, add explicit deterministic CI and check affordances, and normalize CI runs around a shared `name/context/branch` row contract across GitHub, GitLab, and Codeberg. Also trim dead trailing padding when deterministic CI and checks buffers render formatted rows.

Closes #487.
Closes #488.
Closes #489.
Closes #490.
Closes #491.
Closes #492.
Closes #493.
Closes #494.