### PR TITLE
refactor(cmd): share list membership helpers

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -1,4 +1,5 @@
 local M = {}
+local collections = require('forge.collections')
 
 local detect = require('forge.detect')
 local ops = require('forge.ops')
@@ -241,19 +242,6 @@ local function token_is_modifier_like(token)
     return false
   end
   return token:find('=', 1, true) ~= nil
-end
-
-local function list_contains(items, value)
-  for _, item in ipairs(items) do
-    if item == value then
-      return true
-    end
-  end
-  return false
-end
-
-local function set_contains(items, value)
-  return type(items) == 'table' and list_contains(items, value)
 end
 
 local function subject_error(family, verb, missing)
@@ -1037,7 +1025,7 @@ function M.parse(args, opts)
     local allowed_values = spec and spec.values or nil
     local verb_values = command.modifier_values and command.modifier_values[name] or nil
     local values = verb_values or allowed_values
-    if type(value) == 'string' and values and not set_contains(values, value) then
+    if type(value) == 'string' and values and not collections.set_contains(values, value) then
       return error_result(('invalid value for %s: %s'):format(name, value))
     end
   end
@@ -1119,7 +1107,7 @@ local function completion_state(command, args)
       name = token:sub(1, eq - 1)
       value = token:sub(eq + 1)
     end
-    if name and list_contains(command.declared_modifiers or {}, name) then
+    if name and collections.list_contains(command.declared_modifiers or {}, name) then
       if state.modifiers[name] == nil then
         state.modifiers[name] = value
       end

--- a/lua/forge/collections.lua
+++ b/lua/forge/collections.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+---@param items any[]?
+---@param value any
+---@return boolean
+function M.list_contains(items, value)
+  for _, item in ipairs(items or {}) do
+    if item == value then
+      return true
+    end
+  end
+  return false
+end
+
+---@param items any[]?
+---@param value any
+---@return boolean
+function M.set_contains(items, value)
+  return type(items) == 'table' and M.list_contains(items, value)
+end
+
+return M

--- a/lua/forge/completion_policy.lua
+++ b/lua/forge/completion_policy.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local availability = require('forge.availability')
+local collections = require('forge.collections')
 local surface_policy = require('forge.surface_policy')
 
 local implicit_pr_completion_verbs = {
@@ -44,20 +45,11 @@ local function issue_completion_available(verb, _, entry)
   return true
 end
 
-local function list_contains(items, value)
-  for _, item in ipairs(items or {}) do
-    if item == value then
-      return true
-    end
-  end
-  return false
-end
-
 local function declares_modifier(command, flag_name)
   if type(command) ~= 'table' then
     return false
   end
-  return list_contains(command.declared_modifiers or command.modifiers, flag_name)
+  return collections.list_contains(command.declared_modifiers or command.modifiers, flag_name)
 end
 
 function M.family_slot(command)

--- a/spec/collections_spec.lua
+++ b/spec/collections_spec.lua
@@ -1,0 +1,25 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+describe('collections helpers', function()
+  local collections
+
+  before_each(function()
+    package.loaded['forge.collections'] = nil
+    collections = require('forge.collections')
+  end)
+
+  it('finds values in sequential lists', function()
+    assert.is_true(collections.list_contains({ 'repo', 'head', 'base' }, 'head'))
+    assert.is_false(collections.list_contains({ 'repo', 'head', 'base' }, 'branch'))
+  end)
+
+  it('treats nil lists as empty for list membership checks', function()
+    assert.is_false(collections.list_contains(nil, 'repo'))
+  end)
+
+  it('only treats tables as sets for set membership checks', function()
+    assert.is_true(collections.set_contains({ 'open', 'closed' }, 'closed'))
+    assert.is_false(collections.set_contains(nil, 'closed'))
+    assert.is_false(collections.set_contains('open,closed', 'closed'))
+  end)
+end)


### PR DESCRIPTION
## Problem

Command parsing and completion policy each carried their own list-membership helpers even though they perform the same checks.

## Solution

Extract the shared membership helpers into a small collections module, update both callers, and add focused specs for the shared helper.