### PR TITLE
feat(ci): filter deterministic jobs by name

### DIFF
--- a/doc/forge.nvim.txt
+++ b/doc/forge.nvim.txt
@@ -229,6 +229,7 @@ Top-level keys: ~
           refresh = '<c-r>',
         },
         log = {
+          filter = '<tab>',
           next_step = ']]',
           prev_step = '[[',
           refresh = '<c-r>',
@@ -283,6 +284,7 @@ Top-level keys: ~
 
   `keys.log`: ~
     Action           Default Key      Meaning ~
+    `filter`         `<tab>`          Filter checks/summary jobs by name
     `next_step`      `]]`             Next step/job
     `prev_step`      `[[`             Previous step/job
     `refresh`        `<c-r>`          Refresh log/summary

--- a/lua/forge/config.lua
+++ b/lua/forge/config.lua
@@ -68,6 +68,7 @@ local surface = require('forge.surface')
 ---@field refresh string|false
 
 ---@class forge.LogViewerKeys
+---@field filter string|false
 ---@field next_step string|false
 ---@field prev_step string|false
 ---@field refresh string|false
@@ -155,6 +156,7 @@ local DEFAULTS = {
       refresh = '<c-r>',
     },
     log = {
+      filter = '<tab>',
       next_step = ']]',
       prev_step = '[[',
       refresh = '<c-r>',
@@ -388,6 +390,7 @@ function M.config()
     if keys.pr ~= nil then
       vim.validate('forge.keys.pr', keys.pr, 'table')
       for _, k in ipairs({
+        'filter',
         'ci',
         'edit',
         'approve',

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -1001,8 +1001,77 @@ end
 ---@field in_progress boolean?
 ---@field status_cmd string[]?
 ---@field json boolean?
+---@field job_filter string?
 ---@field browse_url_fn fun(job_id: string): string?
 ---@field log_cmd_fn fun(job_id: string, failed: boolean): string[], forge.LogOpts
+
+local function normalize_job_filter_input(text)
+  if text == nil then
+    return nil, true
+  end
+  local trimmed = vim.trim(text)
+  if trimmed == '' then
+    return nil, false
+  end
+  return trimmed, false
+end
+
+local function matches_job_filter(name, job_filter)
+  if type(job_filter) ~= 'string' or job_filter == '' then
+    return true
+  end
+  local candidate = type(name) == 'string' and strip_ansi(name):lower() or ''
+  return candidate:find(job_filter:lower(), 1, true) ~= nil
+end
+
+local function filter_summary(parsed, job_filter)
+  if type(job_filter) ~= 'string' or job_filter == '' then
+    return parsed
+  end
+  local matched_ids = {}
+  local header_rows = {}
+  for _, lnum in ipairs(parsed.job_lnums or {}) do
+    header_rows[lnum] = true
+    local job = parsed.jobs and parsed.jobs[lnum] or nil
+    if job and job.id and matches_job_filter(parsed.lines[lnum], job_filter) then
+      matched_ids[job.id] = true
+    end
+  end
+  local lines = {}
+  local hls = {}
+  local jobs = {}
+  local job_lnums = {}
+  local first_job = parsed.job_lnums and parsed.job_lnums[1] or nil
+  local header_limit = first_job and (first_job - 1) or 0
+  for lnum = 1, header_limit do
+    lines[#lines + 1] = parsed.lines[lnum]
+    hls[#lines] = parsed.hls[lnum] or {}
+  end
+  if next(matched_ids) == nil then
+    local text = ('No jobs matching "%s"'):format(job_filter)
+    lines[#lines + 1] = text
+    hls[#lines] = {
+      {
+        col = 0,
+        end_col = #text,
+        group = 'ForgeDim',
+      },
+    }
+    return { lines = lines, hls = hls, jobs = jobs, job_lnums = job_lnums }
+  end
+  for lnum, line in ipairs(parsed.lines or {}) do
+    local job = parsed.jobs and parsed.jobs[lnum] or nil
+    if job and matched_ids[job.id] then
+      lines[#lines + 1] = line
+      hls[#lines] = parsed.hls[lnum] or {}
+      jobs[#lines] = job
+      if header_rows[lnum] then
+        job_lnums[#job_lnums + 1] = #lines
+      end
+    end
+  end
+  return { lines = lines, hls = hls, jobs = jobs, job_lnums = job_lnums }
+end
 
 local function parse_summary(raw_lines)
   local lines = {}
@@ -1241,6 +1310,7 @@ function M.open_summary(cmd, opts, reuse_buf)
         end
         parsed = parse_summary(raw_lines)
       end
+      parsed = filter_summary(parsed, opts.job_filter)
 
       vim.bo[buf].modifiable = true
       vim.api.nvim_buf_set_lines(buf, 0, -1, false, parsed.lines)
@@ -1290,6 +1360,24 @@ function M.open_summary(cmd, opts, reuse_buf)
           map(keys.refresh, function()
             M.open_summary(cmd, opts, buf)
           end, 'Refresh')
+          map(keys.filter, function()
+            vim.ui.input(
+              { prompt = 'Filter jobs: ', default = opts.job_filter or '' },
+              function(input)
+                local next_filter, cancelled = normalize_job_filter_input(input)
+                if cancelled then
+                  return
+                end
+                vim.schedule(function()
+                  if not vim.api.nvim_buf_is_valid(buf) then
+                    return
+                  end
+                  opts.job_filter = next_filter
+                  M.open_summary(cmd, opts, buf)
+                end)
+              end
+            )
+          end, 'Filter jobs')
           map(keys.next_step, function()
             jump(buf, 'header', 1)
           end, 'Next job')

--- a/lua/forge/pr_checks.lua
+++ b/lua/forge/pr_checks.lua
@@ -243,6 +243,25 @@ local function render(buf, lines)
   set_data(buf, { lines = lines })
 end
 
+local function normalize_job_filter_input(text)
+  if text == nil then
+    return nil, true
+  end
+  local trimmed = vim.trim(text)
+  if trimmed == '' then
+    return nil, false
+  end
+  return trimmed, false
+end
+
+local function matches_job_filter(name, job_filter)
+  if type(job_filter) ~= 'string' or job_filter == '' then
+    return true
+  end
+  local candidate = type(name) == 'string' and name:lower() or ''
+  return candidate:find(job_filter:lower(), 1, true) ~= nil
+end
+
 ---@param check forge.Check?
 ---@return boolean
 openable_check = function(check)
@@ -299,6 +318,7 @@ end
 ---@param pr forge.PRRef
 ---@param opts table?
 local function setup_keymaps(buf, f, pr, opts)
+  opts = opts or {}
   local cfg = require('forge').config()
   local keys = type(cfg.keys) == 'table' and cfg.keys.log or {}
   local function map(key, fn, desc)
@@ -321,6 +341,21 @@ local function setup_keymaps(buf, f, pr, opts)
       open_check(f, check, pr.scope)
     end
   end, { buffer = buf, desc = 'Open' })
+  map(keys.filter, function()
+    vim.ui.input({ prompt = 'Filter jobs: ', default = opts.job_filter or '' }, function(input)
+      local next_filter, cancelled = normalize_job_filter_input(input)
+      if cancelled then
+        return
+      end
+      vim.schedule(function()
+        if not vim.api.nvim_buf_is_valid(buf) then
+          return
+        end
+        opts.job_filter = next_filter
+        M.open(f, pr, opts, buf)
+      end)
+    end)
+  end, 'Filter jobs')
   map(keys.refresh, function()
     M.open(f, pr, opts, buf)
   end, 'Refresh')
@@ -386,14 +421,21 @@ end
 
 ---@param checks forge.Check[]
 ---@param scope forge.Scope?
+---@param job_filter string?
 ---@return forge.Check[]
-local function normalize_checks(checks, scope)
+local function normalize_checks(checks, scope, job_filter)
   local forge = require('forge')
   local normalized = vim.deepcopy(checks)
   for _, check in ipairs(normalized) do
     check.scope = check.scope or scope
   end
-  return forge.filter_checks(normalized, 'all')
+  local filtered = forge.filter_checks(normalized, 'all')
+  if type(job_filter) ~= 'string' or job_filter == '' then
+    return filtered
+  end
+  return vim.tbl_filter(function(check)
+    return matches_job_filter(check.name, job_filter)
+  end, filtered)
 end
 
 ---@param f forge.Forge
@@ -431,9 +473,12 @@ function M.open(f, pr, opts, reuse_buf)
         log.error(msg)
         return
       end
-      local checks = normalize_checks(decoded, pr.scope)
+      local checks = normalize_checks(decoded, pr.scope, opts.job_filter)
       if #checks == 0 then
-        render(buf, render_placeholder(('No checks for #%s'):format(pr.num), 'ForgeDim'))
+        local msg = opts.job_filter
+            and ('No jobs matching "%s" for #%s'):format(opts.job_filter, pr.num)
+          or ('No checks for #%s'):format(pr.num)
+        render(buf, render_placeholder(msg, 'ForgeDim'))
         return
       end
       render(buf, render_rows(checks))

--- a/spec/config_validation_spec.lua
+++ b/spec/config_validation_spec.lua
@@ -103,6 +103,7 @@ describe('config validation', function()
           edit = '<c-e>',
         },
         log = {
+          filter = '<tab>',
           refresh = '<leader>r',
         },
       },
@@ -111,6 +112,7 @@ describe('config validation', function()
     local cfg = config.config()
 
     assert.equals('<c-e>', cfg.keys.pr.edit)
+    assert.equals('<tab>', cfg.keys.log.filter)
     assert.equals('<leader>r', cfg.keys.log.refresh)
   end)
 

--- a/spec/log_spec.lua
+++ b/spec/log_spec.lua
@@ -679,17 +679,20 @@ describe('summary job mappings', function()
   local original_system
   local original_open
   local original_ui_open
+  local original_ui_input
 
   before_each(function()
     original_system = vim.system
     original_open = log_mod.open
     original_ui_open = vim.ui.open
+    original_ui_input = vim.ui.input
   end)
 
   after_each(function()
     vim.system = original_system
     log_mod.open = original_open
     vim.ui.open = original_ui_open
+    vim.ui.input = original_ui_input
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if vim.api.nvim_buf_is_valid(buf) then
@@ -846,6 +849,74 @@ describe('summary job mappings', function()
     browse()
 
     assert.same({ 'https://example.com/runs/77/job/12345' }, opened)
+  end)
+
+  it('filters summary jobs by name and preserves filtered job actions', function()
+    local opened = {}
+    local prompts = {}
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          name = 'quality',
+          status = 'completed',
+          conclusion = 'success',
+          jobs = {
+            {
+              databaseId = 12345,
+              name = 'lint',
+              status = 'completed',
+              conclusion = 'success',
+            },
+            {
+              databaseId = 67890,
+              name = 'test',
+              status = 'completed',
+              conclusion = 'failure',
+            },
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+    vim.ui.input = function(opts, cb)
+      prompts[#prompts + 1] = opts
+      cb('test')
+    end
+    log_mod.open = function(cmd, opts)
+      opened[#opened + 1] = { cmd = cmd, opts = opts }
+    end
+
+    log_mod.open_summary({ 'gh', 'run', 'view' }, {
+      forge_name = 'github',
+      scope = test_scope,
+      run_id = '12345',
+      json = true,
+      log_cmd_fn = function(job_id, failed)
+        return { 'log', job_id, tostring(failed) }, { job_id = job_id }
+      end,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      return lines[1] == 'p  quality' and lines[4] == 'f  test'
+    end)
+
+    vim.fn.maparg('<tab>', 'n', false, true).callback()
+    vim.wait(100, function()
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      return #lines == 3 and lines[1] == 'p  quality' and lines[3] == 'f  test'
+    end)
+
+    vim.api.nvim_win_set_cursor(0, { 3, 0 })
+    vim.fn.maparg('<cr>', 'n', false, true).callback()
+
+    assert.equals('Filter jobs: ', prompts[1].prompt)
+    assert.same({ 'log', '67890', 'true' }, opened[1].cmd)
+    assert.same({ job_id = '67890', replace_win = vim.api.nvim_get_current_win() }, opened[1].opts)
   end)
 end)
 

--- a/spec/pr_checks_spec.lua
+++ b/spec/pr_checks_spec.lua
@@ -5,6 +5,7 @@ local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
 describe('pr checks buffer', function()
   local old_system
   local old_ui_open
+  local old_ui_input
   local old_preload
   local captured
 
@@ -23,6 +24,7 @@ describe('pr checks buffer', function()
     }
     old_system = vim.system
     old_ui_open = vim.ui.open
+    old_ui_input = vim.ui.input
     old_preload = helpers.capture_preload({
       'forge',
       'forge.layout',
@@ -41,6 +43,7 @@ describe('pr checks buffer', function()
             ci = { refresh = 5 },
             keys = {
               log = {
+                filter = '<tab>',
                 next_step = ']]',
                 prev_step = '[[',
                 refresh = '<c-r>',
@@ -130,6 +133,7 @@ describe('pr checks buffer', function()
   after_each(function()
     vim.system = old_system
     vim.ui.open = old_ui_open
+    vim.ui.input = old_ui_input
 
     helpers.restore_preload(old_preload)
     package.loaded['forge'] = nil
@@ -217,6 +221,65 @@ describe('pr checks buffer', function()
         replace_win = win,
       },
     }, captured.logs[1])
+  end)
+
+  it('filters checks by name from the deterministic checks buffer', function()
+    local prompts = {}
+    vim.ui.input = function(opts, cb)
+      prompts[#prompts + 1] = opts
+      cb('lint')
+    end
+    vim.system = function(_, _, cb)
+      cb({
+        code = 0,
+        stdout = vim.json.encode({
+          {
+            name = 'lint',
+            bucket = 'fail',
+            link = 'https://example.com/actions/runs/123/job/456',
+          },
+          {
+            name = 'test',
+            bucket = 'pass',
+            link = 'https://example.com/actions/runs/123/job/789',
+          },
+        }),
+      })
+      return {
+        kill = function() end,
+      }
+    end
+
+    local mod = require('forge.pr_checks')
+    mod.open({
+      name = 'github',
+      labels = { pr_one = 'PR' },
+      capabilities = { per_pr_checks = true },
+      checks_json_cmd = function()
+        return { 'checks', '42' }
+      end,
+      check_log_cmd = function(_, run_id, failed, job_id)
+        return { 'log', run_id, tostring(failed), job_id or '' }
+      end,
+    }, {
+      num = '42',
+      scope = scope,
+    })
+
+    local buf = vim.api.nvim_get_current_buf()
+    vim.wait(100, function()
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      return #lines == 2 and lines[2] == 'test'
+    end)
+
+    vim.fn.maparg('<tab>', 'n', false, true).callback()
+    vim.wait(100, function()
+      local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+      return #lines == 1 and lines[1] == 'lint'
+    end)
+
+    assert.equals('Filter jobs: ', prompts[1].prompt)
+    assert.equals('', prompts[1].default)
   end)
 
   it('trims trailing padding from rendered check rows before writing the buffer', function()


### PR DESCRIPTION
## Problem

Interactive CI and checks pickers already support fuzzy row search, but the deterministic PR checks and run-summary buffers had no built-in way to narrow long job lists by name.

## Solution

Add a shared job-name filter prompt on the deterministic checks and CI summary buffers, wire it through the log key group, and keep filtered job actions working after refreshes. Update config validation, docs, and buffer specs to cover the new filter path.

Closes #495.