### PR TITLE
refactor(core): stop routing internal calls through forge root

### DIFF
--- a/lua/forge/cmd.lua
+++ b/lua/forge/cmd.lua
@@ -246,7 +246,7 @@ end
 local function subject_error(family, verb, missing)
   if family == 'pr' then
     if verb == 'edit' then
-      local f = require('forge').detect()
+      local f = detect.detect()
       return ('missing %s number'):format((f and f.labels and f.labels.pr_one) or 'PR')
     end
     return missing and 'missing argument' or 'too many arguments'
@@ -256,7 +256,7 @@ local function subject_error(family, verb, missing)
   end
   if family == 'review' then
     if missing then
-      local f = require('forge').detect()
+      local f = detect.detect()
       return ('missing %s number'):format((f and f.labels and f.labels.pr_one) or 'PR')
     end
     return 'too many arguments'
@@ -577,7 +577,7 @@ function M.parse(args, opts)
   if subject_pattern then
     local subject_label
     if subject.kind == 'pr' then
-      local f = require('forge').detect()
+      local f = detect.detect()
       subject_label = ((f and f.labels and f.labels.pr_one) or 'PR') .. ' number'
     elseif subject.kind == 'issue' then
       subject_label = 'issue number'

--- a/lua/forge/cmd_complete.lua
+++ b/lua/forge/cmd_complete.lua
@@ -3,6 +3,10 @@ local M = {}
 local collections = require('forge.collections')
 local detect = require('forge.detect')
 local source_mod = require('forge.cmd_complete_source')
+local issue_mod = require('forge.issue')
+local pr_mod = require('forge.pr')
+local resolve_mod = require('forge.resolve')
+local review_mod = require('forge.review')
 local state_mod = require('forge.state')
 
 ---@param command forge.Command
@@ -115,8 +119,7 @@ end
 ---@param state forge.CommandCompletionState
 ---@return forge.PRCompletionTarget?
 local function implicit_pr_completion_target(state)
-  local forge_mod = require('forge')
-  local f = forge_mod.detect()
+  local f = detect.detect()
   if not f then
     return nil
   end
@@ -128,7 +131,7 @@ local function implicit_pr_completion_target(state)
   local pr
   ---@type forge.CmdError?
   local err
-  pr, err = forge_mod.current_pr(opts)
+  pr, err = pr_mod.current_pr(opts)
   if err then
     return nil
   end
@@ -140,7 +143,7 @@ local function implicit_pr_completion_target(state)
       entry = pr_completion_entry(pr, state_name or 'OPEN', pr_state),
     }
   end
