### PR TITLE
refactor(state): extract cached repo and status state

### DIFF
--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -1,7 +1,6 @@
 local M = {}
 
 local action_mod = require('forge.action')
-local cache_mod = require('forge.cache')
 local compose_mod = require('forge.compose')
 local config_mod = require('forge.config')
 local context_mod = require('forge.context')
@@ -10,6 +9,7 @@ local format_mod = require('forge.format')
 local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
 local scope_mod = require('forge.scope')
+local state_mod = require('forge.state')
 local system_mod = require('forge.system')
 local target_mod = require('forge.target')
 local template_mod = require('forge.template')
@@ -27,16 +27,6 @@ function M.review_adapter_names()
   return review_mod.names()
 end
 
-local repo_info_cache = cache_mod.new(30 * 60)
-local pr_state_cache = cache_mod.new(60)
-local list_cache = cache_mod.new(2 * 60)
-local status_ttl = 30
-
----@type table<string, { value: forge.Status|false|nil, updated_at: integer?, inflight: boolean?, request_id: integer? }>
-local status_cache = {}
-
-local status_augroup
-
 ---@param cmd string
 ---@return string?
 local function fn_system_text(cmd)
@@ -51,14 +41,6 @@ local function fn_system_text(cmd)
 end
 
 local git_root = detect_mod.git_root
-
----@param num string
----@param scope? forge.Scope
----@return string?
-local function pr_state_key(num, scope)
-  local root = git_root()
-  return root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
-end
 
 local function push_target(branch, scope)
   if scope_mod.key(scope) ~= '' then
@@ -112,131 +94,11 @@ local function open_web_create(label, cmd, url)
   log.info(success_msg)
 end
 
-local function emit_status_update()
-  vim.api.nvim_exec_autocmds('User', {
-    pattern = 'ForgeStatusUpdate',
-    modeline = false,
-  })
-end
-
----@param root string?
-local function clear_status_cache(root)
-  if root then
-    status_cache[root] = nil
-    return
-  end
-  status_cache = {}
-end
-
-local function setup_status_autocmds()
-  if status_augroup then
-    return
-  end
-  status_augroup = vim.api.nvim_create_augroup('forge_status', { clear = true })
-  vim.api.nvim_create_autocmd({ 'DirChanged', 'FocusGained' }, {
-    group = status_augroup,
-    callback = function()
-      clear_status_cache()
-    end,
-  })
-end
-
----@param root string
----@param request_id integer
----@param value forge.Status?
-local function set_status_value(root, request_id, value)
-  local entry = status_cache[root]
-  if not entry or entry.request_id ~= request_id then
-    return
-  end
-  entry.inflight = false
-  entry.updated_at = os.time()
-  local previous = entry.value == false and nil or entry.value
-  local next_value = value
-  entry.value = value or false
-  if not vim.deep_equal(previous, next_value) then
-    emit_status_update()
-  end
-end
-
----@param root string
-local function refresh_status(root)
-  local entry = status_cache[root] or {}
-  if entry.inflight then
-    return
-  end
-  entry.inflight = true
-  entry.request_id = (entry.request_id or 0) + 1
-  status_cache[root] = entry
-  ---@type integer
-  local request_id = entry.request_id
-  vim.schedule(function()
-    local current = status_cache[root]
-    if not current or current.request_id ~= request_id then
-      return
-    end
-    local forge = detect_mod.detect_at_root(root)
-    if not forge then
-      local branch = target_mod.current_branch({ cwd = root })
-      if branch then
-        set_status_value(root, request_id, { branch = branch })
-      else
-        set_status_value(root, request_id, nil)
-      end
-      return
-    end
-    local head = resolve_mod.head(nil, {
-      forge = forge,
-      target_opts = {
-        cwd = root,
-      },
-    })
-    if not head then
-      local branch = target_mod.current_branch({ cwd = root })
-      if branch then
-        set_status_value(root, request_id, { branch = branch })
-      else
-        set_status_value(root, request_id, nil)
-      end
-      return
-    end
-    local status = {
-      branch = head.branch,
-    }
-    if head.scope then
-      status.scope = head.scope
-    end
-    resolve_mod.current_pr_async({
-      forge = forge,
-      head_branch = head.branch,
-      head_scope = head.scope,
-      target_opts = {
-        cwd = root,
-      },
-    }, function(pr)
-      status.pr = pr
-      set_status_value(root, request_id, status)
-    end)
-  end)
-end
-
 ---@param f forge.Forge
 ---@param scope? forge.Scope
 ---@return forge.RepoInfo
 function M.repo_info(f, scope)
