### PR TITLE
refactor(state): route direct readers through forge.state

### DIFF
--- a/lua/forge/availability.lua
+++ b/lua/forge/availability.lua
@@ -1,5 +1,6 @@
 local M = {}
 local picker_entry = require('forge.picker.entry')
+local state_mod = require('forge.state')
 local surface_policy = require('forge.surface_policy')
 
 local function pr_state(f, entry)
@@ -15,7 +16,7 @@ local function pr_state(f, entry)
       is_draft = value.is_draft == true,
     }
   end
-  return require('forge').pr_state(f, value.num, value.scope)
+  return state_mod.pr_state(f, value.num, value.scope)
 end
 
 local function pr_open(entry)
@@ -44,7 +45,7 @@ function M.pr_merge_methods(f, entry)
     return {}
   end
   local value = picker_entry.value(entry)
-  local info = require('forge').repo_info(f, value and value.scope or nil)
+  local info = state_mod.repo_info(f, value and value.scope or nil)
   if not merge_permission(info) or type((info or {}).merge_methods) ~= 'table' then
     return {}
   end

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -7,6 +7,7 @@ local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker = require('forge.picker')
 local picker_session = require('forge.picker.session')
+local state_mod = require('forge.state')
 local surface_policy = require('forge.surface_policy')
 
 local next_ci_filter = {
@@ -347,7 +348,7 @@ local function pr_toggle_draft_action(f, pr, opts)
   opts = opts or {}
   local is_draft = rawget(pr, 'is_draft')
   if is_draft == nil then
-    local pr_state = require('forge').pr_state(f, pr.num, pr.scope)
+    local pr_state = state_mod.pr_state(f, pr.num, pr.scope)
     is_draft = pr_state.is_draft == true
   end
   ops.pr_toggle_draft(f, pr, is_draft, opts)

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -3,6 +3,7 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
 
 local preload_modules = {
+  'forge.state',
   'forge',
   'forge.logger',
   'forge.ops',
@@ -11,12 +12,15 @@ local preload_modules = {
 }
 
 local loaded_modules = {
+  'forge.availability',
+  'forge.completion_policy',
   'forge',
   'forge.cmd',
   'forge.logger',
   'forge.ops',
   'forge.pickers',
   'forge.resolve',
+  'forge.state',
 }
 
 local function repo_scope(repo)
@@ -186,6 +190,34 @@ describe(':Forge command', function()
             return nil, captured.branch_pr_error(opts, policy)
           end
           return captured.branch_pr_result, captured.branch_pr_error
+        end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        clear_cache = function()
+          captured.cleared = true
+        end,
+        clear_list_kind = function(kind)
+          captured.cleared_kinds = captured.cleared_kinds or {}
+          table.insert(captured.cleared_kinds, kind)
+        end,
+        list_key = function(kind, state)
+          return kind .. ':' .. state
+        end,
+        get_list = function(key)
+          table.insert(captured.get_list_calls, key)
+          return captured.lists[key]
+        end,
+        set_list = function(key, value)
+          captured.lists[key] = value
+        end,
+        pr_state = function(_, num, scope)
+          return captured.pr_states[(scope and scope.slug or 'owner/current') .. '#' .. num] or {}
+        end,
+        repo_info = function(_, scope)
+          return captured.repo_infos[scope and scope.slug or 'owner/current']
+            or { permission = 'WRITE', merge_methods = { 'merge', 'squash', 'rebase' } }
         end,
       }
     end
@@ -371,31 +403,14 @@ describe(':Forge command', function()
         create_issue = function(opts)
           captured.create_issue = opts
         end,
-        clear_cache = function()
-          captured.cleared = true
-        end,
-        clear_list_kind = function(kind)
-          captured.cleared_kinds = captured.cleared_kinds or {}
-          table.insert(captured.cleared_kinds, kind)
-        end,
+        clear_cache = require('forge.state').clear_cache,
+        clear_list_kind = require('forge.state').clear_list_kind,
         scope_key = scope_key,
-        list_key = function(kind, state)
-          return kind .. ':' .. state
-        end,
-        get_list = function(key)
-          table.insert(captured.get_list_calls, key)
-          return captured.lists[key]
-        end,
-        set_list = function(key, value)
-          captured.lists[key] = value
-        end,
-        pr_state = function(_, num, scope)
-          return captured.pr_states[(scope and scope.slug or 'owner/current') .. '#' .. num] or {}
-        end,
-        repo_info = function(_, scope)
-          return captured.repo_infos[scope and scope.slug or 'owner/current']
-            or { permission = 'WRITE', merge_methods = { 'merge', 'squash', 'rebase' } }
-        end,
+        list_key = require('forge.state').list_key,
+        get_list = require('forge.state').get_list,
+        set_list = require('forge.state').set_list,
+        pr_state = require('forge.state').pr_state,
+        repo_info = require('forge.state').repo_info,
         file_loc = function(range)
           local name = vim.api.nvim_buf_get_name(0)
           if name:match('^%w[%w+.-]*://') then

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -22,8 +22,10 @@ local preload_modules = {
   'forge.ops',
   'forge.picker',
   'forge.surface_policy',
+  'forge.state',
 }
 local loaded_modules = {
+  'forge.availability',
   'forge',
   'forge.config',
   'forge.logger',
@@ -32,6 +34,7 @@ local loaded_modules = {
   'forge.picker.session',
   'forge.pickers',
   'forge.review',
+  'forge.state',
   'forge.surface_policy',
 }
 
@@ -236,6 +239,57 @@ describe('pickers', function()
         end,
         warn = function(msg)
           table.insert(logger_messages.warn, msg)
+        end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        list_key = function(kind, state)
+          return kind .. ':' .. state
+        end,
+        get_list = function(key)
+          return cache[key]
+        end,
+        set_list = function(key, value)
+          cache[key] = value
+        end,
+        clear_list = function(key)
+          if key then
+            cache[key] = nil
+          end
+        end,
+        repo_info = function(f)
+          return f:repo_info()
+        end,
+        pr_state = function(f, num, scope)
+          local key = pr_state_key(scope, num)
+          local cached = pr_state_cache[key]
+          if cached ~= nil then
+            return cached
+          end
+          local state = f:pr_state(num, scope)
+          pr_state_cache[key] = state
+          return state
+        end,
+        set_pr_state = function(num, state, scope)
+          pr_state_cache[pr_state_key(scope, num)] = state
+          return state
+        end,
+        clear_pr_state = function(num, scope)
+          if num ~= nil then
+            pr_state_cache[pr_state_key(scope, num)] = nil
+            return
+          end
+          if scope ~= nil then
+            local prefix = pr_state_scope_key(scope)
+            for key in pairs(pr_state_cache) do
+              if key:sub(1, #prefix) == prefix then
+                pr_state_cache[key] = nil
+              end
+            end
+            return
+          end
+          pr_state_cache = {}
         end,
       }
     end
@@ -538,39 +592,10 @@ describe('pickers', function()
         remote_web_url = function()
           return 'https://example.com/repo'
         end,
-        repo_info = function(f)
-          return f:repo_info()
-        end,
-        pr_state = function(f, num, scope)
-          local key = pr_state_key(scope, num)
-          local cached = pr_state_cache[key]
-          if cached ~= nil then
-            return cached
-          end
-          local state = f:pr_state(num, scope)
-          pr_state_cache[key] = state
-          return state
-        end,
-        set_pr_state = function(num, state, scope)
-          pr_state_cache[pr_state_key(scope, num)] = state
-          return state
-        end,
-        clear_pr_state = function(num, scope)
-          if num ~= nil then
-            pr_state_cache[pr_state_key(scope, num)] = nil
-            return
-          end
-          if scope ~= nil then
-            local prefix = pr_state_scope_key(scope)
-            for key in pairs(pr_state_cache) do
-              if key:sub(1, #prefix) == prefix then
-                pr_state_cache[key] = nil
-              end
-            end
-            return
-          end
-          pr_state_cache = {}
-        end,
+        repo_info = require('forge.state').repo_info,
+        pr_state = require('forge.state').pr_state,
+        set_pr_state = require('forge.state').set_pr_state,
+        clear_pr_state = require('forge.state').clear_pr_state,
         create_issue = function(...)
           issue_create_calls = issue_create_calls + 1
           issue_create_opts = select(1, ...)


### PR DESCRIPTION
## Problem

Direct PR and repo-info reads in `lua/forge/availability.lua` and `lua/forge/pickers.lua` still reached back through the top-level `forge` facade, which left state access split across both modules.

## Solution

Route those direct reads through `forge.state` and align the picker and command specs with explicit `forge.state` stubs so the extracted module boundary is exercised directly.
