### PR TITLE
refactor(surface): share toggle state helper

### DIFF
--- a/lua/forge/surface_policy.lua
+++ b/lua/forge/surface_policy.lua
@@ -3,6 +3,8 @@ local picker_entry = require('forge.picker.entry')
 
 local M = {}
 
+---@param entry forge.PickerEntry?
+---@return forge.PickerEntry?
 function M.selected(entry)
   if entry and rawget(entry, 'placeholder') then
     return nil
@@ -10,6 +12,8 @@ function M.selected(entry)
   return entry
 end
 
+---@param entry forge.PickerEntry?
+---@return forge.PickerRowKind
 function M.row_kind(entry)
   if entry == nil then
     return 'none'
@@ -21,6 +25,23 @@ function M.row_kind(entry)
     return rawget(entry, 'placeholder_kind') == 'error' and 'error' or 'empty'
   end
   return 'entity'
+end
+
+---@param entry forge.PickerEntry?
+---@return 'close'|'reopen'?
+local function toggle_verb_for_state(entry)
+  local value = picker_entry.value(entry)
+  if not value then
+    return nil
+  end
+  local state = (value.state or ''):lower()
+  if state == 'open' or state == 'opened' then
+    return 'close'
+  end
+  if state == 'closed' then
+    return 'reopen'
+  end
+  return nil
 end
 
 function M.closes(def, entry)
@@ -67,36 +88,20 @@ function M.has_dynamic_label(def)
   return type(rawget(def, 'label')) == 'function' or type(rawget(def, 'available')) == 'function'
 end
 
+---@param entry forge.PickerEntry?
+---@return forge.ToggleVerb?
 function M.issue_toggle_verb(entry)
-  local value = picker_entry.value(entry)
-  if not value then
-    return nil
-  end
-  local state = (value.state or ''):lower()
-  if state == 'open' or state == 'opened' then
-    return 'close'
-  end
-  if state == 'closed' then
-    return 'reopen'
-  end
-  return nil
+  return toggle_verb_for_state(entry)
 end
 
+---@param entry forge.PickerEntry?
+---@return forge.ToggleVerb?
 function M.pr_toggle_verb(entry)
-  local value = picker_entry.value(entry)
-  if not value then
-    return nil
-  end
-  local state = (value.state or ''):lower()
-  if state == 'open' or state == 'opened' then
-    return 'close'
-  end
-  if state == 'closed' then
-    return 'reopen'
-  end
-  return nil
+  return toggle_verb_for_state(entry)
 end
 
+---@param entry forge.PickerEntry?
+---@return forge.ToggleVerb?
 function M.ci_toggle_verb(entry)
   local value = picker_entry.value(entry)
   if not value then

--- a/lua/forge/types.lua
+++ b/lua/forge/types.lua
@@ -128,6 +128,8 @@
 ---@alias forge.PRLookupPass forge.PRLookupState[]
 ---@alias forge.RepoLike forge.Scope|forge.RepoTarget|string
 ---@alias forge.HeadLike forge.HeadInput|forge.HeadRef|forge.RevTarget|string
+---@alias forge.PickerRowKind 'none'|'load_more'|'error'|'empty'|'entity'
+---@alias forge.ToggleVerb 'close'|'reopen'|'cancel'|'rerun'
 
 ---@class forge.BranchPRPolicy
 ---@field searches forge.PRLookupPass[]


### PR DESCRIPTION
## Problem

Surface policy kept identical PR and issue toggle-by-state logic inline, and the shared picker/cmdline state layer had no narrow type aliases for row kinds or toggle verbs.

## Solution

Extract the shared close/reopen state helper in surface policy and add small LuaCATS aliases for picker row kinds and toggle verbs.