### PR TITLE
refactor(target): share forge URL parsing helpers

### DIFF
--- a/lua/forge/scope.lua
+++ b/lua/forge/scope.lua
@@ -1,33 +1,5 @@
 local M = {}
-
-local function normalize_url(url)
-  if type(url) ~= 'string' then
-    return nil
-  end
-  local normalized = vim.trim(url)
-  if normalized == '' then
-    return nil
-  end
-  normalized = normalized:gsub('%.git$', '')
-  normalized = normalized:gsub('^ssh://git@', 'https://')
-  normalized = normalized:gsub('^git@([^:]+):', 'https://%1/')
-  normalized = normalized:gsub('/+$', '')
-  normalized = normalized:gsub('#.*$', '')
-  normalized = normalized:gsub('%?.*$', '')
-  return normalized
-end
-
-local function split_url(url)
-  local normalized = normalize_url(url)
-  if not normalized then
-    return nil
-  end
-  local host, path = normalized:match('^https?://([^/]+)/(.+)$')
-  if not host or not path then
-    return nil
-  end
-  return host, path
-end
+local url_mod = require('forge.url')
 
 local SUBJECT_PATHS = {
   github = {
@@ -53,7 +25,7 @@ local BRANCH_PATHS = {
 ---@param url string
 ---@return forge.Scope?
 local function github_scope(url)
-  local host, path = split_url(url)
+  local host, path = url_mod.split(url)
   if not host or not path then
     return nil
   end
@@ -77,12 +49,11 @@ end
 ---@param url string
 ---@return forge.Scope?
 local function gitlab_scope(url)
-  local host, path = split_url(url)
+  local host, path = url_mod.split(url)
   if not host or not path then
     return nil
   end
-  local slug = path:match('^(.-)/%-/') or path
-  slug = slug and slug:gsub('/+$', '') or nil
+  local slug = path
   if not slug or slug == '' then
     return nil
   end
@@ -105,7 +76,7 @@ end
 ---@param url string
 ---@return forge.Scope?
 local function codeberg_scope(url)
-  local host, path = split_url(url)
+  local host, path = url_mod.split(url)
   if not host or not path then
     return nil
   end

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -1,4 +1,5 @@
 local M = {}
+local url_mod = require('forge.url')
 
 local default_hosts = {
   github = 'github.com',
@@ -17,42 +18,6 @@ local function trim(text)
     return nil
   end
   return value
-end
-
----@param url any
----@return string?
-local function normalize_url(url)
-  local value = trim(url)
-  if not value then
-    return nil
-  end
-  local normalized = tostring(value)
-  normalized = normalized:gsub('%.git$', '')
-  normalized = normalized:gsub('^ssh://git@', 'https://')
-  normalized = normalized:gsub('^git@([^:]+):', 'https://%1/')
-  normalized = normalized:gsub('/+$', '')
-  normalized = normalized:gsub('#.*$', '')
-  normalized = normalized:gsub('%?.*$', '')
-  return normalized
-end
-
----@param url any
----@return string?, string?
-local function split_url(url)
-  local normalized = normalize_url(url)
-  if not normalized then
-    return nil
-  end
-  local host, path = normalized:match('^https?://([^/]+)/(.+)$')
-  if not host or not path then
-    return nil
-  end
-  path = path:match('^(.-)/%-/') or path
-  path = path:gsub('/+$', '')
-  if path == '' then
-    return nil
-  end
-  return host, path
 end
 
 ---@param opts table?
@@ -282,7 +247,7 @@ function M.parse_repo(text)
   if value:match('^[^/]+%.[^/]+/.+$') then
     hosted = 'https://' .. value
   end
-  local host, slug = split_url(hosted)
+  local host, slug = url_mod.split(hosted)
   if host and slug then
     return {
       kind = 'repo',
@@ -351,7 +316,7 @@ function M.resolve_repo(text, opts)
 
   local remote = remote_url(value, cwd)
   if remote then
-    local host, slug = split_url(remote)
+    local host, slug = url_mod.split(remote)
     if not host or not slug then
       return nil, 'invalid remote address: ' .. value
     end

--- a/lua/forge/url.lua
+++ b/lua/forge/url.lua
@@ -1,0 +1,52 @@
+local M = {}
+
+---@param text any
+---@return string?
+local function trim(text)
+  if type(text) ~= 'string' then
+    return nil
+  end
+  local value = vim.trim(text)
+  if value == '' then
+    return nil
+  end
+  return value
+end
+
+---@param url any
+---@return string?
+function M.normalize(url)
+  local value = trim(url)
+  if not value then
+    return nil
+  end
+  local normalized = tostring(value)
+  normalized = normalized:gsub('%.git$', '')
+  normalized = normalized:gsub('^ssh://git@', 'https://')
+  normalized = normalized:gsub('^git@([^:]+):', 'https://%1/')
+  normalized = normalized:gsub('/+$', '')
+  normalized = normalized:gsub('#.*$', '')
+  normalized = normalized:gsub('%?.*$', '')
+  return normalized
+end
+
+---@param url any
+---@return string?, string?
+function M.split(url)
+  local normalized = M.normalize(url)
+  if not normalized then
+    return nil
+  end
+  local host, path = normalized:match('^https?://([^/]+)/(.+)$')
+  if not host or not path then
+    return nil
+  end
+  path = path:match('^(.-)/%-/') or path
+  path = path:gsub('/+$', '')
+  if path == '' then
+    return nil
+  end
+  return host, path
+end
+
+return M

--- a/spec/url_spec.lua
+++ b/spec/url_spec.lua
@@ -1,0 +1,39 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('url helpers', function()
+  it('normalizes forge remote URLs into https repo URLs', function()
+    local url = require('forge.url')
+
+    assert.equals('https://github.com/owner/repo', url.normalize('git@github.com:owner/repo.git'))
+    assert.equals(
+      'https://gitlab.com/group/project',
+      url.normalize('  ssh://git@gitlab.com/group/project.git  ')
+    )
+    assert.equals(
+      'https://gitlab.com/group/project',
+      url.normalize('https://gitlab.com/group/project?foo=1#frag')
+    )
+  end)
+
+  it('splits normalized forge URLs into host and path', function()
+    local url = require('forge.url')
+
+    assert.same({ 'codeberg.org', 'owner/repo' }, { url.split('git@codeberg.org:owner/repo.git') })
+  end)
+
+  it('drops gitlab subject suffixes when splitting forge URLs', function()
+    local url = require('forge.url')
+
+    assert.same(
+      { 'gitlab.com', 'group/subgroup/project' },
+      { url.split('https://gitlab.com/group/subgroup/project/-/merge_requests/42') }
+    )
+  end)
+
+  it('returns nil for unsupported or empty URLs', function()
+    local url = require('forge.url')
+
+    assert.is_nil(url.normalize('   '))
+    assert.is_nil(url.split('owner/repo'))
+  end)
+end)


### PR DESCRIPTION
## Problem

`scope` and `target` each carried their own copies of the same forge URL normalization and splitting logic.

## Solution

Move the shared URL parsing into `forge.url`, update both call sites to use it, and add focused specs for the shared helper.