### PR TITLE
refactor(init): isolate forge detection state

### DIFF
--- a/lua/forge/detect.lua
+++ b/lua/forge/detect.lua
@@ -1,5 +1,210 @@
 local M = {}
 
+local config_mod = require('forge.config')
+
+---@type table<string, forge.Forge>
+local registered_sources = {}
+
+---@type table<string, { name: string, source: forge.Forge }>
+local forge_cache = {}
+
+---@type table<string, string>
+local root_cache = {}
+
+local builtin_hosts = {
+  github = { 'github' },
+  gitlab = { 'gitlab' },
+  codeberg = { 'codeberg', 'gitea', 'forgejo' },
+}
+
+---@param cmd string
+---@return string?
+local function fn_system_text(cmd)
+  local text = vim.trim(vim.fn.system(cmd))
+  if vim.v.shell_error ~= 0 and (text == '' or text:match('^fatal:') or text:match('^error:')) then
+    return nil
+  end
+  if text == '' then
+    return nil
+  end
+  return text
+end
+
+---@param cmd string[]
+---@return string?
+local function system_text(cmd)
+  local result = vim.system(cmd, { text = true }):wait()
+  if result.code ~= 0 then
+    return nil
+  end
+  local text = vim.trim(result.stdout or '')
+  if text == '' then
+    return nil
+  end
+  return text
+end
+
+---@param name string
+---@param source forge.Forge
+function M.register(name, source)
+  registered_sources[name] = source
+end
+
+---@return table<string, forge.Forge>
+function M.registered_sources()
+  return registered_sources
+end
+
+---@param name string
+---@return forge.Forge?
+local function resolve_source(name)
+  if registered_sources[name] then
+    return registered_sources[name]
+  end
+  local ok, mod = pcall(require, 'forge.backends.' .. name)
+  if ok then
+    return mod
+  end
+  return nil
+end
+
+---@param root string
+---@return forge.Forge?
+local function cached_source(root)
+  local cached = forge_cache[root]
+  if type(cached) ~= 'table' or type(cached.name) ~= 'string' or type(cached.source) ~= 'table' then
+    return nil
+  end
+  local registered = registered_sources[cached.name]
+  if registered then
+    if registered == cached.source then
+      return cached.source
+    end
+    forge_cache[root] = nil
+    return nil
+  end
+  if package.loaded['forge.backends.' .. cached.name] == cached.source then
+    return cached.source
+  end
+  forge_cache[root] = nil
+  return nil
+end
+
+---@param remote string
+---@return string? forge_name
+local function detect_from_remote(remote)
+  local cfg = config_mod.config().sources
+
+  for name, opts in pairs(cfg) do
+    for _, host in ipairs(opts.hosts or {}) do
+      if remote:find(host, 1, true) then
+        return name
+      end
+    end
+  end
+
+  for name, patterns in pairs(builtin_hosts) do
+    for _, pattern in ipairs(patterns) do
+      if remote:find(pattern, 1, true) then
+        return name
+      end
+    end
+  end
+
+  return nil
+end
+
+---@return string?
+function M.git_root()
+  local cwd = vim.fn.getcwd()
+  if root_cache[cwd] then
+    return root_cache[cwd]
+  end
+  local root = fn_system_text('git rev-parse --show-toplevel')
+  if not root then
+    return nil
+  end
+  root_cache[cwd] = root
+  return root
+end
+
+---@param root string
+---@return forge.Forge?
+function M.detect_at_root(root)
+  local log = require('forge.logger')
+  local cached = cached_source(root)
+  if cached then
+    return cached
+  end
+  local remote = system_text({ 'git', '-C', root, 'remote', 'get-url', 'origin' })
+  if not remote then
+    log.debug('detect: no origin remote')
+    return nil
+  end
+  local name = detect_from_remote(remote)
+  if not name then
+    log.debug('detect: no forge matched remote ' .. remote)
+    return nil
+  end
+  local source = resolve_source(name)
+  if not source then
+    log.debug('detect: failed to load source module ' .. name)
+    return nil
+  end
+  if vim.fn.executable(source.cli) ~= 1 then
+    log.debug('detect: CLI ' .. source.cli .. ' not found')
+    return nil
+  end
+  forge_cache[root] = {
+    name = name,
+    source = source,
+  }
+  return source
+end
+
+---@return forge.Forge?
+function M.detect()
+  local log = require('forge.logger')
+  local root = M.git_root()
+  if not root then
+    log.debug('detect: not a git repository')
+    return nil
+  end
+  local cached = cached_source(root)
+  if cached then
+    return cached
+  end
+  local remote = fn_system_text('git remote get-url origin')
+  if not remote then
+    log.debug('detect: no origin remote')
+    return nil
+  end
+  local name = detect_from_remote(remote)
+  if not name then
+    log.debug('detect: no forge matched remote ' .. remote)
+    return nil
+  end
+  local source = resolve_source(name)
+  if not source then
+    log.debug('detect: failed to load source module ' .. name)
+    return nil
+  end
+  if vim.fn.executable(source.cli) ~= 1 then
+    log.debug('detect: CLI ' .. source.cli .. ' not found')
+    return nil
+  end
+  forge_cache[root] = {
+    name = name,
+    source = source,
+  }
+  return source
+end
+
+function M.clear_cache()
+  forge_cache = {}
+  root_cache = {}
+end
+
 function M.forge_name()
   local ok, forge = pcall(require, 'forge')
   if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -5,6 +5,7 @@ local cache_mod = require('forge.cache')
 local compose_mod = require('forge.compose')
 local config_mod = require('forge.config')
 local context_mod = require('forge.context')
