### PR TITLE
refactor(ci): share request and buffer lifecycle helpers (#531)

### DIFF
--- a/lua/forge/buf_lifecycle.lua
+++ b/lua/forge/buf_lifecycle.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 ---@generic T: table
----@param init T|fun(): T|nil
+---@param init? T|fun(): T|nil
 ---@return T
 local function init_data(init)
   if type(init) == 'function' then
@@ -13,7 +13,7 @@ end
 ---@generic T: table
 ---@param buf_data table<integer, T>
 ---@param buf integer
----@param init T|fun(): T|nil
+---@param init? T|fun(): T|nil
 ---@return T
 function M.data_for(buf_data, buf, init)
   local data = buf_data[buf]
@@ -28,7 +28,7 @@ end
 ---@param buf_data table<integer, T>
 ---@param buf integer
 ---@param fields table
----@param init T|fun(): T|nil
+---@param init? T|fun(): T|nil
 ---@return T
 function M.set_data(buf_data, buf, fields, init)
   local data = M.data_for(buf_data, buf, init)
@@ -52,7 +52,7 @@ end
 ---@param buf_data table<integer, table>
 ---@param buf integer
 ---@param field string?
----@param init table|fun(): table|nil
+---@param init? table|fun(): table|nil
 function M.stop_proc(buf_data, buf, field, init)
   local data = M.data_for(buf_data, buf, init)
   field = field or 'proc'
@@ -68,7 +68,7 @@ end
 ---@param buf_data table<integer, table>
 ---@param buf integer
 ---@param field string?
----@param init table|fun(): table|nil
+---@param init? table|fun(): table|nil
 function M.stop_procs(buf_data, buf, field, init)
   local data = M.data_for(buf_data, buf, init)
   field = field or 'procs'
@@ -87,7 +87,7 @@ end
 ---@param buf_data table<integer, table>
 ---@param buf integer
 ---@param stop fun(buf: integer)
----@param init table|fun(): table|nil
+---@param init? table|fun(): table|nil
 ---@return integer
 function M.begin_request(buf_data, buf, stop, init)
   local data = M.data_for(buf_data, buf, init)
@@ -170,6 +170,7 @@ function M.prepare_buf(opts)
       })
     end
   end
+  ---@cast buf integer
   vim.bo[buf].filetype = opts.filetype
   M.set_public_buffer_state(buf, opts.kind, opts.url)
   return buf, reusing

