### PR TITLE
refactor(picker): share picker entry value helper

### DIFF
--- a/lua/forge/availability.lua
+++ b/lua/forge/availability.lua
@@ -1,18 +1,9 @@
 local M = {}
+local picker_entry = require('forge.picker.entry')
 local surface_policy = require('forge.surface_policy')
 
-local function entry_value(entry)
-  if type(entry) ~= 'table' or type(entry.value) ~= 'table' then
-    return nil
-  end
-  if entry.placeholder or entry.load_more then
-    return nil
-  end
-  return entry.value
-end
-
 local function pr_state(f, entry)
-  local value = entry_value(entry)
+  local value = picker_entry.value(entry)
   if not value then
     return nil
   end
@@ -52,7 +43,7 @@ function M.pr_merge_methods(f, entry)
   if state and state.is_draft then
     return {}
   end
-  local value = entry_value(entry)
+  local value = picker_entry.value(entry)
   local info = require('forge').repo_info(f, value and value.scope or nil)
   if not merge_permission(info) or type((info or {}).merge_methods) ~= 'table' then
     return {}

--- a/lua/forge/picker/entry.lua
+++ b/lua/forge/picker/entry.lua
@@ -1,0 +1,16 @@
+local M = {}
+
+---@param entry forge.PickerEntry?
+---@return table?
+function M.value(entry)
+  if type(entry) ~= 'table' or rawget(entry, 'placeholder') or rawget(entry, 'load_more') then
+    return nil
+  end
+  local value = rawget(entry, 'value')
+  if type(value) ~= 'table' then
+    return nil
+  end
+  return value
+end
+
+return M

--- a/lua/forge/surface_policy.lua
+++ b/lua/forge/surface_policy.lua
@@ -1,16 +1,7 @@
 local ci = require('forge.ci')
+local picker_entry = require('forge.picker.entry')
 
 local M = {}
-
-local function entry_value(entry)
-  if not entry or rawget(entry, 'placeholder') or rawget(entry, 'load_more') then
-    return nil
-  end
-  if type(entry.value) ~= 'table' then
-    return nil
-  end
-  return entry.value
-end
 
 function M.selected(entry)
   if entry and rawget(entry, 'placeholder') then
@@ -77,7 +68,7 @@ function M.has_dynamic_label(def)
 end
 
 function M.issue_toggle_verb(entry)
-  local value = entry_value(entry)
+  local value = picker_entry.value(entry)
   if not value then
     return nil
   end
@@ -92,7 +83,7 @@ function M.issue_toggle_verb(entry)
 end
 
 function M.pr_toggle_verb(entry)
-  local value = entry_value(entry)
+  local value = picker_entry.value(entry)
   if not value then
     return nil
   end
@@ -107,7 +98,7 @@ function M.pr_toggle_verb(entry)
 end
 
 function M.ci_toggle_verb(entry)
-  local value = entry_value(entry)
+  local value = picker_entry.value(entry)
   if not value then
     return nil
   end

--- a/spec/picker_entry_spec.lua
+++ b/spec/picker_entry_spec.lua
@@ -1,0 +1,38 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('forge.picker.entry.value', function()
+  local picker_entry
+
+  before_each(function()
+    package.loaded['forge.picker.entry'] = nil
+    picker_entry = require('forge.picker.entry')
+  end)
+
+  it('returns a table value for actionable entries', function()
+    local value = { num = '1', state = 'OPEN' }
+
+    assert.same(value, picker_entry.value({ value = value }))
+  end)
+
+  it('returns nil for placeholder and load-more rows', function()
+    assert.is_nil(picker_entry.value({ placeholder = true, value = { state = 'OPEN' } }))
+    assert.is_nil(picker_entry.value({ load_more = true, value = { state = 'OPEN' } }))
+  end)
+
+  it('returns nil when the entry or value is not a table', function()
+    assert.is_nil(picker_entry.value(nil))
+    assert.is_nil(picker_entry.value({ value = 'not-a-table' }))
+  end)
+
+  it('uses rawget so metatable-backed picker flags do not masquerade as row flags', function()
+    local entry = setmetatable({ value = { state = 'OPEN' } }, {
+      __index = function(_, key)
+        if key == 'placeholder' then
+          return true
+        end
+      end,
+    })
+
+    assert.same({ state = 'OPEN' }, picker_entry.value(entry))
+  end)
+end)


### PR DESCRIPTION
## Problem

Picker-facing modules duplicated the same entry-value extraction and row filtering logic in more than one place.

## Solution

Extract a shared picker entry helper, switch the existing callers to it, and add a focused spec for the helper itself.