+local detect_mod = require('forge.detect')
 local format_mod = require('forge.format')
 local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
@@ -13,35 +14,18 @@ local system_mod = require('forge.system')
 local target_mod = require('forge.target')
 local template_mod = require('forge.template')
 
----@type table<string, forge.Forge>
-local sources = {}
-
----@param name string
----@param source forge.Forge
-function M.register(name, source)
-  sources[name] = source
-end
-
+M.register = detect_mod.register
 M.register_source = M.register
 M.register_context_provider = context_mod.register
 M.register_action = action_mod.register
 M.register_review_adapter = review_mod.register
 M.run_action = action_mod.run
-
----@return table<string, forge.Forge>
-function M.registered_sources()
-  return sources
-end
+M.registered_sources = detect_mod.registered_sources
+M.detect = detect_mod.detect
 
 function M.review_adapter_names()
   return review_mod.names()
 end
-
----@type table<string, forge.Forge>
-local forge_cache = {}
-
----@type table<string, string>
-local root_cache = {}
 
 local repo_info_cache = cache_mod.new(30 * 60)
 local pr_state_cache = cache_mod.new(60)
@@ -66,33 +50,7 @@ local function fn_system_text(cmd)
   return text
 end
 
----@param cmd string[]
----@return string?
-local function system_text(cmd)
-  local result = vim.system(cmd, { text = true }):wait()
-  if result.code ~= 0 then
-    return nil
-  end
-  local text = vim.trim(result.stdout or '')
-  if text == '' then
-    return nil
-  end
-  return text
-end
-
----@return string?
-local function git_root()
-  local cwd = vim.fn.getcwd()
-  if root_cache[cwd] then
-    return root_cache[cwd]
-  end
-  local root = fn_system_text('git rev-parse --show-toplevel')
-  if not root then
-    return nil
-  end
-  root_cache[cwd] = root
-  return root
-end
+local git_root = detect_mod.git_root
 
 ---@param num string
 ---@param scope? forge.Scope
@@ -152,78 +110,6 @@ local function open_web_create(label, cmd, url)
     return
   end
   log.info(success_msg)
-end
-
-local builtin_hosts = {
-  github = { 'github' },
-  gitlab = { 'gitlab' },
-  codeberg = { 'codeberg', 'gitea', 'forgejo' },
-}
-
-local function resolve_source(name)
-  if sources[name] then
-    return sources[name]
-  end
-  local ok, mod = pcall(require, 'forge.backends.' .. name)
-  if ok then
-    sources[name] = mod
-    return mod
-  end
-  return nil
-end
-
----@param remote string
----@return string? forge_name
-local function detect_from_remote(remote)
-  local cfg = M.config().sources
-
-  for name, opts in pairs(cfg) do
-    for _, host in ipairs(opts.hosts or {}) do
-      if remote:find(host, 1, true) then
-        return name
-      end
-    end
-  end
-
-  for name, patterns in pairs(builtin_hosts) do
-    for _, pattern in ipairs(patterns) do
-      if remote:find(pattern, 1, true) then
-        return name
-      end
-    end
-  end
-
-  return nil
-end
-
----@param root string
----@return forge.Forge?
-local function detect_at_root(root)
-  local log = require('forge.logger')
-  if forge_cache[root] then
-    return forge_cache[root]
-  end
-  local remote = system_text({ 'git', '-C', root, 'remote', 'get-url', 'origin' })
-  if not remote then
-    log.debug('detect: no origin remote')
-    return nil
-  end
-  local name = detect_from_remote(remote)
-  if not name then
-    log.debug('detect: no forge matched remote ' .. remote)
-    return nil
-  end
-  local source = resolve_source(name)
-  if not source then
-    log.debug('detect: failed to load source module ' .. name)
-    return nil
-  end
-  if vim.fn.executable(source.cli) ~= 1 then
-    log.debug('detect: CLI ' .. source.cli .. ' not found')
-    return nil
-  end
-  forge_cache[root] = source
-  return source
 end
 
 local function emit_status_update()
