### PR TITLE
refactor(compose): route list invalidation through forge.state

### DIFF
--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -1,5 +1,6 @@
 local M = {}
 local scope = require('forge.scope')
+local state_mod = require('forge.state')
 local submission = require('forge.submission')
 local system_mod = require('forge.system')
 local template = require('forge.template')
@@ -494,7 +495,7 @@ local function push_and_create(
                   if err then
                     log.error(err)
                   end
-                  require('forge').clear_list()
+                  state_mod.clear_list()
                   if buf and vim.api.nvim_buf_is_valid(buf) then
                     vim.bo[buf].modified = false
                     close_compose_buf(buf)
@@ -525,7 +526,7 @@ local function submit_issue(f, title, body, labels, buf, ref, metadata)
             set_clipboard(url)
           end
           log.info(('created issue -> %s'):format(url))
-          require('forge').clear_list()
+          state_mod.clear_list()
           if buf and vim.api.nvim_buf_is_valid(buf) then
             vim.bo[buf].modified = false
             close_compose_buf(buf)
@@ -548,7 +549,7 @@ local function update_issue(f, num, title, body, buf, ref, metadata, previous)
       vim.schedule(function()
         if result.code == 0 then
           log.info(('updated issue #%s'):format(num))
-          require('forge').clear_list()
+          state_mod.clear_list()
           if buf and vim.api.nvim_buf_is_valid(buf) then
             vim.bo[buf].modified = false
             close_compose_buf(buf)
@@ -870,7 +871,7 @@ local function update_pr(f, num, title, body, buf, ref, metadata, previous)
           end
         end
         log.info(('updated %s #%s'):format(f.labels.pr_one, num))
-        require('forge').clear_list()
+        state_mod.clear_list()
         if buf and vim.api.nvim_buf_is_valid(buf) then
           vim.bo[buf].modified = false
           close_compose_buf(buf)

--- a/spec/compose_abandon_spec.lua
+++ b/spec/compose_abandon_spec.lua
@@ -11,6 +11,7 @@ describe('compose abandon behavior', function()
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.state'] = package.preload['forge.state'],
       ['forge.template'] = package.preload['forge.template'],
     }
 
@@ -34,7 +35,6 @@ describe('compose abandon behavior', function()
 
     package.preload['forge'] = function()
       return {
-        clear_list = function() end,
         current_scope = function()
           return {
             kind = 'github',
@@ -42,6 +42,11 @@ describe('compose abandon behavior', function()
             slug = 'owner/repo',
           }
         end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        clear_list = function() end,
       }
     end
 
@@ -68,6 +73,7 @@ describe('compose abandon behavior', function()
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
   end)
 
@@ -77,11 +83,13 @@ describe('compose abandon behavior', function()
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.state'] = old_preload['forge.state']
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do

--- a/spec/compose_issue_spec.lua
+++ b/spec/compose_issue_spec.lua
@@ -47,6 +47,7 @@ describe('compose issue create', function()
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.state'] = package.preload['forge.state'],
       ['forge.template'] = package.preload['forge.template'],
     }
 
@@ -69,15 +70,19 @@ describe('compose issue create', function()
 
     package.preload['forge'] = function()
       return {
-        clear_list = function()
-          captured.cleared = captured.cleared + 1
-        end,
         current_scope = function()
           return {
             kind = 'github',
             host = 'github.com',
             slug = 'owner/repo',
           }
+        end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
         end,
       }
     end
@@ -108,6 +113,7 @@ describe('compose issue create', function()
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
   end)
 
@@ -118,11 +124,13 @@ describe('compose issue create', function()
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.state'] = old_preload['forge.state']
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
@@ -486,6 +494,7 @@ describe('compose issue edit', function()
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.state'] = package.preload['forge.state'],
       ['forge.template'] = package.preload['forge.template'],
     }
 
@@ -508,15 +517,19 @@ describe('compose issue edit', function()
 
     package.preload['forge'] = function()
       return {
-        clear_list = function()
-          captured.cleared = captured.cleared + 1
-        end,
         current_scope = function()
           return {
             kind = 'github',
             host = 'github.com',
             slug = 'owner/repo',
           }
+        end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
         end,
       }
     end
@@ -547,6 +560,7 @@ describe('compose issue edit', function()
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
   end)
 
@@ -557,11 +571,13 @@ describe('compose issue edit', function()
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.state'] = old_preload['forge.state']
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -61,6 +61,7 @@ describe('compose pr edit', function()
     old_preload = {
       ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.state'] = package.preload['forge.state'],
     }
 
     vim.api.nvim_feedkeys = function() end
@@ -89,15 +90,19 @@ describe('compose pr edit', function()
 
     package.preload['forge'] = function()
       return {
-        clear_list = function()
-          captured.cleared = captured.cleared + 1
-        end,
         current_scope = function()
           return {
             kind = 'github',
             host = 'github.com',
             slug = 'owner/repo',
           }
+        end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
         end,
       }
     end
@@ -120,6 +125,7 @@ describe('compose pr edit', function()
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
   end)
 
   after_each(function()
@@ -131,10 +137,12 @@ describe('compose pr edit', function()
 
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.state'] = old_preload['forge.state']
 
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
       if

--- a/spec/compose_split_spec.lua
+++ b/spec/compose_split_spec.lua
@@ -63,6 +63,7 @@ describe('compose split session', function()
       ['forge'] = package.preload['forge'],
       ['forge.config'] = package.preload['forge.config'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.state'] = package.preload['forge.state'],
       ['forge.template'] = package.preload['forge.template'],
     }
 
@@ -86,15 +87,19 @@ describe('compose split session', function()
 
     package.preload['forge'] = function()
       return {
-        clear_list = function()
-          captured.cleared = captured.cleared + 1
-        end,
         current_scope = function()
           return {
             kind = 'github',
             host = 'github.com',
             slug = 'owner/repo',
           }
+        end,
+      }
+    end
+    package.preload['forge.state'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
         end,
       }
     end
@@ -131,6 +136,7 @@ describe('compose split session', function()
     package.loaded['forge.compose'] = nil
     package.loaded['forge.config'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
 
     vim.cmd('silent! only')
@@ -149,12 +155,14 @@ describe('compose split session', function()
     package.preload['forge'] = old_preload['forge']
     package.preload['forge.config'] = old_preload['forge.config']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.state'] = old_preload['forge.state']
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.config'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.template'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do


### PR DESCRIPTION
## Problem

Compose create and update flows still cleared cached lists through the top-level `forge` facade, which left state invalidation split across both module layers.

## Solution

Route compose list invalidation through `forge.state` and update the compose specs to stub that module explicitly where they observe cache clears.
