### PR TITLE
refactor(detect): route internal callers through forge.detect

### DIFF
--- a/lua/forge/context.lua
+++ b/lua/forge/context.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local detect_mod = require('forge.detect')
+
 local providers = {}
 
 local function git_output(cmd)
@@ -42,7 +44,7 @@ providers.current = function()
     root = root,
     branch = git_output({ 'git', 'branch', '--show-current' }) or '',
     head = git_output({ 'git', 'rev-parse', 'HEAD' }) or '',
-    forge = forge_mod.detect(),
+    forge = detect_mod.detect(),
     has_file = has_file,
     loc = has_file and forge_mod.file_loc() or nil,
   }

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local ci = require('forge.ci')
+local detect_mod = require('forge.detect')
 local log = require('forge.logger')
 local system_mod = require('forge.system')
 
@@ -87,7 +88,7 @@ local function detect_or_warn(f)
   if f then
     return f
   end
-  f = require('forge').detect()
+  f = detect_mod.detect()
   if not f then
     log.warn('no forge detected')
     return nil

--- a/lua/forge/resolve.lua
+++ b/lua/forge/resolve.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local detect_mod = require('forge.detect')
 local scope_mod = require('forge.scope')
 local system_mod = require('forge.system')
 local target_mod = require('forge.target')
@@ -57,11 +58,7 @@ local function current_forge(opts)
   if type(opts) == 'table' and type(opts.forge) == 'table' then
     return opts.forge
   end
-  local ok, forge = pcall(require, 'forge')
-  if not ok or type(forge) ~= 'table' or type(forge.detect) ~= 'function' then
-    return nil
-  end
-  return forge.detect()
+  return detect_mod.detect()
 end
 
 ---@param value any

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -35,16 +35,21 @@ describe('context', function()
     end
 
     old_preload = {
+      ['forge.detect'] = package.preload['forge.detect'],
       ['forge'] = package.preload['forge'],
     }
 
+    package.preload['forge.detect'] = function()
+      return {
+        detect = function()
+          return { name = 'github' }
+        end,
+      }
+    end
     package.preload['forge'] = function()
       return {
         config = function()
           return current_config
-        end,
-        detect = function()
-          return { name = 'github' }
         end,
         file_loc = function()
           return 'lua/forge/init.lua:10'
@@ -52,13 +57,16 @@ describe('context', function()
       }
     end
 
+    package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
     package.loaded['forge.context'] = nil
   end)
 
   after_each(function()
     vim.system = old_system
+    package.preload['forge.detect'] = old_preload['forge.detect']
     package.preload['forge'] = old_preload['forge']
+    package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
     package.loaded['forge.context'] = nil
   end)

--- a/spec/ops_spec.lua
+++ b/spec/ops_spec.lua
@@ -26,6 +26,7 @@ describe('shared operations', function()
     old_ui_select = vim.ui.select
     old_ui_open = vim.ui.open
     old_preload = {
+      ['forge.detect'] = package.preload['forge.detect'],
       ['forge'] = package.preload['forge'],
       ['forge.log'] = package.preload['forge.log'],
       ['forge.logger'] = package.preload['forge.logger'],
@@ -168,7 +169,15 @@ describe('shared operations', function()
         open = function() end,
       }
     end
+    package.preload['forge.detect'] = function()
+      return {
+        detect = function()
+          return nil
+        end,
+      }
+    end
 
+    package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
     package.loaded['forge.log'] = nil
     package.loaded['forge.logger'] = nil
@@ -185,6 +194,8 @@ describe('shared operations', function()
     vim.ui.select = old_ui_select
     vim.ui.open = old_ui_open
 
+    package.loaded['forge.detect'] = nil
+    package.preload['forge.detect'] = old_preload['forge.detect']
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.log'] = old_preload['forge.log']
     package.preload['forge.logger'] = old_preload['forge.logger']

--- a/spec/resolve_spec.lua
+++ b/spec/resolve_spec.lua
@@ -4,10 +4,12 @@ local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
 
 local preload_modules = {
   'forge',
+  'forge.detect',
 }
 
 local loaded_modules = {
   'forge',
+  'forge.detect',
   'forge.resolve',
   'forge.scope',
   'forge.target',
@@ -60,6 +62,13 @@ describe('current_pr resolver', function()
           return {
             targets = {},
           }
+        end,
+      }
+    end
+    package.preload['forge.detect'] = function()
+      return {
+        detect = function()
+          return github
         end,
       }
     end

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -37,7 +37,6 @@ local function fake_forge(opts)
     end,
   }
 end
-
 local function fake_gitlab_forge()
   return fake_forge({
     name = 'gitlab',
@@ -113,6 +112,7 @@ describe('routes', function()
     end
 
     old_preload = {
+      ['forge.detect'] = package.preload['forge.detect'],
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
       ['forge.picker'] = package.preload['forge.picker'],
@@ -120,13 +120,21 @@ describe('routes', function()
       ['fzf-lua'] = package.preload['fzf-lua'],
     }
 
+    package.preload['forge.detect'] = function()
+      return {
+        detect = function()
+          return detected_forge
+        end,
+        forge_name = function()
+          return detected_forge and detected_forge.name or nil
+        end,
+      }
+    end
+
     package.preload['forge'] = function()
       return {
         config = function()
           return current_config
-        end,
-        detect = function()
-          return detected_forge
         end,
         file_loc = function()
           local name = vim.api.nvim_buf_get_name(0)
@@ -154,6 +162,7 @@ describe('routes', function()
       }
     end
 
+    package.loaded['forge.detect'] = nil
     package.preload['forge.picker'] = function()
       local picker = dofile(vim.fn.getcwd() .. '/lua/forge/picker/init.lua')
       return vim.tbl_extend('force', picker, {
@@ -204,12 +213,14 @@ describe('routes', function()
     vim.system = old_system
     vim.ui.open = old_ui_open
 
+    package.preload['forge.detect'] = old_preload['forge.detect']
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
     package.preload['forge.picker'] = old_preload['forge.picker']
     package.preload['forge.pickers'] = old_preload['forge.pickers']
     package.preload['fzf-lua'] = old_preload['fzf-lua']
 
+    package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.picker'] = nil


### PR DESCRIPTION
## Problem

Several internal modules were still reaching back through `require('forge').detect()` even after detection moved into `lua/forge/detect.lua`.

## Solution

Point the resolver, ops, and context modules at `forge.detect` directly and update the affected specs to stub that seam instead of the public facade.