-  pr, err = require('forge.resolve').branch_pr(opts, {
+  pr, err = resolve_mod.branch_pr(opts, {
     searches = { { 'closed' } },
   })
   if err then
@@ -152,7 +155,7 @@ local function implicit_pr_completion_target(state)
       entry = pr_completion_entry(pr, 'CLOSED'),
     }
   end
-  pr, err = require('forge.resolve').branch_pr(opts, {
+  pr, err = resolve_mod.branch_pr(opts, {
     searches = { { 'merged' } },
   })
   if err then
@@ -174,8 +177,7 @@ local function merge_method_completion_target(command, state)
   if command.family ~= 'pr' or command.name ~= 'merge' then
     return nil
   end
-  local forge_mod = require('forge')
-  local f = forge_mod.detect()
+  local f = detect.detect()
   if not f then
     return nil
   end
@@ -193,7 +195,7 @@ local function merge_method_completion_target(command, state)
       entry = pr_completion_entry({ num = num, scope = scope }, state_name or 'OPEN', pr_state),
     }
   end
-  local pr, err = forge_mod.current_pr(opts)
+  local pr, err = pr_mod.current_pr(opts)
   if err or not pr then
     return nil
   end
@@ -235,12 +237,11 @@ end
 ---@param policy table
 ---@return string[]
 local function complete_pr_subjects(command, state, prefix, policy)
-  local f, forge_mod, scope = source_mod.forge(state)
-  if not f or not forge_mod then
+  local f, scope = source_mod.forge(state)
+  if not f then
     return {}
   end
-  local prs =
-    source_mod.list(forge_mod, f, 'pr', policy.states_to_consult, policy.fetch_state, scope)
+  local prs = source_mod.list(f, 'pr', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.pr_fields or {}
   local number_field = fields.number
   local state_field = fields.state
@@ -268,12 +269,11 @@ end
 ---@param policy table
 ---@return string[]
 local function complete_issue_subjects(command, state, prefix, policy)
-  local f, forge_mod, scope = source_mod.forge(state)
-  if not f or not forge_mod then
+  local f, scope = source_mod.forge(state)
+  if not f then
     return {}
   end
-  local issues =
-    source_mod.list(forge_mod, f, 'issue', policy.states_to_consult, policy.fetch_state, scope)
+  local issues = source_mod.list(f, 'issue', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.issue_fields or {}
   local items = {}
   local seen = {}
@@ -296,12 +296,11 @@ end
 ---@param policy table
 ---@return string[]
 local function complete_run_subjects(state, prefix, policy)
-  local f, forge_mod, scope = source_mod.forge(state)
-  if not f or not forge_mod then
+  local f, scope = source_mod.forge(state)
+  if not f then
     return {}
   end
-  local runs =
-    source_mod.list(forge_mod, f, 'ci', policy.states_to_consult, policy.fetch_state, scope)
+  local runs = source_mod.list(f, 'ci', policy.states_to_consult, policy.fetch_state, scope)
   local items = {}
   local seen = {}
   for _, run in ipairs(runs or {}) do
@@ -315,12 +314,11 @@ end
 ---@param policy table
 ---@return string[]
 local function complete_release_subjects(state, prefix, policy)
-  local f, forge_mod, scope = source_mod.forge(state)
-  if not f or not forge_mod then
+  local f, scope = source_mod.forge(state)
+  if not f then
     return {}
   end
-  local releases =
-    source_mod.list(forge_mod, f, 'release', policy.states_to_consult, policy.fetch_state, scope)
+  local releases = source_mod.list(f, 'release', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.release_fields or {}
   local items = {}
   local seen = {}
@@ -355,10 +353,10 @@ local function completion_values(cmd_mod, command, state, flag_name, prefix)
     return source_mod.target_values(prefix or '')
   end
   if policy.source == 'template' then
-    return source_mod.filter(require('forge').template_slugs(), prefix or '')
+    return source_mod.filter(issue_mod.template_slugs(), prefix or '')
   end
   if policy.source == 'adapter' then
-    return source_mod.filter(require('forge').review_adapter_names(), prefix or '')
+    return source_mod.filter(review_mod.names(), prefix or '')
   end
   if policy.source == 'available_merge_methods' then
     local target = merge_method_completion_target(command, state)

--- a/lua/forge/cmd_complete.lua
+++ b/lua/forge/cmd_complete.lua
@@ -2,11 +2,11 @@ local M = {}
 
 local collections = require('forge.collections')
 local detect = require('forge.detect')
-local source_mod = require('forge.cmd_complete_source')
 local issue_mod = require('forge.issue')
 local pr_mod = require('forge.pr')
 local resolve_mod = require('forge.resolve')
 local review_mod = require('forge.review')
+local source_mod = require('forge.cmd_complete_source')
 local state_mod = require('forge.state')
 
 ---@param command forge.Command
@@ -318,7 +318,8 @@ local function complete_release_subjects(state, prefix, policy)
   if not f then
     return {}
   end
-  local releases = source_mod.list(f, 'release', policy.states_to_consult, policy.fetch_state, scope)
+  local releases =
+    source_mod.list(f, 'release', policy.states_to_consult, policy.fetch_state, scope)
   local fields = f.release_fields or {}
   local items = {}
   local seen = {}

--- a/lua/forge/cmd_complete_source.lua
+++ b/lua/forge/cmd_complete_source.lua
@@ -1,5 +1,8 @@
 local M = {}
 
+local config_mod = require('forge.config')
+local detect_mod = require('forge.detect')
+local repo_mod = require('forge.repo')
 local state_mod = require('forge.state')
 local target_mod = require('forge.target')
 
@@ -71,21 +74,16 @@ local function json_list(cmd)
   return data
 end
 
----@param forge_mod table
 ---@param scope forge.Scope?
 ---@return string
-local function completion_scope_key(forge_mod, scope)
-  if type(forge_mod.scope_key) == 'function' then
-    return forge_mod.scope_key(scope)
-  end
-  return ''
+local function completion_scope_key(scope)
+  return repo_mod.scope_key(scope)
 end
 
----@param forge_mod table
 ---@param kind string
 ---@return integer
-local function completion_limit(forge_mod, kind)
-  local cfg = type(forge_mod.config) == 'function' and forge_mod.config() or nil
+local function completion_limit(kind)
+  local cfg = config_mod.config()
   local display = type(cfg) == 'table' and cfg.display or nil
   local limits = type(display) == 'table' and display.limits or nil
   if kind == 'pr' then
@@ -103,11 +101,10 @@ local function completion_limit(forge_mod, kind)
   return 50
 end
 
----@param forge_mod table
 ---@param f forge.Forge
 ---@param state forge.CommandCompletionState
 ---@return forge.Scope?
-local function completion_scope(forge_mod, f, state)
+local function completion_scope(f, state)
   local repo = state.modifiers.repo
   if type(repo) == 'string' and repo ~= '' then
     local resolved = target_mod.resolve_repo(repo, target_parse_opts())
@@ -115,31 +112,26 @@ local function completion_scope(forge_mod, f, state)
       return target_mod.repo_scope(resolved, f.name)
     end
   end
-  if type(forge_mod.current_scope) == 'function' then
-    return forge_mod.current_scope(f.name)
-  end
-  return nil
+  return repo_mod.current_scope(f.name)
 end
 
----@param forge_mod table
 ---@param kind string
 ---@param state string
 ---@param scope forge.Scope?
 ---@return string
-local function completion_list_key(forge_mod, kind, state, scope)
-  return state_mod.list_key(kind, scoped_id(state, completion_scope_key(forge_mod, scope)))
+local function completion_list_key(kind, state, scope)
+  return state_mod.list_key(kind, scoped_id(state, completion_scope_key(scope)))
 end
 
----@param forge_mod table
 ---@param kind string
 ---@param states string[]
 ---@param scope forge.Scope?
 ---@return table[]?
-local function cached_completion_list(forge_mod, kind, states, scope)
+local function cached_completion_list(kind, states, scope)
   local items = {}
   local found = false
   for _, state in ipairs(states) do
-    local cached = state_mod.get_list(completion_list_key(forge_mod, kind, state, scope))
+    local cached = state_mod.get_list(completion_list_key(kind, state, scope))
     if type(cached) == 'table' then
       found = true
       for _, item in ipairs(cached) do
@@ -153,14 +145,13 @@ local function cached_completion_list(forge_mod, kind, states, scope)
   return nil
 end
 
----@param forge_mod table
 ---@param f forge.Forge
 ---@param kind string
 ---@param state string
 ---@param scope forge.Scope?
 ---@return table[]
-local function fetch_completion_list(forge_mod, f, kind, state, scope)
-  local limit = completion_limit(forge_mod, kind)
+local function fetch_completion_list(f, kind, state, scope)
+  local limit = completion_limit(kind)
   local cmd = nil
   if kind == 'pr' and type(f.list_pr_json_cmd) == 'function' then
     cmd = f:list_pr_json_cmd(state, limit, scope)
@@ -182,7 +173,7 @@ local function fetch_completion_list(forge_mod, f, kind, state, scope)
     end
     data = normalized
   end
-  state_mod.set_list(completion_list_key(forge_mod, kind, state, scope), data)
+  state_mod.set_list(completion_list_key(kind, state, scope), data)
   return data
 end
 
@@ -310,29 +301,24 @@ function M.target_values(prefix)
 end
 
 ---@param state forge.CommandCompletionState
----@return forge.Forge?, table?, forge.Scope?
+---@return forge.Forge?, forge.Scope?
 function M.forge(state)
-  local ok, forge_mod = pcall(require, 'forge')
-  if not ok or type(forge_mod) ~= 'table' or type(forge_mod.detect) ~= 'function' then
-    return nil, nil, nil
-  end
-  local f = forge_mod.detect()
+  local f = detect_mod.detect()
   if not f then
-    return nil, forge_mod, nil
+    return nil, nil
   end
-  return f, forge_mod, completion_scope(forge_mod, f, state)
+  return f, completion_scope(f, state)
 end
 
----@param forge_mod table
 ---@param f forge.Forge
 ---@param kind string
 ---@param states string[]
 ---@param fetch_state string?
 ---@param scope forge.Scope?
 ---@return table[]
-function M.list(forge_mod, f, kind, states, fetch_state, scope)
-  return cached_completion_list(forge_mod, kind, states, scope)
-    or fetch_completion_list(forge_mod, f, kind, fetch_state or states[1], scope)
+function M.list(f, kind, states, fetch_state, scope)
+  return cached_completion_list(kind, states, scope)
+    or fetch_completion_list(f, kind, fetch_state or states[1], scope)
 end
 
 ---@param value string?

--- a/lua/forge/cmd_dispatch.lua
+++ b/lua/forge/cmd_dispatch.lua
@@ -1,8 +1,13 @@
 local M = {}
 
+local action_target_mod = require('forge.action_target')
+local issue_mod = require('forge.issue')
 local log = require('forge.logger')
 local ops = require('forge.ops')
+local pr_mod = require('forge.pr')
+local repo_mod = require('forge.repo')
 local resolve_mod = require('forge.cmd_resolve')
+local routes_mod = require('forge.routes')
 local state_mod = require('forge.state')
 
 ---@param command forge.Command
@@ -10,13 +15,13 @@ local function dispatch_pr(command)
   if not resolve_mod.require_git_or_warn() then
     return
   end
-  local f, forge_mod = resolve_mod.require_forge_or_warn()
-  if not f or not forge_mod then
+  local f = resolve_mod.require_forge_or_warn()
+  if not f then
     return
   end
   local num = command.subjects[1]
   if command.name == 'create' then
-    forge_mod.create_pr(resolve_mod.create_pr_opts(command, f.name))
+    pr_mod.create_pr(resolve_mod.create_pr_opts(command, f.name))
     return
   end
   if command.name == 'open' then
@@ -160,14 +165,14 @@ local function dispatch_issue(command)
   if not resolve_mod.require_git_or_warn() then
     return
   end
-  local f, forge_mod = resolve_mod.require_forge_or_warn()
-  if not f or not forge_mod then
+  local f = resolve_mod.require_forge_or_warn()
+  if not f then
     return
   end
   local num = command.subjects[1]
   local scope = resolve_mod.resolve_repo_modifier(command, f.name)
   if command.name == 'create' then
-    forge_mod.create_issue(resolve_mod.create_issue_opts(command, f.name))
+    issue_mod.create_issue(resolve_mod.create_issue_opts(command, f.name))
     return
   end
   if command.name == 'browse' then
@@ -204,7 +209,7 @@ local function dispatch_ci(command)
     return
   end
   if command.name == 'open' and command.subjects[1] == nil then
-    require('forge').ci({
+    action_target_mod.ci({
       repo = command.parsed_modifiers.repo,
       head = command.parsed_modifiers.head,
     })
@@ -271,8 +276,8 @@ local function dispatch_browse(command)
   if not resolve_mod.require_git_or_warn() then
     return
   end
-  local f, forge_mod = resolve_mod.require_forge_or_warn()
-  if not f or not forge_mod then
+  local f = resolve_mod.require_forge_or_warn()
+  if not f then
     return
   end
   local scope = resolve_mod.resolve_scope_modifier(command, f.name)
@@ -289,7 +294,7 @@ local function dispatch_browse(command)
       branch = explicit_branch and explicit_branch.branch or nil
     end
     if not branch then
-      local ctx = forge_mod.current_context()
+      local ctx = routes_mod.current_context()
       branch = type(ctx) == 'table' and ctx.branch or nil
     end
     if ops.browse_location(f, location, scope, branch) then
@@ -300,19 +305,19 @@ local function dispatch_browse(command)
   end
   local commit = command.parsed_modifiers.commit
   if commit and commit.commit then
-    forge_mod.open('browse.commit', { commit = commit.commit, scope = scope })
+    routes_mod.open('browse.commit', { commit = commit.commit, scope = scope })
     return
   end
   local branch = command.parsed_modifiers.branch
-  local file_loc = forge_mod.file_loc(command.range)
+  local file_loc = repo_mod.file_loc(command.range)
   if branch and branch.branch then
     if ops.browse_file(f, file_loc, branch.branch, scope) then
       return
     end
-    forge_mod.open('browse.branch', { branch = branch.branch, scope = scope })
+    routes_mod.open('browse.branch', { branch = branch.branch, scope = scope })
     return
   end
-  local ctx = forge_mod.current_context()
+  local ctx = routes_mod.current_context()
   local ctx_branch = type(ctx) == 'table' and ctx.branch or nil
   if ops.browse_file(f, file_loc, ctx_branch, scope) then
     return

--- a/lua/forge/cmd_resolve.lua
+++ b/lua/forge/cmd_resolve.lua
@@ -1,6 +1,9 @@
 local M = {}
 
+local detect_mod = require('forge.detect')
 local log = require('forge.logger')
+local pr_mod = require('forge.pr')
+local resolve_api = require('forge.resolve')
 local target_mod = require('forge.target')
 
 ---@return forge.TargetParseOpts
@@ -24,15 +27,14 @@ function M.require_git_or_warn()
   return true
 end
 
----@return forge.Forge?, table?
+---@return forge.Forge?
 function M.require_forge_or_warn()
-  local forge_mod = require('forge')
-  local f = forge_mod.detect()
+  local f = detect_mod.detect()
   if not f then
     log.warn('no forge detected')
-    return nil, forge_mod
+    return nil
   end
-  return f, forge_mod
+  return f
 end
 
 ---@param command forge.Command
@@ -80,7 +82,7 @@ end
 ---@param f forge.Forge
 ---@return forge.PRRef?
 function M.resolve_current_pr_or_warn(command, f)
-  local pr, err = require('forge').current_pr(M.current_pr_resolution_opts(command, f))
+  local pr, err = pr_mod.current_pr(M.current_pr_resolution_opts(command, f))
   if err then
     log.warn(err.message)
     return nil
@@ -98,8 +100,7 @@ end
 ---@param no_match string
 ---@return forge.PRRef?
 function M.resolve_branch_pr_or_warn(command, f, policy, no_match)
-  local pr, err =
-    require('forge.resolve').branch_pr(M.current_pr_resolution_opts(command, f), policy)
+  local pr, err = resolve_api.branch_pr(M.current_pr_resolution_opts(command, f), policy)
   if err then
     log.warn(err.message)
     return nil

--- a/lua/forge/health.lua
+++ b/lua/forge/health.lua
@@ -1,5 +1,9 @@
 local M = {}
 
+local config_mod = require('forge.config')
+local detect_mod = require('forge.detect')
+local review_mod = require('forge.review')
+
 local function codediff_status()
   if vim.fn.exists(':CodeDiff') ~= 2 then
     return false, false
@@ -72,10 +76,9 @@ function M.check()
     vim.health.error('tree-sitter yaml parser not found (required for YAML issue form templates)')
   end
 
-  local forge_mod = require('forge')
-  local configured_adapter = vim.trim((((forge_mod.config() or {}).review or {}).adapter or ''))
+  local configured_adapter = vim.trim((((config_mod.config() or {}).review or {}).adapter or ''))
   local review_names = {}
-  for _, name in ipairs((forge_mod.review_adapter_names and forge_mod.review_adapter_names()) or {}) do
+  for _, name in ipairs(review_mod.names()) do
     review_names[name] = true
   end
 
@@ -125,7 +128,7 @@ function M.check()
   end
 
   vim.health.start('Registered sources')
-  for name, source in pairs(forge_mod.registered_sources()) do
+  for name, source in pairs(detect_mod.registered_sources()) do
     if name ~= 'github' and name ~= 'gitlab' and name ~= 'codeberg' then
       if vim.fn.executable(source.cli) == 1 then
         vim.health.ok(source.cli .. ' found (custom: ' .. name .. ')')

--- a/lua/forge/picker/checks.lua
+++ b/lua/forge/picker/checks.lua
@@ -1,3 +1,4 @@
+local format_mod = require('forge.format')
 local log = require('forge.logger')
 local picker = require('forge.picker')
 local picker_session = require('forge.picker.session')
@@ -41,10 +42,9 @@ local check_openable = picker_shared.check_openable
 function M.pick(f, num, filter, cached_checks, opts)
   opts = opts or {}
   filter = filter or 'all'
-  local forge_mod = require('forge')
   local ref = scoped_forge_ref(f, opts.scope)
   local current_checks = cached_checks
-  local request_key = state_mod.list_key('check', scoped_id(num, scoped_key(forge_mod, ref)))
+  local request_key = state_mod.list_key('check', scoped_id(num, scoped_key(ref)))
   local labels = {
     all = 'all',
     fail = 'failed',
@@ -69,10 +69,10 @@ function M.pick(f, num, filter, cached_checks, opts)
   end
 
   local function build_check_entries(checks)
-    local filtered = forge_mod.filter_checks(checks, filter)
+    local filtered = format_mod.filter_checks(checks, filter)
     local count = #filtered
     local rows_for = cached_rows(function(width)
-      return forge_mod.format_checks(filtered, { width = width })
+      return format_mod.format_checks(filtered, { width = width })
     end)
     local displays = rows_for()
     local entries = {}

--- a/lua/forge/picker/ci.lua
+++ b/lua/forge/picker/ci.lua
@@ -1,4 +1,6 @@
 local ci = require('forge.ci')
+local config_mod = require('forge.config')
+local format_mod = require('forge.format')
 local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker = require('forge.picker')
@@ -48,13 +50,11 @@ local expanded_limit = picker_shared.expanded_limit
 function M.pick(f, branch, filter, opts)
   opts = opts or {}
   filter = filter or 'all'
-  local forge_mod = require('forge')
-  local limits = limit_settings(forge_mod.config().display.limits.runs, opts.limit)
+  local limits = limit_settings(config_mod.config().display.limits.runs, opts.limit)
   local limit_step = limits.step
   local visible_limit = limits.visible
   local ref = scoped_forge_ref(f, opts.scope)
-  local request_key =
-    state_mod.list_key('ci', scoped_id(branch or 'all', scoped_key(forge_mod, ref)))
+  local request_key = state_mod.list_key('ci', scoped_id(branch or 'all', scoped_key(ref)))
   local labels = {
     all = 'all',
     fail = 'failed',
@@ -104,13 +104,13 @@ function M.pick(f, branch, filter, opts)
       table.insert(normalized, run)
     end
     local has_more = #normalized > limit
-    local filtered = forge_mod.filter_runs(normalized, filter)
+    local filtered = format_mod.filter_runs(normalized, filter)
     if #filtered > limit then
       filtered = vim.list_slice(filtered, 1, limit)
     end
     local count = #filtered
     local rows_for = cached_rows(function(width)
-      return forge_mod.format_runs(filtered, { width = width })
+      return format_mod.format_runs(filtered, { width = width })
     end)
     local displays = rows_for()
 

--- a/lua/forge/picker/issue.lua
+++ b/lua/forge/picker/issue.lua
@@ -1,3 +1,6 @@
+local config_mod = require('forge.config')
+local format_mod = require('forge.format')
+local issue_mod = require('forge.issue')
 local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker = require('forge.picker')
@@ -44,15 +47,14 @@ function M.pick(state, f, opts)
   opts = opts or {}
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
   local state_label = ({ all = 'All', open = 'Open', closed = 'Closed' })[state] or state
-  local forge_mod = require('forge')
-  local cfg = forge_mod.config()
+  local cfg = config_mod.config()
   local limits = limit_settings(cfg.display.limits.issues, opts.limit)
   local limit_step = limits.step
   local visible_limit = limits.visible
   local fetch_limit = limits.fetch
   local use_cache = limits.use_cache
   local ref = scoped_forge_ref(f, opts.scope)
-  local scope_suffix = scoped_key(forge_mod, ref)
+  local scope_suffix = scoped_key(ref)
   local cache_key = scoped_list_key('issue', state, scope_suffix)
   local issue_fields = f.issue_fields
   local num_field = issue_fields.number
@@ -76,7 +78,7 @@ function M.pick(state, f, opts)
     local state_field = issue_fields.state
     local entries = {}
     local rows_for = cached_rows(function(width)
-      return forge_mod.format_issues(issues, issue_fields, issue_show_state, { width = width })
+      return format_mod.format_issues(issues, issue_fields, issue_show_state, { width = width })
     end)
     local displays = rows_for()
     for i, issue in ipairs(issues) do
@@ -356,7 +358,7 @@ function M.pick(state, f, opts)
       name = 'create',
       label = 'create',
       fn = function()
-        forge_mod.create_issue({ back = opts.back, scope = ref })
+        issue_mod.create_issue({ back = opts.back, scope = ref })
       end,
     },
     {

--- a/lua/forge/picker/pr.lua
+++ b/lua/forge/picker/pr.lua
@@ -1,9 +1,12 @@
 local availability = require('forge.availability')
+local config_mod = require('forge.config')
+local format_mod = require('forge.format')
 local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker = require('forge.picker')
 local picker_session = require('forge.picker.session')
 local picker_shared = require('forge.picker.shared')
+local pr_mod = require('forge.pr')
 local state_mod = require('forge.state')
 local surface_policy = require('forge.surface_policy')
 
@@ -54,15 +57,14 @@ function M.pick(state, f, opts)
   opts = opts or {}
   local next_state = ({ all = 'open', open = 'closed', closed = 'all' })[state]
   local state_label = ({ all = 'All', open = 'Open', closed = 'Closed' })[state] or state
-  local forge_mod = require('forge')
-  local cfg = forge_mod.config()
+  local cfg = config_mod.config()
   local limits = limit_settings(cfg.display.limits.pulls, opts.limit)
   local limit_step = limits.step
   local visible_limit = limits.visible
   local fetch_limit = limits.fetch
   local use_cache = limits.use_cache
   local ref = scoped_forge_ref(f, opts.scope)
-  local scope_suffix = scoped_key(forge_mod, ref)
+  local scope_suffix = scoped_key(ref)
   local cache_key = scoped_list_key('pr', state, scope_suffix)
   local pr_fields = f.pr_fields
   local num_field = pr_fields.number
@@ -85,7 +87,7 @@ function M.pick(state, f, opts)
     end
     local entries = {}
     local rows_for = cached_rows(function(width)
-      return forge_mod.format_prs(prs, pr_fields, show_state, { width = width })
+      return format_mod.format_prs(prs, pr_fields, show_state, { width = width })
     end)
     local displays = rows_for()
     for i, pr in ipairs(prs) do
@@ -524,7 +526,7 @@ function M.pick(state, f, opts)
       label = 'create',
       available = pr_create_visible,
       fn = function()
-        forge_mod.create_pr({ back = opts.back, scope = ref })
+        pr_mod.create_pr({ back = opts.back, scope = ref })
       end,
     },
     {

--- a/lua/forge/picker/release.lua
+++ b/lua/forge/picker/release.lua
@@ -1,8 +1,11 @@
+local config_mod = require('forge.config')
+local format_mod = require('forge.format')
 local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker = require('forge.picker')
 local picker_session = require('forge.picker.session')
 local picker_shared = require('forge.picker.shared')
+local repo_mod = require('forge.repo')
 local state_mod = require('forge.state')
 
 local M = {}
@@ -35,13 +38,12 @@ local remove_list_row = picker_shared.remove_list_row
 ---@param opts? forge.PickerLimitOpts
 function M.pick(state, f, opts)
   opts = opts or {}
-  local forge_mod = require('forge')
-  local limits = limit_settings(forge_mod.config().display.limits.releases, opts.limit)
+  local limits = limit_settings(config_mod.config().display.limits.releases, opts.limit)
   local limit_step = limits.step
   local visible_limit = limits.visible
   local fetch_limit = limits.fetch
   local ref = scoped_forge_ref(f, opts.scope)
-  local cache_key = state_mod.list_key('release', scoped_id('list', scoped_key(forge_mod, ref)))
+  local cache_key = state_mod.list_key('release', scoped_id('list', scoped_key(ref)))
   local rel_fields = f.release_fields
   local next_state = ({ all = 'draft', draft = 'prerelease', prerelease = 'all' })[state]
   local title = ({ all = 'Releases', draft = 'Draft Releases', prerelease = 'Pre-releases' })[state]
@@ -108,7 +110,7 @@ function M.pick(state, f, opts)
     end
     local entries = {}
     local rows_for = cached_rows(function(width)
-      return forge_mod.format_releases(filtered, rel_fields, { width = width })
+      return format_mod.format_releases(filtered, rel_fields, { width = width })
     end)
     local displays = rows_for()
     for i, rel in ipairs(filtered) do
@@ -240,7 +242,7 @@ function M.pick(state, f, opts)
       close = false,
       fn = function(entry)
         if entry and not entry.load_more then
-          local base = forge_mod.remote_web_url(entry.value.scope)
+          local base = repo_mod.remote_web_url(entry.value.scope)
           local tag = entry.value.tag
           local url = base .. '/releases/tag/' .. tag
           set_clipboard(url)

--- a/lua/forge/picker/shared.lua
+++ b/lua/forge/picker/shared.lua
@@ -2,6 +2,7 @@ local layout = require('forge.layout')
 local log = require('forge.logger')
 local ops = require('forge.ops')
 local picker_session = require('forge.picker.session')
+local repo_mod = require('forge.repo')
 local state_mod = require('forge.state')
 local surface_policy = require('forge.surface_policy')
 
@@ -89,18 +90,11 @@ local function scoped_forge_ref(f, ref)
   if ref then
     return ref
   end
-  local forge_mod = require('forge')
-  if forge_mod.current_scope then
-    return forge_mod.current_scope(f.name)
-  end
-  return nil
+  return repo_mod.current_scope(f.name)
 end
 
-local function scoped_key(forge_mod, ref)
-  if forge_mod.scope_key then
-    return forge_mod.scope_key(ref)
-  end
-  return ''
+local function scoped_key(ref)
+  return repo_mod.scope_key(ref)
 end
 
 local function scoped_id(id, suffix)

--- a/lua/forge/pickers.lua
+++ b/lua/forge/pickers.lua
@@ -2,6 +2,7 @@ local M = {}
 
 local ops = require('forge.ops')
 local picker_shared = require('forge.picker.shared')
+local routes_mod = require('forge.routes')
 
 local normalize_pr_ref = picker_shared.normalize_pr_ref
 local pr_action_fns = picker_shared.pr_action_fns
@@ -80,7 +81,7 @@ function M.pr_actions(f, pr)
 end
 
 function M.git()
-  require('forge').open()
+  routes_mod.open()
 end
 
 return M

--- a/spec/cmd_spec.lua
+++ b/spec/cmd_spec.lua
@@ -1,13 +1,16 @@
 vim.opt.runtimepath:prepend(vim.fn.getcwd())
 
 describe('command schema', function()
-  local cmd = require('forge.cmd')
+  local cmd
   local old_system
   local old_preload
 
   before_each(function()
     old_system = vim.system
-    old_preload = package.preload['forge']
+    old_preload = {
+      ['forge'] = package.preload['forge'],
+      ['forge.detect'] = package.preload['forge.detect'],
+    }
 
     vim.system = function(cmdline)
       local key = table.concat(cmdline, ' ')
@@ -57,15 +60,34 @@ describe('command schema', function()
         end,
       }
     end
+    package.preload['forge.detect'] = function()
+      return {
+        detect = function()
+          local forge = require('forge')
+          return forge.detect and forge.detect() or nil
+        end,
+        forge_name = function()
+          local forge = require('forge')
+          local detected = forge.detect and forge.detect() or nil
+          return type(detected) == 'table' and detected.name or nil
+        end,
+      }
+    end
 
     package.loaded['forge'] = nil
+    package.loaded['forge.detect'] = nil
+    package.loaded['forge.cmd'] = nil
     package.loaded['forge.target'] = nil
+    cmd = require('forge.cmd')
   end)
 
   after_each(function()
     vim.system = old_system
-    package.preload['forge'] = old_preload
+    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.detect'] = old_preload['forge.detect']
     package.loaded['forge'] = nil
+    package.loaded['forge.detect'] = nil
+    package.loaded['forge.cmd'] = nil
     package.loaded['forge.target'] = nil
   end)
 

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -475,6 +475,10 @@ describe(':Forge command', function()
     package.preload['forge.detect'] = function()
       return {
         detect = require('forge').detect,
+        forge_name = function()
+          local detected = require('forge').detect()
+          return type(detected) == 'table' and detected.name or nil
+        end,
       }
     end
     package.preload['forge.issue'] = function()

--- a/spec/command_spec.lua
+++ b/spec/command_spec.lua
@@ -3,6 +3,14 @@ vim.opt.runtimepath:prepend(vim.fn.getcwd())
 local helpers = dofile(vim.fn.getcwd() .. '/spec/helpers.lua')
 
 local preload_modules = {
+  'forge.action_target',
+  'forge.config',
+  'forge.detect',
+  'forge.issue',
+  'forge.pr',
+  'forge.repo',
+  'forge.review',
+  'forge.routes',
   'forge.state',
   'forge',
   'forge.logger',
@@ -12,18 +20,26 @@ local preload_modules = {
 }
 
 local loaded_modules = {
+  'forge.action_target',
   'forge.availability',
   'forge.completion_policy',
   'forge',
+  'forge.config',
   'forge.cmd',
   'forge.cmd_complete',
   'forge.cmd_complete_source',
   'forge.cmd_dispatch',
   'forge.cmd_resolve',
+  'forge.detect',
+  'forge.issue',
   'forge.logger',
   'forge.ops',
   'forge.pickers',
+  'forge.pr',
+  'forge.repo',
+  'forge.review',
   'forge.resolve',
+  'forge.routes',
   'forge.state',
 }
 
@@ -444,6 +460,52 @@ describe(':Forge command', function()
           end
           return adapters
         end,
+      }
+    end
+    package.preload['forge.action_target'] = function()
+      return {
+        ci = require('forge').ci,
+      }
+    end
+    package.preload['forge.config'] = function()
+      return {
+        config = require('forge').config,
+      }
+    end
+    package.preload['forge.detect'] = function()
+      return {
+        detect = require('forge').detect,
+      }
+    end
+    package.preload['forge.issue'] = function()
+      return {
+        create_issue = require('forge').create_issue,
+        template_slugs = require('forge').template_slugs,
+      }
+    end
+    package.preload['forge.pr'] = function()
+      return {
+        create_pr = require('forge').create_pr,
+        current_pr = require('forge').current_pr,
+      }
+    end
+    package.preload['forge.repo'] = function()
+      return {
+        current_scope = require('forge').current_scope,
+        scope_key = require('forge').scope_key,
+        file_loc = require('forge').file_loc,
+        remote_web_url = require('forge').remote_web_url,
+      }
+    end
+    package.preload['forge.review'] = function()
+      return {
+        names = require('forge').review_adapter_names,
+      }
+    end
+    package.preload['forge.routes'] = function()
+      return {
+        current_context = require('forge').current_context,
+        open = require('forge').open,
       }
     end
 

--- a/spec/health_spec.lua
+++ b/spec/health_spec.lua
@@ -28,8 +28,10 @@ describe('health', function()
     }
     old_inspect = vim.treesitter.language.inspect
     old_preload = {
-      ['forge'] = package.preload['forge'],
+      ['forge.config'] = package.preload['forge.config'],
+      ['forge.detect'] = package.preload['forge.detect'],
       ['forge.picker'] = package.preload['forge.picker'],
+      ['forge.review'] = package.preload['forge.review'],
       ['codediff.core.installer'] = package.preload['codediff.core.installer'],
       ['fzf-lua'] = package.preload['fzf-lua'],
     }
@@ -67,7 +69,7 @@ describe('health', function()
       error('missing parser: ' .. lang)
     end
 
-    package.preload['forge'] = function()
+    package.preload['forge.config'] = function()
       return {
         config = function()
           return {
@@ -76,9 +78,17 @@ describe('health', function()
             },
           }
         end,
-        review_adapter_names = function()
+      }
+    end
+    package.preload['forge.review'] = function()
+      return {
+        names = function()
           return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
         end,
+      }
+    end
+    package.preload['forge.detect'] = function()
+      return {
         registered_sources = function()
           return {}
         end,
@@ -108,8 +118,10 @@ describe('health', function()
       return {}
     end
 
-    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.detect'] = nil
     package.loaded['forge.picker'] = nil
+    package.loaded['forge.review'] = nil
     package.loaded['forge.health'] = nil
     package.loaded['fzf-lua'] = nil
   end)
@@ -124,14 +136,18 @@ describe('health', function()
     vim.health.error = old_health.error
     vim.treesitter.language.inspect = old_inspect
 
-    package.preload['forge'] = old_preload['forge']
+    package.preload['forge.config'] = old_preload['forge.config']
+    package.preload['forge.detect'] = old_preload['forge.detect']
     package.preload['forge.picker'] = old_preload['forge.picker']
+    package.preload['forge.review'] = old_preload['forge.review']
     package.preload['codediff.core.installer'] = old_preload['codediff.core.installer']
     package.preload['fzf-lua'] = old_preload['fzf-lua']
 
-    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
+    package.loaded['forge.detect'] = nil
     package.loaded['forge.picker'] = nil
     package.loaded['codediff.core.installer'] = nil
+    package.loaded['forge.review'] = nil
     package.loaded['forge.health'] = nil
     package.loaded['fzf-lua'] = nil
   end)
@@ -184,7 +200,7 @@ describe('health', function()
   end)
 
   it('warns when the configured diffview adapter is unavailable', function()
-    package.preload['forge'] = function()
+    package.preload['forge.config'] = function()
       return {
         config = function()
           return {
@@ -193,15 +209,9 @@ describe('health', function()
             },
           }
         end,
-        review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
-        end,
-        registered_sources = function()
-          return {}
-        end,
       }
     end
-    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
     package.loaded['forge.health'] = nil
 
     require('forge.health').check()
@@ -215,7 +225,7 @@ describe('health', function()
   end)
 
   it('warns when the configured diffs adapter is unavailable', function()
-    package.preload['forge'] = function()
+    package.preload['forge.config'] = function()
       return {
         config = function()
           return {
@@ -224,15 +234,9 @@ describe('health', function()
             },
           }
         end,
-        review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
-        end,
-        registered_sources = function()
-          return {}
-        end,
       }
     end
-    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
     package.loaded['forge.health'] = nil
 
     require('forge.health').check()
@@ -282,7 +286,7 @@ describe('health', function()
   end)
 
   it('warns when codediff is configured but unavailable', function()
-    package.preload['forge'] = function()
+    package.preload['forge.config'] = function()
       return {
         config = function()
           return {
@@ -291,15 +295,9 @@ describe('health', function()
             },
           }
         end,
-        review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
-        end,
-        registered_sources = function()
-          return {}
-        end,
       }
     end
-    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
     package.loaded['forge.health'] = nil
 
     require('forge.health').check()
@@ -322,7 +320,7 @@ describe('health', function()
       end
       return old_exists(name)
     end
-    package.preload['forge'] = function()
+    package.preload['forge.config'] = function()
       return {
         config = function()
           return {
@@ -330,12 +328,6 @@ describe('health', function()
               adapter = 'codediff',
             },
           }
-        end,
-        review_adapter_names = function()
-          return { 'browse', 'checkout', 'codediff', 'diffs', 'diffview', 'worktree' }
-        end,
-        registered_sources = function()
-          return {}
         end,
       }
     end
@@ -346,7 +338,7 @@ describe('health', function()
         end,
       }
     end
-    package.loaded['forge'] = nil
+    package.loaded['forge.config'] = nil
     package.loaded['codediff.core.installer'] = nil
     package.loaded['forge.health'] = nil
 

--- a/spec/pickers_spec.lua
+++ b/spec/pickers_spec.lua
@@ -18,6 +18,8 @@ local pr_state_cache
 local preload_modules = {
   'fzf-lua.utils',
   'forge',
+  'forge.format',
+  'forge.issue',
   'forge.logger',
   'forge.ops',
   'forge.picker',
@@ -26,7 +28,10 @@ local preload_modules = {
   'forge.picker.issue',
   'forge.picker.pr',
   'forge.picker.release',
+  'forge.pr',
   'forge.picker.shared',
+  'forge.repo',
+  'forge.routes',
   'forge.surface_policy',
   'forge.state',
 }
@@ -34,6 +39,8 @@ local loaded_modules = {
   'forge.availability',
   'forge',
   'forge.config',
+  'forge.format',
+  'forge.issue',
   'forge.logger',
   'forge.ops',
   'forge.picker',
@@ -42,10 +49,13 @@ local loaded_modules = {
   'forge.picker.issue',
   'forge.picker.pr',
   'forge.picker.release',
+  'forge.pr',
   'forge.picker.shared',
   'forge.picker.session',
   'forge.pickers',
+  'forge.repo',
   'forge.review',
+  'forge.routes',
   'forge.state',
   'forge.surface_policy',
 }
@@ -510,23 +520,8 @@ describe('pickers', function()
         end,
       }
     end
-    package.preload['forge'] = function()
+    package.preload['forge.format'] = function()
       return {
-        config = require('forge.config').config,
-        list_key = function(kind, state)
-          return kind .. ':' .. state
-        end,
-        get_list = function(key)
-          return cache[key]
-        end,
-        set_list = function(key, value)
-          cache[key] = value
-        end,
-        clear_list = function(key)
-          if key then
-            cache[key] = nil
-          end
-        end,
         format_prs = function(prs)
           return vim.tbl_map(function(pr)
             return {
@@ -601,21 +596,85 @@ describe('pickers', function()
             { ' ' .. (rel.title or '') },
           }
         end,
+      }
+    end
+    package.preload['forge.repo'] = function()
+      return {
+        current_scope = function()
+          return nil
+        end,
+        scope_key = function(scope)
+          if type(scope) ~= 'table' then
+            return ''
+          end
+          return table.concat({
+            scope.kind or '',
+            scope.host or '',
+            scope.slug or '',
+          }, '|')
+        end,
         remote_web_url = function()
           return 'https://example.com/repo'
         end,
-        repo_info = require('forge.state').repo_info,
-        pr_state = require('forge.state').pr_state,
-        set_pr_state = require('forge.state').set_pr_state,
-        clear_pr_state = require('forge.state').clear_pr_state,
+      }
+    end
+    package.preload['forge.issue'] = function()
+      return {
         create_issue = function(...)
           issue_create_calls = issue_create_calls + 1
           issue_create_opts = select(1, ...)
         end,
+      }
+    end
+    package.preload['forge.pr'] = function()
+      return {
         create_pr = function(...)
           pr_create_calls = pr_create_calls + 1
           pr_create_opts = select(1, ...)
         end,
+      }
+    end
+    package.preload['forge.routes'] = function()
+      return {
+        open = function() end,
+      }
+    end
+    package.preload['forge'] = function()
+      return {
+        config = require('forge.config').config,
+        list_key = function(kind, state)
+          return kind .. ':' .. state
+        end,
+        get_list = function(key)
+          return cache[key]
+        end,
+        set_list = function(key, value)
+          cache[key] = value
+        end,
+        clear_list = function(key)
+          if key then
+            cache[key] = nil
+          end
+        end,
+        format_prs = require('forge.format').format_prs,
+        format_pr = require('forge.format').format_pr,
+        format_issues = require('forge.format').format_issues,
+        format_issue = require('forge.format').format_issue,
+        format_checks = require('forge.format').format_checks,
+        format_check = require('forge.format').format_check,
+        filter_checks = require('forge.format').filter_checks,
+        format_runs = require('forge.format').format_runs,
+        format_run = require('forge.format').format_run,
+        filter_runs = require('forge.format').filter_runs,
+        format_releases = require('forge.format').format_releases,
+        format_release = require('forge.format').format_release,
+        remote_web_url = require('forge.repo').remote_web_url,
+        repo_info = require('forge.state').repo_info,
+        pr_state = require('forge.state').pr_state,
+        set_pr_state = require('forge.state').set_pr_state,
+        clear_pr_state = require('forge.state').clear_pr_state,
+        create_issue = require('forge.issue').create_issue,
+        create_pr = require('forge.pr').create_pr,
         edit_pr = function() end,
       }
     end


### PR DESCRIPTION
## Problem

Internal command, picker, completion, and health paths still route through the root `forge` convenience facade, which obscures module ownership and keeps #548 unfinished.

## Solution

Switch those internal callsites to their owning modules (`forge.config`, `forge.detect`, `forge.issue`, `forge.pr`, `forge.repo`, `forge.review`, `forge.routes`, and `forge.action_target`) and update specs to stub the direct dependencies. Closes #548