@@ -289,7 +175,7 @@ local function refresh_status(root)
     if not current or current.request_id ~= request_id then
       return
     end
-    local forge = detect_at_root(root)
+    local forge = detect_mod.detect_at_root(root)
     if not forge then
       local branch = target_mod.current_branch({ cwd = root })
       if branch then
@@ -332,40 +218,6 @@ local function refresh_status(root)
       set_status_value(root, request_id, status)
     end)
   end)
-end
-
----@return forge.Forge?
-function M.detect()
-  local log = require('forge.logger')
-  local root = git_root()
-  if not root then
-    log.debug('detect: not a git repository')
-    return nil
-  end
-  if forge_cache[root] then
-    return forge_cache[root]
-  end
-  local remote = fn_system_text('git remote get-url origin')
-  if not remote then
-    log.debug('detect: no origin remote')
-    return nil
-  end
-  local name = detect_from_remote(remote)
-  if not name then
-    log.debug('detect: no forge matched remote ' .. remote)
-    return nil
-  end
-  local source = resolve_source(name)
-  if not source then
-    log.debug('detect: failed to load source module ' .. name)
-    return nil
-  end
-  if vim.fn.executable(source.cli) ~= 1 then
-    log.debug('detect: CLI ' .. source.cli .. ' not found')
-    return nil
-  end
-  forge_cache[root] = source
-  return source
 end
 
 ---@param f forge.Forge
@@ -478,10 +330,9 @@ function M.clear_list_kind(kind)
 end
 
 function M.clear_cache()
-  forge_cache = {}
+  detect_mod.clear_cache()
   repo_info_cache.clear()
   pr_state_cache.clear()
-  root_cache = {}
   list_cache.clear()
   clear_status_cache()
 end

--- a/spec/detect_spec.lua
+++ b/spec/detect_spec.lua
@@ -1,0 +1,85 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+describe('detect', function()
+  local detect = require('forge.detect')
+  local old_executable
+  local old_fn_system
+  local old_system
+
+  before_each(function()
+    old_executable = vim.fn.executable
+    old_fn_system = vim.fn.system
+    old_system = vim.system
+  end)
+
+  after_each(function()
+    vim.fn.executable = old_executable
+    vim.fn.system = old_fn_system
+    vim.system = old_system
+    detect.clear_cache()
+  end)
+
+  it('detects and caches the current forge', function()
+    local calls = {}
+    vim.fn.executable = function(bin)
+      if bin == 'gh' then
+        return 1
+      end
+      return old_executable(bin)
+    end
+    vim.fn.system = function(cmd)
+      calls[#calls + 1] = cmd
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      if cmd == 'git remote get-url origin' then
+        return 'git@github.com:owner/current.git\n'
+      end
+      return ''
+    end
+    vim.system = helpers.system_router({
+      calls = calls,
+      default = helpers.command_result('', 1),
+    })
+
+    local first = detect.detect()
+    local second = detect.detect()
+
+    assert.equals('github', first and first.name)
+    assert.same(first, second)
+    assert.same({
+      'git rev-parse --show-toplevel',
+      'git remote get-url origin',
+    }, calls)
+  end)
+
+  it('detects a forge at an explicit root', function()
+    vim.fn.executable = function(bin)
+      if bin == 'gh' then
+        return 1
+      end
+      return old_executable(bin)
+    end
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      return ''
+    end
+    vim.system = helpers.system_router({
+      responses = {
+        ['git -C /repo remote get-url origin'] = helpers.command_result(
+          'git@github.com:owner/current.git\n'
+        ),
+      },
+      default = helpers.command_result('', 1),
+    })
+
+    local forge = detect.detect_at_root('/repo')
+
+    assert.equals('github', forge and forge.name)
+    assert.equals('github', detect.forge_name())
+  end)
+end)


### PR DESCRIPTION
## Problem

`lua/forge/init.lua` was still carrying source registration, git-root lookup, backend detection, and detection cache state alongside unrelated public API and workflow code.

## Solution

Move forge detection into `lua/forge/detect.lua`, let `init.lua` delegate to that module, and add direct detection coverage in `spec/detect_spec.lua`.