-  local root = git_root()
-  local key = root and (root .. '|' .. scope_mod.key(scope)) or nil
-  if key then
-    local cached = repo_info_cache.get(key)
-    if cached ~= nil then
-      return cached
-    end
-  end
-  local info = f:repo_info(scope)
-  if key then
-    repo_info_cache.set(key, info)
-  end
-  return info
+  return state_mod.repo_info(f, scope)
 end
 
 ---@param f forge.Forge
@@ -244,18 +106,7 @@ end
 ---@param scope? forge.Scope
 ---@return forge.PRState
 function M.pr_state(f, num, scope)
-  local key = pr_state_key(num, scope)
-  if key then
-    local cached = pr_state_cache.get(key)
-    if cached ~= nil then
-      return cached
-    end
-  end
-  local state = f:pr_state(num, scope)
-  if key then
-    pr_state_cache.set(key, state)
-  end
-  return state
+  return state_mod.pr_state(f, num, scope)
 end
 
 ---@param num string
@@ -263,99 +114,52 @@ end
 ---@param scope? forge.Scope
 ---@return forge.PRState
 function M.set_pr_state(num, state, scope)
-  local key = pr_state_key(num, scope)
-  if key then
-    pr_state_cache.set(key, state)
-  end
-  return state
+  return state_mod.set_pr_state(num, state, scope)
 end
 
 ---@param num? string
 ---@param scope? forge.Scope
 function M.clear_pr_state(num, scope)
-  local root = git_root()
-  clear_status_cache(root)
-  if not root then
-    pr_state_cache.clear()
-    return
-  end
-  if num ~= nil then
-    local key = pr_state_key(num, scope)
-    if key then
-      pr_state_cache.clear(key)
-      return
-    end
-    pr_state_cache.clear()
-    return
-  end
-  if scope ~= nil then
-    pr_state_cache.clear_prefix(root .. '|' .. scope_mod.key(scope) .. '|')
-    return
-  end
-  pr_state_cache.clear()
+  state_mod.clear_pr_state(num, scope)
 end
 
 ---@param kind string
 ---@param state string
 ---@return string
 function M.list_key(kind, state)
-  local root = git_root() or ''
-  return root .. ':' .. kind .. ':' .. state
+  return state_mod.list_key(kind, state)
 end
 
 ---@param key string
 ---@return table[]?
 function M.get_list(key)
-  return list_cache.get(key)
+  return state_mod.get_list(key)
 end
 
 ---@param key string
 ---@param data table[]
 function M.set_list(key, data)
-  list_cache.set(key, data)
+  state_mod.set_list(key, data)
 end
 
 ---@param key string?
 function M.clear_list(key)
-  list_cache.clear(key)
-  local root = type(key) == 'string' and key:match('^(.-):') or git_root()
-  clear_status_cache(root)
+  state_mod.clear_list(key)
 end
 
 ---@param kind string
 function M.clear_list_kind(kind)
-  local root = git_root() or ''
-  list_cache.clear_prefix(root .. ':' .. kind .. ':')
-  clear_status_cache(root ~= '' and root or nil)
+  state_mod.clear_list_kind(kind)
 end
 
 function M.clear_cache()
   detect_mod.clear_cache()
-  repo_info_cache.clear()
-  pr_state_cache.clear()
-  list_cache.clear()
-  clear_status_cache()
+  state_mod.clear_cache()
 end
 
 ---@return forge.Status?
 function M.status()
-  setup_status_autocmds()
-  local root = git_root()
-  if not root then
-    return nil
-  end
-  local entry = status_cache[root]
-  local stale = not entry or not entry.updated_at or entry.updated_at <= (os.time() - status_ttl)
-  if stale then
-    refresh_status(root)
-    entry = status_cache[root]
-  end
-  if not entry or entry.value == false or entry.value == nil then
-    return nil
-  end
-  local value = entry.value
-  ---@cast value forge.Status
-  return value
+  return state_mod.status()
 end
 
 ---@param range? { start_line: integer, end_line: integer }

