### PR TITLE
refactor(init): extract repo helpers (#518)

### DIFF
--- a/lua/forge/backends/codeberg.lua
+++ b/lua/forge/backends/codeberg.lua
@@ -1,5 +1,6 @@
-local forge = require('forge')
+local config_mod = require('forge.config')
 local log = require('forge.logger')
+local repo_mod = require('forge.repo')
 local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
 
@@ -79,8 +80,8 @@ local M = {
 }
 
 local function repo_arg(scope)
-  local current = scope or forge.current_scope(M.name)
-  return forge.scope_repo_arg(current) or ''
+  local current = scope or repo_mod.current_scope(M.name)
+  return repo_mod.scope_repo_arg(current) or ''
 end
 
 local function append_csv(cmd, flag, values)
@@ -102,7 +103,7 @@ function M:list_pr_json_cmd(state, limit, scope)
     '--state',
     state,
     '--limit',
-    tostring(limit or forge.config().display.limits.pulls),
+    tostring(limit or config_mod.config().display.limits.pulls),
     '--output',
     'json',
     '--fields',
@@ -124,7 +125,7 @@ function M:list_issue_json_cmd(state, limit, scope)
     '--state',
     state,
     '--limit',
-    tostring(limit or forge.config().display.limits.issues),
+    tostring(limit or config_mod.config().display.limits.issues),
     '--output',
     'json',
     '--fields',
@@ -138,7 +139,7 @@ end
 ---@param num string
 ---@param scope forge.Scope?
 function M:view_web(kind, num, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(('%s/%s/%s'):format(base, kind, num))
 end
 
@@ -188,7 +189,7 @@ end
 ---@param branch string
 ---@param scope forge.Scope?
 function M:browse(loc, branch, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   local file, lines = loc:match('^(.+):(.+)$')
   vim.ui.open(('%s/src/branch/%s/%s#L%s'):format(base, branch, file, lines))
 end
@@ -196,14 +197,14 @@ end
 ---@param branch string
 ---@param scope forge.Scope?
 function M:browse_branch(branch, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(base .. '/src/branch/' .. branch)
 end
 
 ---@param commit string
 ---@param scope forge.Scope?
 function M:browse_commit(commit, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(base .. '/commit/' .. commit)
 end
 
@@ -218,7 +219,7 @@ local LIST_PATHS = {
 ---@param scope forge.Scope?
 ---@return string?
 function M:list_web_url(kind, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -308,7 +309,7 @@ end
 ---@return string[]
 function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local _ = failed_only
-  local lines = forge.config().ci.lines
+  local lines = config_mod.config().ci.lines
   local job_flag = job_id and (' --job %s'):format(job_id) or ''
   return {
     'sh',
@@ -340,7 +341,7 @@ end
 ---@param limit integer?
 ---@return string[]
 function M:list_runs_json_cmd(branch, scope, limit)
-  local limit_arg = tostring(limit or forge.config().display.limits.runs)
+  local limit_arg = tostring(limit or config_mod.config().display.limits.runs)
   local cmd = 'tea api --repo '
     .. repo_arg(scope)
     .. ' "/repos/{owner}/{repo}/actions/runs?limit='
@@ -386,7 +387,7 @@ end
 ---@param scope forge.Scope?
 ---@return string?
 function M:run_web_url(id, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -430,7 +431,7 @@ end
 ---@return string[]
 function M:run_log_cmd(id, failed_only, scope)
   local _ = failed_only
-  local lines = forge.config().ci.lines
+  local lines = config_mod.config().ci.lines
   return {
     'sh',
     '-c',
@@ -702,7 +703,7 @@ end
 ---@return string
 function M:create_pr_web_url(scope, _, head_branch, base_branch)
   local branch = head_branch or vim.trim(vim.fn.system('git branch --show-current'))
-  local base_url = forge.remote_web_url(scope)
+  local base_url = repo_mod.remote_web_url(scope)
   local default = base_branch
   if not default or default == '' then
     default = vim.trim(
@@ -854,7 +855,7 @@ end
 ---@param limit integer?
 ---@return string[]
 function M:list_releases_json_cmd(scope, limit)
-  local limit_arg = tostring(limit or forge.config().display.limits.releases)
+  local limit_arg = tostring(limit or config_mod.config().display.limits.releases)
   return {
     'sh',
     '-c',
@@ -865,7 +866,7 @@ end
 ---@param tag string
 ---@param scope forge.Scope?
 function M:browse_release(tag, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(base .. '/releases/tag/' .. tag)
 end
 

--- a/lua/forge/backends/github.lua
+++ b/lua/forge/backends/github.lua
@@ -1,5 +1,6 @@
-local forge = require('forge')
+local config_mod = require('forge.config')
 local log = require('forge.logger')
+local repo_mod = require('forge.repo')
 local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
 
@@ -70,8 +71,8 @@ local M = {
 }
 
 local function nwo(scope)
-  local current = scope or forge.current_scope(M.name)
-  return forge.scope_repo_arg(current) or ''
+  local current = scope or repo_mod.current_scope(M.name)
+  return repo_mod.scope_repo_arg(current) or ''
 end
 
 local function tty_env()
@@ -114,7 +115,7 @@ function M:list_pr_json_cmd(state, limit, scope)
     'pr',
     'list',
     '--limit',
-    tostring(limit or forge.config().display.limits.pulls),
+    tostring(limit or config_mod.config().display.limits.pulls),
     '--state',
     state,
     '--json',
@@ -138,7 +139,7 @@ function M:list_issue_json_cmd(state, limit, scope)
     'issue',
     'list',
     '--limit',
-    tostring(limit or forge.config().display.limits.issues),
+    tostring(limit or config_mod.config().display.limits.issues),
     '--state',
     state,
     '--json',
@@ -225,7 +226,7 @@ local LIST_PATHS = {
 ---@param scope forge.Scope?
 ---@return string?
 function M:list_web_url(kind, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -253,14 +254,14 @@ end
 ---@param scope forge.Scope?
 ---@return string[]
 function M:fetch_pr(num, scope)
-  local current = forge.current_scope(M.name)
+  local current = repo_mod.current_scope(M.name)
   local remote = 'origin'
   if
     scope
-    and forge.scope_key(scope) ~= ''
-    and forge.scope_key(scope) ~= forge.scope_key(current)
+    and repo_mod.scope_key(scope) ~= ''
+    and repo_mod.scope_key(scope) ~= repo_mod.scope_key(current)
   then
-    remote = forge.remote_web_url(scope) .. '.git'
+    remote = repo_mod.remote_web_url(scope) .. '.git'
   end
   return { 'git', 'fetch', remote, ('pull/%s/head:pr-%s'):format(num, num) }
 end
@@ -337,7 +338,7 @@ end
 ---@param scope forge.Scope?
 ---@return string[]
 function M:check_log_cmd(run_id, failed_only, job_id, scope)
-  local lines = forge.config().ci.lines
+  local lines = config_mod.config().ci.lines
   local flag = failed_only and '--log-failed' or '--log'
   local job_flag = job_id and (' --job %s'):format(job_id) or ''
   return {
@@ -375,7 +376,7 @@ end
 ---@param scope forge.Scope?
 ---@return string?
 function M:run_web_url(id, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -461,7 +462,7 @@ end
 ---@param scope forge.Scope?
 ---@return string[]
 function M:run_log_cmd(id, failed_only, scope)
-  local lines = forge.config().ci.lines
+  local lines = config_mod.config().ci.lines
   local flag = failed_only and '--log-failed' or '--log'
   return {
     'sh',
@@ -482,7 +483,7 @@ function M:list_runs_json_cmd(branch, scope, limit)
     '--json',
     'databaseId,displayTitle,workflowName,name,headBranch,status,conclusion,event,url,createdAt',
     '--limit',
-    tostring(limit or forge.config().display.limits.runs),
+    tostring(limit or config_mod.config().display.limits.runs),
   }
   local repo = nwo(scope)
   if repo ~= '' then
@@ -844,8 +845,8 @@ function M:create_pr_web_cmd(scope, head_scope, head_branch, base_branch)
     and head ~= ''
     and head_scope
     and scope
-    and forge.scope_key(head_scope) ~= ''
-    and forge.scope_key(head_scope) ~= forge.scope_key(scope)
+    and repo_mod.scope_key(head_scope) ~= ''
+    and repo_mod.scope_key(head_scope) ~= repo_mod.scope_key(scope)
     and head_scope.owner
     and head_scope.owner ~= ''
   then
@@ -885,7 +886,7 @@ end
 ---@param scope forge.Scope?
 ---@return string?
 function M:create_issue_web_url(scope)
-  local url = forge.remote_web_url(scope)
+  local url = repo_mod.remote_web_url(scope)
   if url == '' then
     return nil
   end
@@ -1010,7 +1011,7 @@ function M:list_releases_json_cmd(scope, limit)
     '--json',
     'tagName,name,isDraft,isPrerelease,isLatest,publishedAt',
     '--limit',
-    tostring(limit or forge.config().display.limits.releases),
+    tostring(limit or config_mod.config().display.limits.releases),
   }
   local repo = nwo(scope)
   if repo ~= '' then

--- a/lua/forge/backends/gitlab.lua
+++ b/lua/forge/backends/gitlab.lua
@@ -1,5 +1,6 @@
-local forge = require('forge')
+local config_mod = require('forge.config')
 local log = require('forge.logger')
+local repo_mod = require('forge.repo')
 local scope_mod = require('forge.scope')
 local submission = require('forge.submission')
 
@@ -69,16 +70,16 @@ local M = {
 }
 
 local function repo_arg(scope)
-  return forge.scope_repo_arg(scope) or forge.remote_web_url()
+  return repo_mod.scope_repo_arg(scope) or repo_mod.remote_web_url()
 end
 
 local function project(scope)
-  local current = scope or forge.current_scope(M.name)
+  local current = scope or repo_mod.current_scope(M.name)
   return scope_mod.encode_project(current) or ''
 end
 
 local function hostname(scope)
-  local current = scope or forge.current_scope(M.name)
+  local current = scope or repo_mod.current_scope(M.name)
   return current and current.host or nil
 end
 
@@ -99,7 +100,7 @@ function M:list_pr_json_cmd(state, limit, scope)
     'mr',
     'list',
     '--per-page',
-    tostring(limit or forge.config().display.limits.pulls),
+    tostring(limit or config_mod.config().display.limits.pulls),
     '--output',
     'json',
   }
@@ -126,7 +127,7 @@ function M:list_issue_json_cmd(state, limit, scope)
     'issue',
     'list',
     '--per-page',
-    tostring(limit or forge.config().display.limits.issues),
+    tostring(limit or config_mod.config().display.limits.issues),
     '--output',
     'json',
   }
@@ -153,7 +154,7 @@ end
 ---@param num string
 ---@param scope forge.Scope?
 function M:browse_subject(num, scope)
-  local current = scope or forge.current_scope(M.name)
+  local current = scope or repo_mod.current_scope(M.name)
   local pid = project(current)
   local host = hostname(current) or 'gitlab.com'
   if pid == '' then
@@ -225,7 +226,7 @@ end
 ---@param branch string
 ---@param scope forge.Scope?
 function M:browse(loc, branch, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   local file, lines = loc:match('^(.+):(.+)$')
   vim.ui.open(('%s/-/blob/%s/%s#L%s'):format(base, branch, file, lines))
 end
@@ -233,14 +234,14 @@ end
 ---@param branch string
 ---@param scope forge.Scope?
 function M:browse_branch(branch, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(base .. '/-/tree/' .. branch)
 end
 
 ---@param commit string
 ---@param scope forge.Scope?
 function M:browse_commit(commit, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(base .. '/-/commit/' .. commit)
 end
 
@@ -255,7 +256,7 @@ local LIST_PATHS = {
 ---@param scope forge.Scope?
 ---@return string?
 function M:list_web_url(kind, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -278,13 +279,13 @@ end
 ---@return string[]
 function M:fetch_pr(num, scope)
   local remote = 'origin'
-  local current = forge.current_scope(M.name)
+  local current = repo_mod.current_scope(M.name)
   if
     scope
-    and forge.scope_key(scope) ~= ''
-    and forge.scope_key(scope) ~= forge.scope_key(current)
+    and repo_mod.scope_key(scope) ~= ''
+    and repo_mod.scope_key(scope) ~= repo_mod.scope_key(current)
   then
-    remote = forge.remote_web_url(scope) .. '.git'
+    remote = repo_mod.remote_web_url(scope) .. '.git'
   end
   return {
     'git',
@@ -375,7 +376,7 @@ end
 ---@return string[]
 function M:check_log_cmd(run_id, failed_only, job_id, scope)
   local _ = failed_only
-  local lines = forge.config().ci.lines
+  local lines = config_mod.config().ci.lines
   local id = job_id or run_id
   return {
     'sh',
@@ -431,7 +432,7 @@ end
 ---@param scope forge.Scope?
 ---@return string?
 function M:run_web_url(id, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   if not base or base == '' then
     return nil
   end
@@ -460,7 +461,7 @@ function M:list_runs_json_cmd(branch, scope, limit)
     '--output',
     'json',
     '--per-page',
-    tostring(limit or forge.config().display.limits.runs),
+    tostring(limit or config_mod.config().display.limits.runs),
     '-R',
     repo_arg(scope),
   }
@@ -494,7 +495,7 @@ end
 ---@param scope forge.Scope?
 ---@return string[]
 function M:run_log_cmd(id, failed_only, scope)
-  local lines = forge.config().ci.lines
+  local lines = config_mod.config().ci.lines
   local jq_filter = failed_only and '[.[] | select(.status=="failed")][0].id // .[0].id'
     or '.[0].id'
   return {
@@ -832,8 +833,8 @@ function M:create_pr_web_cmd(scope, head_scope, head_branch, base_branch)
   local cmd = { 'glab', 'mr', 'create', '--web', '-R', repo_arg(scope) }
   if
     head_scope
-    and forge.scope_key(head_scope) ~= ''
-    and forge.scope_key(head_scope) ~= forge.scope_key(scope)
+    and repo_mod.scope_key(head_scope) ~= ''
+    and repo_mod.scope_key(head_scope) ~= repo_mod.scope_key(scope)
   then
     table.insert(cmd, '--head')
     table.insert(cmd, repo_arg(head_scope))
@@ -993,7 +994,7 @@ function M:list_releases_json_cmd(scope, limit)
     '--output',
     'json',
     '--per-page',
-    tostring(limit or forge.config().display.limits.releases),
+    tostring(limit or config_mod.config().display.limits.releases),
     '-R',
     repo_arg(scope),
   }
@@ -1002,7 +1003,7 @@ end
 ---@param tag string
 ---@param scope forge.Scope?
 function M:browse_release(tag, scope)
-  local base = forge.remote_web_url(scope)
+  local base = repo_mod.remote_web_url(scope)
   vim.ui.open(base .. '/-/releases/' .. tag)
 end
 

--- a/lua/forge/compose.lua
+++ b/lua/forge/compose.lua
@@ -1,4 +1,5 @@
 local M = {}
+local repo_mod = require('forge.repo')
 local scope = require('forge.scope')
 local state_mod = require('forge.state')
 local submission = require('forge.submission')
@@ -15,11 +16,7 @@ local function resolve_bufpath(ref, forge_name)
   if path then
     return path
   end
-  local ok, forge = pcall(require, 'forge')
-  if not ok or type(forge) ~= 'table' or type(forge.current_scope) ~= 'function' then
-    return nil
-  end
-  return scope.bufpath(forge.current_scope(forge_name))
+  return scope.bufpath(repo_mod.current_scope(forge_name))
 end
 
 ---@class forge.ComposeBuilder
@@ -65,12 +62,11 @@ function ComposeBuilder:apply(buf)
 end
 
 local function current_repo_web_url(forge_name)
-  local remote = vim.trim(vim.fn.system('git remote get-url origin'))
-  if vim.v.shell_error ~= 0 or remote == '' then
+  local ref = repo_mod.current_scope(forge_name)
+  if not ref then
     return ''
   end
-  local ref = scope.from_url(forge_name, remote)
-  return scope.web_url(ref)
+  return repo_mod.remote_web_url(ref)
 end
 
 local function set_public_buffer_state(buf, forge_name, kind, ref)

--- a/lua/forge/context.lua
+++ b/lua/forge/context.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local detect_mod = require('forge.detect')
+local repo_mod = require('forge.repo')
 
 local providers = {}
 
@@ -36,7 +37,6 @@ providers.current = function()
     return nil, 'not a git repository'
   end
 
-  local forge_mod = require('forge')
   local has_file = in_repo_file(root)
 
   return {
@@ -46,7 +46,7 @@ providers.current = function()
     head = git_output({ 'git', 'rev-parse', 'HEAD' }) or '',
     forge = detect_mod.detect(),
     has_file = has_file,
-    loc = has_file and forge_mod.file_loc() or nil,
+    loc = has_file and repo_mod.file_loc() or nil,
   }
 end
 

--- a/lua/forge/init.lua
+++ b/lua/forge/init.lua
@@ -6,6 +6,7 @@ local config_mod = require('forge.config')
 local context_mod = require('forge.context')
 local detect_mod = require('forge.detect')
 local format_mod = require('forge.format')
+local repo_mod = require('forge.repo')
 local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
 local scope_mod = require('forge.scope')
@@ -25,19 +26,6 @@ M.detect = detect_mod.detect
 
 function M.review_adapter_names()
   return review_mod.names()
-end
-
----@param cmd string
----@return string?
-local function fn_system_text(cmd)
-  local text = vim.trim(vim.fn.system(cmd))
-  if vim.v.shell_error ~= 0 and (text == '' or text:match('^fatal:') or text:match('^error:')) then
-    return nil
-  end
-  if text == '' then
-    return nil
-  end
-  return text
 end
 
 local git_root = detect_mod.git_root
@@ -165,113 +153,51 @@ end
 ---@param range? { start_line: integer, end_line: integer }
 ---@return string
 function M.file_loc(range)
-  local root = git_root()
-  if not root then
-    return vim.fn.expand('%:t')
-  end
-  local buf_name = vim.api.nvim_buf_get_name(0)
-  if buf_name == '' or buf_name:match('^%w[%w+.-]*://') then
-    return ''
-  end
-  local root_prefix = vim.fs.normalize(root) .. '/'
-  local path = vim.fs.normalize(buf_name)
-  if path:sub(1, #root_prefix) ~= root_prefix then
-    return ''
-  end
-  local file = path:sub(#root_prefix + 1)
-  if type(range) == 'table' and range.start_line and range.end_line then
-    local s = range.start_line
-    local e = range.end_line
-    if s > e then
-      s, e = e, s
-    end
-    if s == e then
-      return ('%s:%d'):format(file, s)
-    end
-    return ('%s:%d-%d'):format(file, s, e)
-  end
-  local mode = vim.fn.mode()
-  if mode:match('[vV]') or mode == '\22' then
-    local s = vim.fn.line('v')
-    local e = vim.fn.line('.')
-    if s > e then
-      s, e = e, s
-    end
-    if s == e then
-      return ('%s:%d'):format(file, s)
-    end
-    return ('%s:%d-%d'):format(file, s, e)
-  end
-  return file
+  return repo_mod.file_loc(range)
 end
 
 ---@param scope? forge.Scope
 ---@return string
 function M.remote_web_url(scope)
-  if scope then
-    return scope_mod.web_url(scope)
-  end
-  if not git_root() then
-    return ''
-  end
-  local remote = fn_system_text('git remote get-url origin')
-  if not remote then
-    return ''
-  end
-  remote = remote:gsub('%.git$', '')
-  remote = remote:gsub('^ssh://git@', 'https://')
-  remote = remote:gsub('^git@([^:]+):', 'https://%1/')
-  return remote
+  return repo_mod.remote_web_url(scope)
 end
 
 ---@param name forge.ScopeKind
 ---@param url string
 ---@return forge.Scope?
 function M.scope_from_url(name, url)
-  return scope_mod.from_url(name, url)
+  return repo_mod.scope_from_url(name, url)
 end
 
 ---@param scope forge.Scope?
 ---@return string?
 function M.scope_repo_arg(scope)
-  return scope_mod.repo_arg(scope)
+  return repo_mod.scope_repo_arg(scope)
 end
 
 ---@param scope forge.Scope?
 ---@return string
 function M.scope_key(scope)
-  return scope_mod.key(scope)
+  return repo_mod.scope_key(scope)
 end
 
 ---@param name? forge.ScopeKind
 ---@return forge.Scope?
 function M.current_scope(name)
-  local url = M.remote_web_url()
-  if url == '' then
-    return nil
-  end
-  local forge_name = name
-  if not forge_name then
-    local f = M.detect()
-    forge_name = f and f.name or nil
-  end
-  if not forge_name then
-    return nil
-  end
-  return scope_mod.from_url(forge_name, url)
+  return repo_mod.current_scope(name)
 end
 
 ---@param scope forge.Scope?
 ---@return string?
 function M.remote_name(scope)
-  return scope_mod.remote_name(scope)
+  return repo_mod.remote_name(scope)
 end
 
 ---@param scope forge.Scope?
 ---@param branch string
 ---@return string?
 function M.remote_ref(scope, branch)
-  return scope_mod.remote_ref(scope, branch)
+  return repo_mod.remote_ref(scope, branch)
 end
 
 M.config = config_mod.config

--- a/lua/forge/ops.lua
+++ b/lua/forge/ops.lua
@@ -3,6 +3,7 @@ local M = {}
 local ci = require('forge.ci')
 local detect_mod = require('forge.detect')
 local log = require('forge.logger')
+local repo_mod = require('forge.repo')
 local system_mod = require('forge.system')
 
 local function trim(text)
@@ -194,8 +195,7 @@ function M.pr_edit(pr, f)
   if not f then
     return
   end
-  local forge = require('forge')
-  local ref = pr.scope or forge.current_scope(f.name)
+  local ref = pr.scope or repo_mod.current_scope(f.name)
   local current_branch = trim(vim.fn.system('git branch --show-current'))
 
   log.debug(('fetching %s #%s...'):format(f.labels.pr_one, pr.num))
@@ -344,8 +344,7 @@ function M.issue_edit(issue, f)
   if not f then
     return
   end
-  local forge = require('forge')
-  local ref = issue.scope or forge.current_scope(f.name)
+  local ref = issue.scope or repo_mod.current_scope(f.name)
 
   log.debug(('fetching issue #%s...'):format(issue.num))
   load_details(
@@ -696,7 +695,7 @@ end
 ---@return boolean
 function M.browse_repo(opts)
   local scope = type(opts) == 'table' and opts.scope or nil
-  local url = require('forge').remote_web_url(scope)
+  local url = repo_mod.remote_web_url(scope)
   if trim(url) == '' then
     return false
   end

--- a/lua/forge/repo.lua
+++ b/lua/forge/repo.lua
@@ -1,0 +1,139 @@
+local M = {}
+
+local detect_mod = require('forge.detect')
+local scope_mod = require('forge.scope')
+
+---@param cmd string
+---@return string?
+local function fn_system_text(cmd)
+  local text = vim.trim(vim.fn.system(cmd))
+  if vim.v.shell_error ~= 0 and (text == '' or text:match('^fatal:') or text:match('^error:')) then
+    return nil
+  end
+  if text == '' then
+    return nil
+  end
+  return text
+end
+
+---@return string?
+local function git_root()
+  if type(detect_mod.git_root) == 'function' then
+    return detect_mod.git_root()
+  end
+  return fn_system_text('git rev-parse --show-toplevel')
+end
+
+---@param range? { start_line: integer, end_line: integer }
+---@return string
+function M.file_loc(range)
+  local root = git_root()
+  if not root then
+    return vim.fn.expand('%:t')
+  end
+  local buf_name = vim.api.nvim_buf_get_name(0)
+  if buf_name == '' or buf_name:match('^%w[%w+.-]*://') then
+    return ''
+  end
+  local root_prefix = vim.fs.normalize(root) .. '/'
+  local path = vim.fs.normalize(buf_name)
+  if path:sub(1, #root_prefix) ~= root_prefix then
+    return ''
+  end
+  local file = path:sub(#root_prefix + 1)
+  if type(range) == 'table' and range.start_line and range.end_line then
+    local s = range.start_line
+    local e = range.end_line
+    if s > e then
+      s, e = e, s
+    end
+    if s == e then
+      return ('%s:%d'):format(file, s)
+    end
+    return ('%s:%d-%d'):format(file, s, e)
+  end
+  local mode = vim.fn.mode()
+  if mode:match('[vV]') or mode == '\22' then
+    local s = vim.fn.line('v')
+    local e = vim.fn.line('.')
+    if s > e then
+      s, e = e, s
+    end
+    if s == e then
+      return ('%s:%d'):format(file, s)
+    end
+    return ('%s:%d-%d'):format(file, s, e)
+  end
+  return file
+end
+
+---@param scope? forge.Scope
+---@return string
+function M.remote_web_url(scope)
+  if scope then
+    return scope_mod.web_url(scope)
+  end
+  if not git_root() then
+    return ''
+  end
+  local remote = fn_system_text('git remote get-url origin')
+  if not remote then
+    return ''
+  end
+  remote = remote:gsub('%.git$', '')
+  remote = remote:gsub('^ssh://git@', 'https://')
+  remote = remote:gsub('^git@([^:]+):', 'https://%1/')
+  return remote
+end
+
+---@param name forge.ScopeKind
+---@param url string
+---@return forge.Scope?
+function M.scope_from_url(name, url)
+  return scope_mod.from_url(name, url)
+end
+
+---@param scope forge.Scope?
+---@return string?
+function M.scope_repo_arg(scope)
+  return scope_mod.repo_arg(scope)
+end
+
+---@param scope forge.Scope?
+---@return string
+function M.scope_key(scope)
+  return scope_mod.key(scope)
+end
+
+---@param name? forge.ScopeKind
+---@return forge.Scope?
+function M.current_scope(name)
+  local url = M.remote_web_url()
+  if url == '' then
+    return nil
+  end
+  local forge_name = name
+  if not forge_name then
+    local f = detect_mod.detect()
+    forge_name = f and f.name or nil
+  end
+  if not forge_name then
+    return nil
+  end
+  return scope_mod.from_url(forge_name, url)
+end
+
+---@param scope forge.Scope?
+---@return string?
+function M.remote_name(scope)
+  return scope_mod.remote_name(scope)
+end
+
+---@param scope forge.Scope?
+---@param branch string
+---@return string?
+function M.remote_ref(scope, branch)
+  return scope_mod.remote_ref(scope, branch)
+end
+
+return M

--- a/lua/forge/review.lua
+++ b/lua/forge/review.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local log = require('forge.logger')
+local repo_mod = require('forge.repo')
 local system_mod = require('forge.system')
 
 ---@type table<string, forge.ReviewAdapter>
@@ -71,13 +72,12 @@ local function fetch_head_cmd(f, pr, target)
 end
 
 local function base_ref(ctx, details)
-  local forge = require('forge')
   local branch = trim(details.base_branch)
   if branch == '' then
     return nil
   end
   local scope = ctx.pr.scope
-  local ref = forge.remote_ref(scope, branch)
+  local ref = repo_mod.remote_ref(scope, branch)
   if ref and ref ~= '' then
     return ref
   end

--- a/lua/forge/routes.lua
+++ b/lua/forge/routes.lua
@@ -3,6 +3,7 @@ local M = {}
 local action = require('forge.action')
 local context = require('forge.context')
 local log = require('forge.logger')
+local repo_mod = require('forge.repo')
 local surface = require('forge.surface')
 
 ---@type string[]
@@ -157,7 +158,7 @@ local function route_handlers()
         end
         ctx.forge:browse(ctx.loc, branch, opts.scope)
       else
-        local url = require('forge').remote_web_url(opts.scope)
+        local url = repo_mod.remote_web_url(opts.scope)
         if url == '' then
           return false, 'no remote web url'
         end

--- a/lua/forge/target.lua
+++ b/lua/forge/target.lua
@@ -702,9 +702,9 @@ function M.repo_scope(repo, forge_name)
   local slug = repo.slug
   if repo.form == 'path' then
     local current = nil
-    local ok, forge = pcall(require, 'forge')
-    if ok and type(forge) == 'table' and type(forge.current_scope) == 'function' then
-      current = forge.current_scope(forge_name)
+    local ok, repo_mod = pcall(require, 'forge.repo')
+    if ok and type(repo_mod) == 'table' and type(repo_mod.current_scope) == 'function' then
+      current = repo_mod.current_scope(forge_name)
     end
     host = current and current.host or default_hosts[forge_name]
   end

--- a/spec/compose_pr_create_spec.lua
+++ b/spec/compose_pr_create_spec.lua
@@ -100,7 +100,11 @@ describe('compose pr create', function()
     end
 
     package.loaded['forge.compose'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.template'] = nil
+
+    vim.cmd('silent! only')
+    vim.cmd('enew!')
   end)
 
   after_each(function()
@@ -113,6 +117,7 @@ describe('compose pr create', function()
     package.preload['forge.template'] = old_preload['forge.template']
 
     package.loaded['forge.compose'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.template'] = nil
 
     for _, buf in ipairs(vim.api.nvim_list_bufs()) do
@@ -123,6 +128,7 @@ describe('compose pr create', function()
         vim.api.nvim_buf_delete(buf, { force = true })
       end
     end
+    vim.cmd('silent! only')
     vim.cmd('enew!')
   end)
 

--- a/spec/compose_pr_edit_spec.lua
+++ b/spec/compose_pr_edit_spec.lua
@@ -44,6 +44,16 @@ describe('compose pr edit', function()
     assert.equals(0, vim.wo[win].conceallevel)
   end
 
+  local function current_scope()
+    return {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/repo',
+      repo_arg = 'owner/repo',
+      web_url = 'https://github.com/owner/repo',
+    }
+  end
+
   before_each(function()
     captured = {
       infos = {},
@@ -59,7 +69,7 @@ describe('compose pr edit', function()
     old_wrap = vim.o.wrap
     old_conceallevel = vim.o.conceallevel
     old_preload = {
-      ['forge'] = package.preload['forge'],
+      ['forge.repo'] = package.preload['forge.repo'],
       ['forge.logger'] = package.preload['forge.logger'],
       ['forge.state'] = package.preload['forge.state'],
     }
@@ -88,14 +98,11 @@ describe('compose pr edit', function()
       }
     end
 
-    package.preload['forge'] = function()
+    package.preload['forge.repo'] = function()
       return {
-        current_scope = function()
-          return {
-            kind = 'github',
-            host = 'github.com',
-            slug = 'owner/repo',
-          }
+        current_scope = current_scope,
+        remote_web_url = function(scope)
+          return (scope and scope.web_url) or current_scope().web_url
         end,
       }
     end
@@ -122,10 +129,13 @@ describe('compose pr edit', function()
       }
     end
 
-    package.loaded['forge'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.state'] = nil
+
+    vim.cmd('silent! only')
+    vim.cmd('enew!')
   end)
 
   after_each(function()
@@ -135,11 +145,11 @@ describe('compose pr edit', function()
     vim.o.wrap = old_wrap
     vim.o.conceallevel = old_conceallevel
 
-    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.repo'] = old_preload['forge.repo']
     package.preload['forge.logger'] = old_preload['forge.logger']
     package.preload['forge.state'] = old_preload['forge.state']
 
-    package.loaded['forge'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.state'] = nil
@@ -152,6 +162,7 @@ describe('compose pr edit', function()
         vim.api.nvim_buf_delete(buf, { force = true })
       end
     end
+    vim.cmd('silent! only')
     vim.cmd('enew!')
   end)
 

--- a/spec/context_spec.lua
+++ b/spec/context_spec.lua
@@ -37,6 +37,7 @@ describe('context', function()
     old_preload = {
       ['forge.detect'] = package.preload['forge.detect'],
       ['forge'] = package.preload['forge'],
+      ['forge.repo'] = package.preload['forge.repo'],
     }
 
     package.preload['forge.detect'] = function()
@@ -51,6 +52,11 @@ describe('context', function()
         config = function()
           return current_config
         end,
+      }
+    end
+
+    package.preload['forge.repo'] = function()
+      return {
         file_loc = function()
           return 'lua/forge/init.lua:10'
         end,
@@ -59,6 +65,7 @@ describe('context', function()
 
     package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.context'] = nil
   end)
 
@@ -66,8 +73,10 @@ describe('context', function()
     vim.system = old_system
     package.preload['forge.detect'] = old_preload['forge.detect']
     package.preload['forge'] = old_preload['forge']
+    package.preload['forge.repo'] = old_preload['forge.repo']
     package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.context'] = nil
   end)
 

--- a/spec/review_spec.lua
+++ b/spec/review_spec.lua
@@ -19,7 +19,7 @@ describe('review adapters', function()
       infos = {},
       errors = {},
     }
-    old_preload = helpers.capture_preload({ 'forge', 'forge.logger' })
+    old_preload = helpers.capture_preload({ 'forge', 'forge.logger', 'forge.repo' })
     old_system = vim.system
     old_exists = vim.fn.exists
     old_nvim_cmd = vim.api.nvim_cmd
@@ -60,6 +60,11 @@ describe('review adapters', function()
         config = function()
           return { review = { adapter = 'checkout' } }
         end,
+      }
+    end
+
+    package.preload['forge.repo'] = function()
+      return {
         remote_ref = function(_, branch)
           return 'origin/' .. branch
         end,
@@ -83,6 +88,7 @@ describe('review adapters', function()
 
     package.loaded['forge'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.review'] = nil
   end)
 
@@ -97,6 +103,7 @@ describe('review adapters', function()
 
     package.loaded['forge'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.review'] = nil
   end)
 

--- a/spec/routes_spec.lua
+++ b/spec/routes_spec.lua
@@ -114,6 +114,7 @@ describe('routes', function()
     old_preload = {
       ['forge.detect'] = package.preload['forge.detect'],
       ['forge'] = package.preload['forge'],
+      ['forge.repo'] = package.preload['forge.repo'],
       ['forge.logger'] = package.preload['forge.logger'],
       ['forge.picker'] = package.preload['forge.picker'],
       ['forge.pickers'] = package.preload['forge.pickers'],
@@ -136,6 +137,11 @@ describe('routes', function()
         config = function()
           return current_config
         end,
+      }
+    end
+
+    package.preload['forge.repo'] = function()
+      return {
         file_loc = function()
           local name = vim.api.nvim_buf_get_name(0)
           if name:match('^%w[%w+.-]*://') then
@@ -203,6 +209,7 @@ describe('routes', function()
     end
 
     package.loaded['forge'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.pickers'] = nil
@@ -215,6 +222,7 @@ describe('routes', function()
 
     package.preload['forge.detect'] = old_preload['forge.detect']
     package.preload['forge'] = old_preload['forge']
+    package.preload['forge.repo'] = old_preload['forge.repo']
     package.preload['forge.logger'] = old_preload['forge.logger']
     package.preload['forge.picker'] = old_preload['forge.picker']
     package.preload['forge.pickers'] = old_preload['forge.pickers']
@@ -222,6 +230,7 @@ describe('routes', function()
 
     package.loaded['forge.detect'] = nil
     package.loaded['forge'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.logger'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['forge.pickers'] = nil

--- a/spec/submission_integration_spec.lua
+++ b/spec/submission_integration_spec.lua
@@ -8,6 +8,42 @@ describe('submission integration', function()
   local old_schedule
   local old_preload
 
+  local function scope_for(name)
+    if name == 'gitlab' then
+      return {
+        kind = 'gitlab',
+        host = 'gitlab.com',
+        slug = 'group/repo',
+        repo_arg = 'group/repo',
+        web_url = 'https://gitlab.com/group/repo',
+      }
+    end
+    if name == 'codeberg' then
+      return {
+        kind = 'codeberg',
+        host = 'codeberg.org',
+        slug = 'forgejo/tea-test',
+        repo_arg = 'forgejo/tea-test',
+        web_url = 'https://codeberg.org/forgejo/tea-test',
+      }
+    end
+    return {
+      kind = 'github',
+      host = 'github.com',
+      slug = 'owner/repo',
+      repo_arg = 'owner/repo',
+      web_url = 'https://github.com/owner/repo',
+    }
+  end
+
+  local function scope_key(scope)
+    return table.concat({
+      scope and scope.kind or '',
+      scope and scope.host or '',
+      scope and scope.slug or '',
+    }, '|')
+  end
+
   before_each(function()
     captured = {
       calls = {},
@@ -22,9 +58,10 @@ describe('submission integration', function()
     old_feedkeys = vim.api.nvim_feedkeys
     old_schedule = vim.schedule
     old_preload = {
-      ['forge'] = package.preload['forge'],
       ['forge.logger'] = package.preload['forge.logger'],
+      ['forge.repo'] = package.preload['forge.repo'],
       ['forge.resolve'] = package.preload['forge.resolve'],
+      ['forge.state'] = package.preload['forge.state'],
       ['forge.template'] = package.preload['forge.template'],
     }
 
@@ -57,26 +94,27 @@ describe('submission integration', function()
       }
     end
 
-    package.preload['forge'] = function()
+    package.preload['forge.repo'] = function()
       return {
-        clear_list = function()
-          captured.cleared = captured.cleared + 1
+        current_scope = function(name)
+          return scope_for(name)
         end,
         scope_repo_arg = function(scope)
           return scope and scope.repo_arg or ''
         end,
-        remote_web_url = function()
-          return ''
+        remote_web_url = function(scope)
+          return scope and scope.web_url or ''
         end,
         scope_key = function(scope)
-          return scope and scope.repo_arg or ''
+          return scope_key(scope)
         end,
-        current_scope = function()
-          return {
-            kind = 'github',
-            host = 'github.com',
-            slug = 'owner/repo',
-          }
+      }
+    end
+
+    package.preload['forge.state'] = function()
+      return {
+        clear_list = function()
+          captured.cleared = captured.cleared + 1
         end,
       }
     end
@@ -116,15 +154,19 @@ describe('submission integration', function()
       }
     end
 
-    package.loaded['forge'] = nil
     package.loaded['forge.backends.codeberg'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.backends.github'] = nil
     package.loaded['forge.backends.gitlab'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.resolve'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.submission'] = nil
     package.loaded['forge.template'] = nil
+
+    vim.cmd('silent! only')
+    vim.cmd('enew!')
   end)
 
   after_each(function()
@@ -133,18 +175,20 @@ describe('submission integration', function()
     vim.api.nvim_feedkeys = old_feedkeys
     vim.schedule = old_schedule
 
-    package.preload['forge'] = old_preload['forge']
     package.preload['forge.logger'] = old_preload['forge.logger']
+    package.preload['forge.repo'] = old_preload['forge.repo']
     package.preload['forge.resolve'] = old_preload['forge.resolve']
+    package.preload['forge.state'] = old_preload['forge.state']
     package.preload['forge.template'] = old_preload['forge.template']
 
-    package.loaded['forge'] = nil
     package.loaded['forge.backends.codeberg'] = nil
     package.loaded['forge.compose'] = nil
     package.loaded['forge.backends.github'] = nil
     package.loaded['forge.backends.gitlab'] = nil
     package.loaded['forge.logger'] = nil
+    package.loaded['forge.repo'] = nil
     package.loaded['forge.resolve'] = nil
+    package.loaded['forge.state'] = nil
     package.loaded['forge.submission'] = nil
     package.loaded['forge.template'] = nil
 
@@ -156,6 +200,7 @@ describe('submission integration', function()
         end
       end
     end
+    vim.cmd('silent! only')
     vim.cmd('enew!')
   end)
 


### PR DESCRIPTION
## Problem

`lua/forge/init.lua` still owned current-repo, scope, and remote web URL helpers, so internal callers and backend adapters had to reach through the top-level `forge` facade for repo resolution.

## Solution

Extract those helpers into `lua/forge/repo.lua`, delegate the top-level API to that module, update internal callers and backends to depend on `forge.repo` directly, and refresh the compose and submission specs to stub the new dependency boundary.