### PR TITLE
fix(compose): leave issue create at default cursor state

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -630,9 +630,6 @@ function M.open_issue(f, result, ref)
       submit_issue(f, issue_title, issue_body, template_labels, buf, ref, submission_data.metadata)
     end,
   })
-
-  vim.api.nvim_win_set_cursor(0, { 1, 2 })
-  vim.cmd.startinsert({ bang = true })
 end
 
 function M.open_issue_edit(f, num, details, ref)

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -136,7 +136,7 @@ describe('compose issue create', function()
     vim.cmd('enew!')
   end)
 
-  it('places the cursor on the title and enters insert mode for issue create', function()
+  it('leaves issue create buffers at the default cursor and mode state', function()
     local compose = require('forge.compose')
     local old_set_cursor = vim.api.nvim_win_set_cursor
     local old_startinsert = vim.cmd.startinsert
@@ -167,8 +167,9 @@ describe('compose issue create', function()
       error(err)
     end
 
-    assert.same({ { win = 0, pos = { 1, 2 } } }, cursor_calls)
-    assert.same({ { bang = true } }, startinsert_calls)
+    assert.same({}, cursor_calls)
+    assert.same({}, startinsert_calls)
+    assert.same({ 1, 0 }, vim.api.nvim_win_get_cursor(0))
   end)
 
   it('submits issues with an empty body', function()


### PR DESCRIPTION
## Problem

Issue creation forces the compose cursor to column 2 and immediately enters insert mode instead of opening at the buffer's default line 1, column 0 position.

## Solution

Remove the issue-create-only cursor and insert-mode override, and update the compose spec to assert the default cursor state.