--- a/lua/forge/state.lua
+++ b/lua/forge/state.lua
@@ -1,0 +1,274 @@
+local M = {}
+
+local cache_mod = require('forge.cache')
+local detect_mod = require('forge.detect')
+local resolve_mod = require('forge.resolve')
+local scope_mod = require('forge.scope')
+local target_mod = require('forge.target')
+
+local repo_info_cache = cache_mod.new(30 * 60)
+local pr_state_cache = cache_mod.new(60)
+local list_cache = cache_mod.new(2 * 60)
+local status_ttl = 30
+
+---@type table<string, { value: forge.Status|false|nil, updated_at: integer?, inflight: boolean?, request_id: integer? }>
+local status_cache = {}
+
+local status_augroup
+
+local git_root = detect_mod.git_root
+
+---@param num string
+---@param scope? forge.Scope
+---@return string?
+local function pr_state_key(num, scope)
+  local root = git_root()
+  return root and (root .. '|' .. scope_mod.key(scope) .. '|' .. num) or nil
+end
+
+local function emit_status_update()
+  vim.api.nvim_exec_autocmds('User', {
+    pattern = 'ForgeStatusUpdate',
+    modeline = false,
+  })
+end
+
+---@param root string?
+local function clear_status_cache(root)
+  if root then
+    status_cache[root] = nil
+    return
+  end
+  status_cache = {}
+end
+
+local function setup_status_autocmds()
+  if status_augroup then
+    return
+  end
+  status_augroup = vim.api.nvim_create_augroup('forge_status', { clear = true })
+  vim.api.nvim_create_autocmd({ 'DirChanged', 'FocusGained' }, {
+    group = status_augroup,
+    callback = function()
+      clear_status_cache()
+    end,
+  })
+end
+
+---@param root string
+---@param request_id integer
+---@param value forge.Status?
+local function set_status_value(root, request_id, value)
+  local entry = status_cache[root]
+  if not entry or entry.request_id ~= request_id then
+    return
+  end
+  entry.inflight = false
+  entry.updated_at = os.time()
+  local previous = entry.value == false and nil or entry.value
+  local next_value = value
+  entry.value = value or false
+  if not vim.deep_equal(previous, next_value) then
+    emit_status_update()
+  end
+end
+
+---@param root string
+local function refresh_status(root)
+  local entry = status_cache[root] or {}
+  if entry.inflight then
+    return
+  end
+  entry.inflight = true
+  entry.request_id = (entry.request_id or 0) + 1
+  status_cache[root] = entry
+  ---@type integer
+  local request_id = entry.request_id
+  vim.schedule(function()
+    local current = status_cache[root]
+    if not current or current.request_id ~= request_id then
+      return
+    end
+    local forge = detect_mod.detect_at_root(root)
+    if not forge then
+      local branch = target_mod.current_branch({ cwd = root })
+      if branch then
+        set_status_value(root, request_id, { branch = branch })
+      else
+        set_status_value(root, request_id, nil)
+      end
+      return
+    end
+    local head = resolve_mod.head(nil, {
+      forge = forge,
+      target_opts = {
+        cwd = root,
+      },
+    })
+    if not head then
+      local branch = target_mod.current_branch({ cwd = root })
+      if branch then
+        set_status_value(root, request_id, { branch = branch })
+      else
+        set_status_value(root, request_id, nil)
+      end
+      return
+    end
+    local status = {
+      branch = head.branch,
+    }
+    if head.scope then
+      status.scope = head.scope
+    end
+    resolve_mod.current_pr_async({
+      forge = forge,
+      head_branch = head.branch,
+      head_scope = head.scope,
+      target_opts = {
+        cwd = root,
+      },
+    }, function(pr)
+      status.pr = pr
+      set_status_value(root, request_id, status)
+    end)
+  end)
+end
+
+---@param f forge.Forge
+---@param scope? forge.Scope
+---@return forge.RepoInfo
+function M.repo_info(f, scope)
+  local root = git_root()
+  local key = root and (root .. '|' .. scope_mod.key(scope)) or nil
+  if key then
+    local cached = repo_info_cache.get(key)
+    if cached ~= nil then
+      return cached
+    end
+  end
+  local info = f:repo_info(scope)
+  if key then
+    repo_info_cache.set(key, info)
+  end
+  return info
+end
+
+---@param f forge.Forge
+---@param num string
+---@param scope? forge.Scope
+---@return forge.PRState
+function M.pr_state(f, num, scope)
+  local key = pr_state_key(num, scope)
+  if key then
+    local cached = pr_state_cache.get(key)
+    if cached ~= nil then
+      return cached
+    end
+  end
+  local state = f:pr_state(num, scope)
+  if key then
+    pr_state_cache.set(key, state)
+  end
+  return state
+end
+
+---@param num string
+---@param state forge.PRState
+---@param scope? forge.Scope
+---@return forge.PRState
+function M.set_pr_state(num, state, scope)
+  local key = pr_state_key(num, scope)
+  if key then
+    pr_state_cache.set(key, state)
+  end
+  return state
+end
+
+---@param num? string
+---@param scope? forge.Scope
+function M.clear_pr_state(num, scope)
+  local root = git_root()
+  clear_status_cache(root)
+  if not root then
+    pr_state_cache.clear()
+    return
+  end
+  if num ~= nil then
+    local key = pr_state_key(num, scope)
+    if key then
+      pr_state_cache.clear(key)
+      return
+    end
+    pr_state_cache.clear()
+    return
+  end
+  if scope ~= nil then
+    pr_state_cache.clear_prefix(root .. '|' .. scope_mod.key(scope) .. '|')
+    return
+  end
+  pr_state_cache.clear()
+end
+
+---@param kind string
+---@param state string
+---@return string
+function M.list_key(kind, state)
+  local root = git_root() or ''
+  return root .. ':' .. kind .. ':' .. state
+end
+
+---@param key string
+---@return table[]?
+function M.get_list(key)
+  return list_cache.get(key)
+end
+
+---@param key string
+---@param data table[]
+function M.set_list(key, data)
+  list_cache.set(key, data)
+end
+
+---@param key string?
+function M.clear_list(key)
+  list_cache.clear(key)
+  local root = type(key) == 'string' and key:match('^(.-):') or git_root()
+  clear_status_cache(root)
+end
+
+---@param kind string
+function M.clear_list_kind(kind)
+  local root = git_root() or ''
+  list_cache.clear_prefix(root .. ':' .. kind .. ':')
+  clear_status_cache(root ~= '' and root or nil)
+end
+
+function M.clear_cache()
+  repo_info_cache.clear()
+  pr_state_cache.clear()
+  list_cache.clear()
+  clear_status_cache()
+end
+
+---@return forge.Status?
+function M.status()
+  setup_status_autocmds()
+  local root = git_root()
+  if not root then
+    return nil
+  end
+  local entry = status_cache[root]
+  local stale = not entry or not entry.updated_at or entry.updated_at <= (os.time() - status_ttl)
+  if stale then
+    refresh_status(root)
+    entry = status_cache[root]
+  end
+  if not entry or entry.value == false or entry.value == nil then
+    return nil
+  end
+  local value = entry.value
+  ---@cast value forge.Status
+  return value
+end
+
+return M