--- a/lua/forge/buf_lifecycle.lua
+++ b/lua/forge/buf_lifecycle.lua
@@ -1,0 +1,258 @@
+local M = {}
+
+---@generic T: table
+---@param init T|fun(): T|nil
+---@return T
+local function init_data(init)
+  if type(init) == 'function' then
+    return init()
+  end
+  return vim.deepcopy(init or {})
+end
+
+---@generic T: table
+---@param buf_data table<integer, T>
+---@param buf integer
+---@param init T|fun(): T|nil
+---@return T
+function M.data_for(buf_data, buf, init)
+  local data = buf_data[buf]
+  if not data then
+    data = init_data(init)
+    buf_data[buf] = data
+  end
+  return data
+end
+
+---@generic T: table
+---@param buf_data table<integer, T>
+---@param buf integer
+---@param fields table
+---@param init T|fun(): T|nil
+---@return T
+function M.set_data(buf_data, buf, fields, init)
+  local data = M.data_for(buf_data, buf, init)
+  for key, value in pairs(fields) do
+    data[key] = value
+  end
+  return data
+end
+
+---@param buf integer
+---@param kind forge.BufferKind
+---@param url string?
+function M.set_public_buffer_state(buf, kind, url)
+  vim.b[buf].forge = {
+    version = 1,
+    kind = kind,
+    url = type(url) == 'string' and url or '',
+  }
+end
+
+---@param buf_data table<integer, table>
+---@param buf integer
+---@param field string?
+---@param init table|fun(): table|nil
+function M.stop_proc(buf_data, buf, field, init)
+  local data = M.data_for(buf_data, buf, init)
+  field = field or 'proc'
+  local proc = data[field]
+  if proc and type(proc.kill) == 'function' then
+    pcall(function()
+      proc:kill()
+    end)
+  end
+  data[field] = nil
+end
+
+---@param buf_data table<integer, table>
+---@param buf integer
+---@param field string?
+---@param init table|fun(): table|nil
+function M.stop_procs(buf_data, buf, field, init)
+  local data = M.data_for(buf_data, buf, init)
+  field = field or 'procs'
+  local procs = data[field]
+  if not procs then
+    return
+  end
+  for _, proc in ipairs(procs) do
+    pcall(function()
+      proc:kill()
+    end)
+  end
+  data[field] = nil
+end
+
+---@param buf_data table<integer, table>
+---@param buf integer
+---@param stop fun(buf: integer)
+---@param init table|fun(): table|nil
+---@return integer
+function M.begin_request(buf_data, buf, stop, init)
+  local data = M.data_for(buf_data, buf, init)
+  data.request_id = (data.request_id or 0) + 1
+  stop(buf)
+  return data.request_id
+end
+
+---@param buf_data table<integer, table>
+---@param buf integer
+---@param request_id integer
+---@return boolean
+function M.request_current(buf_data, buf, request_id)
+  local data = buf_data[buf]
+  return data ~= nil and data.request_id == request_id
+end
+
+---@param name string?
+---@return integer?
+function M.find_buf_by_name(name)
+  if not name or name == '' then
+    return nil
+  end
+  local buf = vim.fn.bufnr(name)
+  if buf ~= -1 and vim.api.nvim_buf_is_valid(buf) then
+    return buf
+  end
+  return nil
+end
+
+---@param split string?
+---@return string
+local function split_prefix(split)
+  return split == 'vertical' and 'vertical' or 'botright'
+end
+
+---@class forge.PrepareBufOpts
+---@field bufname string?
+---@field reuse_buf integer?
+---@field split string?
+---@field filetype string
+---@field kind forge.BufferKind
+---@field url string?
+---@field on_wipeout fun(buf: integer)?
+
+---@param opts forge.PrepareBufOpts
+---@return integer, boolean
+function M.prepare_buf(opts)
+  local buf
+  local reusing = false
+  if opts.reuse_buf and vim.api.nvim_buf_is_valid(opts.reuse_buf) then
+    buf = opts.reuse_buf
+    reusing = true
+  else
+    local existing = M.find_buf_by_name(opts.bufname)
+    if existing then
+      buf = existing
+      reusing = true
+      local wins = vim.fn.win_findbuf(buf)
+      if #wins == 0 then
+        vim.cmd('noautocmd ' .. split_prefix(opts.split) .. ' sbuffer ' .. buf)
+      end
+    else
+      vim.cmd('noautocmd ' .. split_prefix(opts.split) .. ' new')
+      buf = vim.api.nvim_get_current_buf()
+      vim.bo[buf].buftype = 'nofile'
+      vim.bo[buf].bufhidden = 'wipe'
+      vim.bo[buf].swapfile = false
+      vim.bo[buf].modifiable = false
+      if opts.bufname then
+        vim.api.nvim_buf_set_name(buf, opts.bufname)
+      end
+      vim.api.nvim_create_autocmd('BufWipeout', {
+        buffer = buf,
+        callback = function()
+          if opts.on_wipeout then
+            opts.on_wipeout(buf)
+          end
+        end,
+      })
+    end
+  end
+  vim.bo[buf].filetype = opts.filetype
+  M.set_public_buffer_state(buf, opts.kind, opts.url)
+  return buf, reusing
+end
+
+---@param buf integer
+---@param ns integer
+---@param lines table[]
+function M.render_simple(buf, ns, lines)
+  vim.bo[buf].modifiable = true
+  vim.api.nvim_buf_set_lines(
+    buf,
+    0,
+    -1,
+    false,
+    vim.tbl_map(function(line)
+      return line.text
+    end, lines)
+  )
+  vim.bo[buf].modifiable = false
+  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
+  for lnum, line in ipairs(lines) do
+    for _, hl in ipairs(line.highlights or {}) do
+      vim.api.nvim_buf_set_extmark(buf, ns, lnum - 1, hl.col, {
+        end_col = hl.end_col,
+        hl_group = hl.group,
+      })
+    end
+  end
+end
+
+---@param lines table[]?
+---@param field string
+---@return integer[]
+function M.line_positions(lines, field)
+  local positions = {}
+  for lnum, line in ipairs(lines or {}) do
+    if line[field] ~= nil then
+      positions[#positions + 1] = lnum
+    end
+  end
+  return positions
+end
+
+---@param lines table[]?
+---@param field string
+---@return any
+function M.current_line_value(lines, field)
+  local line = vim.api.nvim_win_get_cursor(0)[1]
+  local entry = (lines or {})[line]
+  return entry and entry[field] or nil
+end
+
+---@param positions integer[]?
+---@param dir integer
+---@param wrap boolean?
+function M.jump_positions(positions, dir, wrap)
+  positions = positions or {}
+  if #positions == 0 then
+    return
+  end
+  local current = vim.api.nvim_win_get_cursor(0)[1]
+  if dir > 0 then
+    for _, lnum in ipairs(positions) do
+      if lnum > current then
+        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
+        return
+      end
+    end
+    if wrap then
+      vim.api.nvim_win_set_cursor(0, { positions[1], 0 })
+    end
+    return
+  end
+  for i = #positions, 1, -1 do
+    if positions[i] < current then
+      vim.api.nvim_win_set_cursor(0, { positions[i], 0 })
+      return
+    end
+  end
+  if wrap then
+    vim.api.nvim_win_set_cursor(0, { positions[#positions], 0 })
+  end
+end
+
+return M

--- a/lua/forge/ci_history.lua
+++ b/lua/forge/ci_history.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local buf_lifecycle = require('forge.buf_lifecycle')
 local config_mod = require('forge.config')
 local format_mod = require('forge.format')
 local layout = require('forge.layout')
@@ -39,52 +40,23 @@ local function bufname(head)
 end
 
 local function data_for(buf)
-  local data = buf_data[buf]
-  if not data then
-    data = {}
-    buf_data[buf] = data
-  end
-  return data
+  return buf_lifecycle.data_for(buf_data, buf)
 end
 
 local function set_data(buf, fields)
-  local data = data_for(buf)
-  for key, value in pairs(fields) do
-    data[key] = value
-  end
-  return data
-end
-
----@param buf integer
----@param kind forge.BufferKind
----@param url string?
-local function set_public_buffer_state(buf, kind, url)
-  vim.b[buf].forge = {
-    version = 1,
-    kind = kind,
-    url = type(url) == 'string' and url or '',
-  }
+  return buf_lifecycle.set_data(buf_data, buf, fields)
 end
 
 local function stop_proc(buf)
-  local proc = data_for(buf).proc
-  if proc and type(proc.kill) == 'function' then
-    pcall(function()
-      proc:kill()
-    end)
-  end
-  data_for(buf).proc = nil
+  buf_lifecycle.stop_proc(buf_data, buf)
 end
 
 local function begin_request(buf)
-  local data = data_for(buf)
-  data.request_id = (data.request_id or 0) + 1
-  stop_proc(buf)
-  return data.request_id
+  return buf_lifecycle.begin_request(buf_data, buf, stop_proc)
 end
 
 local function request_current(buf, request_id)
-  return data_for(buf).request_id == request_id
+  return buf_lifecycle.request_current(buf_data, buf, request_id)
 end
 
 local function limit_settings(buf, opts)
@@ -104,49 +76,15 @@ local function limit_settings(buf, opts)
   return step, limit
 end
 
-local function line_positions(buf)
-  local lines = data_for(buf).lines or {}
-  local positions = {}
-  for lnum, line in ipairs(lines) do
-    if line.run ~= nil then
-      positions[#positions + 1] = lnum
-    end
-  end
-  return positions
-end
-
 local function jump(buf, dir)
-  local positions = line_positions(buf)
-  if #positions == 0 then
-    return
-  end
-  local current = vim.api.nvim_win_get_cursor(0)[1]
-  if dir > 0 then
-    for _, lnum in ipairs(positions) do
-      if lnum > current then
-        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
-        return
-      end
-    end
-    vim.api.nvim_win_set_cursor(0, { positions[1], 0 })
-    return
-  end
-  for i = #positions, 1, -1 do
-    if positions[i] < current then
-      vim.api.nvim_win_set_cursor(0, { positions[i], 0 })
-      return
-    end
-  end
-  vim.api.nvim_win_set_cursor(0, { positions[#positions], 0 })
+  local positions = buf_lifecycle.line_positions(data_for(buf).lines, 'run')
+  buf_lifecycle.jump_positions(positions, dir, true)
 end
 
 ---@param buf integer
 ---@return forge.CIRun?
 local function current_run(buf)
-  local line = vim.api.nvim_win_get_cursor(0)[1]
-  local lines = data_for(buf).lines or {}
-  local entry = lines[line]
-  return entry and entry.run or nil
+  return buf_lifecycle.current_line_value(data_for(buf).lines, 'run')
 end
 
 ---@param run forge.CIRun
@@ -253,26 +191,7 @@ end
 ---@param buf integer
 ---@param lines forge.CIHistoryLine[]
 local function render(buf, lines)
-  vim.bo[buf].modifiable = true
-  vim.api.nvim_buf_set_lines(
-    buf,
-    0,
-    -1,
-    false,
-    vim.tbl_map(function(line)
-      return line.text
-    end, lines)
-  )
-  vim.bo[buf].modifiable = false
-  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
-  for lnum, line in ipairs(lines) do
-    for _, hl in ipairs(line.highlights or {}) do
-      vim.api.nvim_buf_set_extmark(buf, ns, lnum - 1, hl.col, {
-        end_col = hl.end_col,
-        hl_group = hl.group,
-      })
-    end
-  end
+  buf_lifecycle.render_simple(buf, ns, lines)
   set_data(buf, { lines = lines })
 end
 
@@ -349,48 +268,20 @@ end
 ---@param reuse_buf integer?
 ---@return integer, boolean
 local function prepare_buf(head, reuse_buf)
-  local name = bufname(head)
-  local buf
-  local reusing = false
-  if reuse_buf and vim.api.nvim_buf_is_valid(reuse_buf) then
-    buf = reuse_buf
-    reusing = true
-  else
-    local existing = name and vim.fn.bufnr(name) or -1
-    if existing ~= -1 and vim.api.nvim_buf_is_valid(existing) then
-      buf = existing
-      reusing = true
-      local wins = vim.fn.win_findbuf(buf)
-      if #wins == 0 then
-        local cfg = config_mod.config()
-        local split = cfg.ci.split or cfg.split
-        local prefix = split == 'vertical' and 'vertical' or 'botright'
-        vim.cmd('noautocmd ' .. prefix .. ' sbuffer ' .. buf)
-      end
-    else
-      local cfg = config_mod.config()
-      local split = cfg.ci.split or cfg.split
-      local prefix = split == 'vertical' and 'vertical' or 'botright'
-      vim.cmd('noautocmd ' .. prefix .. ' new')
-      buf = vim.api.nvim_get_current_buf()
-      vim.bo[buf].buftype = 'nofile'
-      vim.bo[buf].bufhidden = 'wipe'
-      vim.bo[buf].swapfile = false
-      vim.bo[buf].modifiable = false
-      if name then
-        vim.api.nvim_buf_set_name(buf, name)
-      end
-      vim.api.nvim_create_autocmd('BufWipeout', {
-        buffer = buf,
-        callback = function()
-          stop_proc(buf)
-          buf_data[buf] = nil
-        end,
-      })
-    end
-  end
-  vim.bo[buf].filetype = 'forgelist'
-  set_public_buffer_state(buf, 'ci_history', scope_mod.branch_web_url(head.scope, head.branch))
+  local cfg = config_mod.config()
+  local split = cfg.ci.split or cfg.split
+  local buf, reusing = buf_lifecycle.prepare_buf({
+    bufname = bufname(head),
+    reuse_buf = reuse_buf,
+    split = split,
+    filetype = 'forgelist',
+    kind = 'ci_history',
+    url = scope_mod.branch_web_url(head.scope, head.branch),
+    on_wipeout = function(wiped)
+      stop_proc(wiped)
+      buf_data[wiped] = nil
+    end,
+  })
   if not reusing then
     render(buf, render_placeholder('Loading...', 'ForgeDim'))
   end

--- a/lua/forge/log.lua
+++ b/lua/forge/log.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local buf_lifecycle = require('forge.buf_lifecycle')
 local config_mod = require('forge.config')
 local log_render = require('forge.log_render')
 local log_summary = require('forge.log_summary')
@@ -30,69 +31,31 @@ local function summary_bufname(opts)
   return ('forge://%s/ci/run/%s'):format(prefix, opts.run_id)
 end
 
----@param name string?
----@return integer?
-local function find_buf_by_name(name)
-  if not name or name == '' then
-    return nil
-  end
-  local bn = vim.fn.bufnr(name)
-  if bn ~= -1 and vim.api.nvim_buf_is_valid(bn) then
-    return bn
-  end
-  return nil
+local function new_data()
+  return { headers = {}, errors = {} }
 end
 
+local find_buf_by_name = buf_lifecycle.find_buf_by_name
+local set_public_buffer_state = buf_lifecycle.set_public_buffer_state
+
 local function data_for(buf)
-  local d = buf_data[buf]
-  if not d then
-    d = { headers = {}, errors = {} }
-    buf_data[buf] = d
-  end
-  return d
+  return buf_lifecycle.data_for(buf_data, buf, new_data)
 end
 
 local function set_data(buf, fields)
-  local d = data_for(buf)
-  for k, v in pairs(fields) do
-    d[k] = v
-  end
-  return d
-end
-
----@param buf integer
----@param kind forge.BufferKind
----@param url string?
-local function set_public_buffer_state(buf, kind, url)
-  vim.b[buf].forge = {
-    version = 1,
-    kind = kind,
-    url = type(url) == 'string' and url or '',
-  }
+  return buf_lifecycle.set_data(buf_data, buf, fields, new_data)
 end
 
 local function stop_procs(buf)
-  local d = buf_data[buf]
-  if d and d.procs then
-    for _, p in ipairs(d.procs) do
-      pcall(function()
-        p:kill()
-      end)
-    end
-    d.procs = nil
-  end
+  buf_lifecycle.stop_procs(buf_data, buf, 'procs', new_data)
 end
 
 local function begin_request(buf)
-  local d = data_for(buf)
-  d.request_id = (d.request_id or 0) + 1
-  stop_procs(buf)
-  return d.request_id
+  return buf_lifecycle.begin_request(buf_data, buf, stop_procs, new_data)
 end
 
 local function request_current(buf, request_id)
-  local d = buf_data[buf]
-  return d and d.request_id == request_id
+  return buf_lifecycle.request_current(buf_data, buf, request_id)
 end
 
 local strip_ansi = log_render.strip_ansi
@@ -108,22 +71,7 @@ local function jump(buf, kind, dir)
     return
   end
   local list = kind == 'header' and d.headers or d.errors
-  local cursor = vim.api.nvim_win_get_cursor(0)[1]
-  if dir > 0 then
-    for _, ln in ipairs(list) do
-      if ln > cursor then
-        vim.api.nvim_win_set_cursor(0, { ln, 0 })
-        return
-      end
-    end
-  else
-    for i = #list, 1, -1 do
-      if list[i] < cursor then
-        vim.api.nvim_win_set_cursor(0, { list[i], 0 })
-        return
-      end
-    end
-  end
+  buf_lifecycle.jump_positions(list, dir, false)
 end
 
 local function setup_keymaps(buf, url, cmd, opts)

--- a/lua/forge/pr_checks.lua
+++ b/lua/forge/pr_checks.lua
@@ -1,5 +1,6 @@
 local M = {}
 
+local buf_lifecycle = require('forge.buf_lifecycle')
 local config_mod = require('forge.config')
 local format_mod = require('forge.format')
 local layout = require('forge.layout')
@@ -33,97 +34,34 @@ local function bufname(pr)
 end
 
 local function data_for(buf)
-  local data = buf_data[buf]
-  if not data then
-    data = {}
-    buf_data[buf] = data
-  end
-  return data
+  return buf_lifecycle.data_for(buf_data, buf)
 end
 
 local function set_data(buf, fields)
-  local data = data_for(buf)
-  for key, value in pairs(fields) do
-    data[key] = value
-  end
-  return data
-end
-
----@param buf integer
----@param kind forge.BufferKind
----@param url string?
-local function set_public_buffer_state(buf, kind, url)
-  vim.b[buf].forge = {
-    version = 1,
-    kind = kind,
-    url = type(url) == 'string' and url or '',
-  }
+  return buf_lifecycle.set_data(buf_data, buf, fields)
 end
 
 local function stop_proc(buf)
-  local proc = data_for(buf).proc
-  if proc and type(proc.kill) == 'function' then
-    pcall(function()
-      proc:kill()
-    end)
-  end
-  data_for(buf).proc = nil
+  buf_lifecycle.stop_proc(buf_data, buf)
 end
 
 local function begin_request(buf)
-  local data = data_for(buf)
-  data.request_id = (data.request_id or 0) + 1
-  stop_proc(buf)
-  return data.request_id
+  return buf_lifecycle.begin_request(buf_data, buf, stop_proc)
 end
 
 local function request_current(buf, request_id)
-  return data_for(buf).request_id == request_id
-end
-
-local function line_positions(buf)
-  local lines = data_for(buf).lines or {}
-  local positions = {}
-  for lnum, line in ipairs(lines) do
-    if line.check ~= nil then
-      positions[#positions + 1] = lnum
-    end
-  end
-  return positions
+  return buf_lifecycle.request_current(buf_data, buf, request_id)
 end
 
 local function jump(buf, dir)
-  local positions = line_positions(buf)
-  if #positions == 0 then
-    return
-  end
-  local current = vim.api.nvim_win_get_cursor(0)[1]
-  if dir > 0 then
-    for _, lnum in ipairs(positions) do
-      if lnum > current then
-        vim.api.nvim_win_set_cursor(0, { lnum, 0 })
-        return
-      end
-    end
-    vim.api.nvim_win_set_cursor(0, { positions[1], 0 })
-    return
-  end
-  for i = #positions, 1, -1 do
-    if positions[i] < current then
-      vim.api.nvim_win_set_cursor(0, { positions[i], 0 })
-      return
-    end
-  end
-  vim.api.nvim_win_set_cursor(0, { positions[#positions], 0 })
+  local positions = buf_lifecycle.line_positions(data_for(buf).lines, 'check')
+  buf_lifecycle.jump_positions(positions, dir, true)
 end
 
 ---@param buf integer
 ---@return forge.Check?
 local function current_check(buf)
-  local line = vim.api.nvim_win_get_cursor(0)[1]
-  local lines = data_for(buf).lines or {}
-  local entry = lines[line]
-  return entry and entry.check or nil
+  return buf_lifecycle.current_line_value(data_for(buf).lines, 'check')
 end
 
 ---@param check forge.Check
@@ -221,26 +159,7 @@ end
 ---@param buf integer
 ---@param lines forge.PRChecksLine[]
 local function render(buf, lines)
-  vim.bo[buf].modifiable = true
-  vim.api.nvim_buf_set_lines(
-    buf,
-    0,
-    -1,
-    false,
-    vim.tbl_map(function(line)
-      return line.text
-    end, lines)
-  )
-  vim.bo[buf].modifiable = false
-  vim.api.nvim_buf_clear_namespace(buf, ns, 0, -1)
-  for lnum, line in ipairs(lines) do
-    for _, hl in ipairs(line.highlights or {}) do
-      vim.api.nvim_buf_set_extmark(buf, ns, lnum - 1, hl.col, {
-        end_col = hl.end_col,
-        hl_group = hl.group,
-      })
-    end
-  end
+  buf_lifecycle.render_simple(buf, ns, lines)
   set_data(buf, { lines = lines })
 end
 
@@ -372,48 +291,20 @@ end
 ---@param reuse_buf integer?
 ---@return integer, boolean
 local function prepare_buf(pr, reuse_buf)
-  local name = bufname(pr)
-  local buf
-  local reusing = false
-  if reuse_buf and vim.api.nvim_buf_is_valid(reuse_buf) then
-    buf = reuse_buf
-    reusing = true
-  else
-    local existing = name and vim.fn.bufnr(name) or -1
-    if existing ~= -1 and vim.api.nvim_buf_is_valid(existing) then
-      buf = existing
-      reusing = true
-      local wins = vim.fn.win_findbuf(buf)
-      if #wins == 0 then
-        local cfg = config_mod.config()
-        local split = cfg.ci.split or cfg.split
-        local prefix = split == 'vertical' and 'vertical' or 'botright'
-        vim.cmd('noautocmd ' .. prefix .. ' sbuffer ' .. buf)
-      end
-    else
-      local cfg = config_mod.config()
-      local split = cfg.ci.split or cfg.split
-      local prefix = split == 'vertical' and 'vertical' or 'botright'
-      vim.cmd('noautocmd ' .. prefix .. ' new')
-      buf = vim.api.nvim_get_current_buf()
-      vim.bo[buf].buftype = 'nofile'
-      vim.bo[buf].bufhidden = 'wipe'
-      vim.bo[buf].swapfile = false
-      vim.bo[buf].modifiable = false
-      if name then
-        vim.api.nvim_buf_set_name(buf, name)
-      end
-      vim.api.nvim_create_autocmd('BufWipeout', {
-        buffer = buf,
-        callback = function()
-          stop_proc(buf)
-          buf_data[buf] = nil
-        end,
-      })
-    end
-  end
-  vim.bo[buf].filetype = 'forgelist'
-  set_public_buffer_state(buf, 'pr_checks', scope_mod.subject_web_url('pr', pr.num, pr.scope))
+  local cfg = config_mod.config()
+  local split = cfg.ci.split or cfg.split
+  local buf, reusing = buf_lifecycle.prepare_buf({
+    bufname = bufname(pr),
+    reuse_buf = reuse_buf,
+    split = split,
+    filetype = 'forgelist',
+    kind = 'pr_checks',
+    url = scope_mod.subject_web_url('pr', pr.num, pr.scope),
+    on_wipeout = function(wiped)
+      stop_proc(wiped)
+      buf_data[wiped] = nil
+    end,
+  })
   if not reusing then
     render(buf, render_placeholder('Loading...', 'ForgeDim'))
   end


### PR DESCRIPTION
## Problem

`lua/forge/log.lua`, `lua/forge/ci_history.lua`, and `lua/forge/pr_checks.lua` still each carried their own small request, buffer-state, and row-navigation lifecycle stack.

## Solution

Extract those shared mechanics into `forge.buf_lifecycle` and rewire the three CI surfaces onto it while keeping their existing buffer behavior intact.

Closes #531