--- a/spec/state_spec.lua
+++ b/spec/state_spec.lua
@@ -1,0 +1,185 @@
+vim.opt.runtimepath:prepend(vim.fn.getcwd())
+
+local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
+
+describe('state', function()
+  local state = require('forge.state')
+  local detect = require('forge.detect')
+  local old_executable
+  local old_fn_system
+  local old_system
+  local real_github
+  local updates
+
+  local function github_scope(repo)
+    return assert(require('forge.scope').from_url('github', 'https://github.com/owner/' .. repo))
+  end
+
+  before_each(function()
+    old_executable = vim.fn.executable
+    old_fn_system = vim.fn.system
+    old_system = vim.system
+    real_github = require('forge.backends.github')
+    updates = 0
+    local group = vim.api.nvim_create_augroup('forge_state_spec', { clear = true })
+    vim.api.nvim_create_autocmd('User', {
+      group = group,
+      pattern = 'ForgeStatusUpdate',
+      callback = function()
+        updates = updates + 1
+      end,
+    })
+  end)
+
+  after_each(function()
+    vim.fn.executable = old_executable
+    vim.fn.system = old_fn_system
+    vim.system = old_system
+    detect.register('github', real_github)
+    detect.clear_cache()
+    state.clear_cache()
+    pcall(vim.api.nvim_del_augroup_by_name, 'forge_state_spec')
+  end)
+
+  it('caches repo info lookups per repo and scope', function()
+    local calls = 0
+    local fake = {
+      repo_info = function(_, scope)
+        calls = calls + 1
+        return {
+          permission = scope and scope.slug or '',
+        }
+      end,
+    }
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'barrettruth/forge.nvim',
+    }
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      return ''
+    end
+
+    local first = state.repo_info(fake, scope)
+    local second = state.repo_info(fake, scope)
+
+    assert.equals(1, calls)
+    assert.same(first, second)
+  end)
+
+  it('caches PR state lookups per repo, scope, and number', function()
+    local calls = 0
+    local fake = {
+      pr_state = function(_, num, scope)
+        calls = calls + 1
+        return {
+          state = 'OPEN',
+          mergeable = 'UNKNOWN',
+          review_decision = num .. '|' .. (scope and scope.slug or ''),
+          is_draft = false,
+        }
+      end,
+    }
+    local scope = {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'barrettruth/forge.nvim',
+    }
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      return ''
+    end
+
+    local first = state.pr_state(fake, '42', scope)
+    local second = state.pr_state(fake, '42', scope)
+
+    assert.equals(1, calls)
+    assert.same(first, second)
+  end)
+
+  it('refreshes and caches branch, scope, and current PR', function()
+    local calls = {}
+    detect.register(
+      'github',
+      vim.tbl_extend('force', real_github, {
+        pr_for_branch_cmd = function(_, branch, scope, state_name)
+          return { 'pr-for-branch', state_name or 'open', branch, scope and scope.slug or '' }
+        end,
+        fetch_pr_details_cmd = function(_, num, scope)
+          return { 'fetch-pr', num, scope and scope.slug or '' }
+        end,
+      })
+    )
+    vim.fn.executable = function(bin)
+      if bin == 'gh' then
+        return 1
+      end
+      return old_executable(bin)
+    end
+    vim.fn.system = function(cmd)
+      if cmd == 'git rev-parse --show-toplevel' then
+        return '/repo\n'
+      end
+      return ''
+    end
+    vim.system = helpers.system_router({
+      calls = calls,
+      responses = {
+        ['git -C /repo remote get-url origin'] = helpers.command_result(
+          'git@github.com:owner/current.git\n'
+        ),
+        ['git -C /repo branch --show-current'] = helpers.command_result('feature\n'),
+        ['git -C /repo config branch.feature.pushRemote'] = helpers.command_result('fork\n'),
+        ['git -C /repo remote get-url fork'] = helpers.command_result(
+          'git@github.com:owner/fork.git\n'
+        ),
+        ['git -C /repo remote get-url upstream'] = helpers.command_result(
+          'git@github.com:owner/upstream.git\n'
+        ),
+        ['pr-for-branch open feature owner/fork'] = helpers.command_result('\n'),
+        ['pr-for-branch open feature owner/upstream'] = helpers.command_result('42\n'),
+        ['fetch-pr 42 owner/upstream'] = helpers.command_result(vim.json.encode({
+          state = 'OPEN',
+          headRefName = 'feature',
+          headRepository = {
+            name = 'fork',
+            nameWithOwner = 'owner/fork',
+          },
+          headRepositoryOwner = {
+            login = 'owner',
+          },
+        })),
+      },
+      default = helpers.command_result('', 1),
+    })
+
+    assert.is_nil(state.status())
+    assert.is_true(vim.wait(200, function()
+      return updates > 0 and state.status() ~= nil
+    end))
+    assert.same({
+      branch = 'feature',
+      scope = github_scope('fork'),
+      pr = {
+        num = '42',
+        scope = github_scope('upstream'),
+      },
+    }, state.status())
+
+    local before = #calls
+    assert.same({
+      branch = 'feature',
+      scope = github_scope('fork'),
+      pr = {
+        num = '42',
+        scope = github_scope('upstream'),
+      },
+    }, state.status())
+    assert.equals(before, #calls)
+  end)
+end)


### PR DESCRIPTION
## Problem

`lua/forge/init.lua` still owned repo info, PR state, list cache, and status cache logic, so the top-level `forge` module remained the internal state container.

## Solution

Move that cache and status ownership into `lua/forge/state.lua`, keep `lua/forge/init.lua` as a thin facade over the extracted state APIs, and add focused specs for the new module.
